### PR TITLE
Fix docker-compose image reference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
 
   streamarr-server:
-    image: docker.io/library/server:0.0.1-SNAPSHOT
+    image: streamarr/streamarr-server:latest
     restart: always
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary

- Replace stale `docker.io/library/server:0.0.1-SNAPSHOT` with `streamarr/streamarr-server:latest` so `docker compose up` pulls the published image from Docker Hub

## Test plan

- [ ] Run `docker compose up` on a fresh machine and verify the image pulls from Docker Hub