### PR TITLE
Add libraries query

### DIFF
--- a/src/main/java/com/streamarr/server/graphql/resolvers/LibraryResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/LibraryResolver.java
@@ -17,6 +17,7 @@ import com.streamarr.server.services.MovieService;
 import com.streamarr.server.services.library.LibraryManagementService;
 import graphql.relay.Connection;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,11 @@ public class LibraryResolver {
   public boolean scanLibrary(String id) {
     libraryManagementService.scanLibrary(parseUuid(id));
     return true;
+  }
+
+  @DgsQuery
+  public List<Library> libraries() {
+    return libraryRepository.findAll();
   }
 
   @DgsQuery

--- a/src/main/resources/schema/root-query.graphqls
+++ b/src/main/resources/schema/root-query.graphqls
@@ -2,4 +2,5 @@ type Query {
     movie(id: ID!): Movie
     rating(id: ID!): Rating!
     library(id: ID!): Library!
+    libraries: [Library!]!
 }

--- a/src/test/java/com/streamarr/server/graphql/resolvers/LibraryResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/LibraryResolverTest.java
@@ -132,6 +132,37 @@ class LibraryResolverTest {
   }
 
   @Test
+  @DisplayName("Should return all libraries when queried")
+  void shouldReturnAllLibrariesWhenQueried() {
+    var moviesLibrary =
+        Library.builder()
+            .name("Movies")
+            .filepath("/mpool/media/movies")
+            .status(LibraryStatus.HEALTHY)
+            .backend(LibraryBackend.LOCAL)
+            .type(MediaType.MOVIE)
+            .externalAgentStrategy(ExternalAgentStrategy.TMDB)
+            .build();
+
+    var showsLibrary =
+        Library.builder()
+            .name("TV Shows")
+            .filepath("/mpool/media/shows")
+            .status(LibraryStatus.HEALTHY)
+            .backend(LibraryBackend.LOCAL)
+            .type(MediaType.SERIES)
+            .externalAgentStrategy(ExternalAgentStrategy.TMDB)
+            .build();
+
+    when(libraryRepository.findAll()).thenReturn(List.of(moviesLibrary, showsLibrary));
+
+    List<String> names =
+        dgsQueryExecutor.executeAndExtractJsonPath("{ libraries { name } }", "data.libraries[*].name");
+
+    assertThat(names).containsExactly("Movies", "TV Shows");
+  }
+
+  @Test
   @DisplayName("Should return error when unsupported media type in items")
   void shouldReturnErrorWhenUnsupportedMediaTypeInItems() {
     var libraryId = UUID.randomUUID();


### PR DESCRIPTION
## Summary
- Add `libraries: [Library!]!` query to the GraphQL schema for fetching all libraries
- Add `@DgsQuery` resolver method delegating to `libraryRepository.findAll()`
- Add thin wiring test verifying the query returns all libraries

## Test plan
- [x] New resolver test `shouldReturnAllLibrariesWhenQueried` passes
- [x] Full test suite (486 tests) passes with zero failures