### PR TITLE
chore: update release-drafter to v7

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: read
@@ -14,9 +12,9 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
+      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Update release-drafter from v6 to v7 and remove the `pull_request` trigger that caused CI failures. The v7 action sets `targetCommitish` to the ephemeral PR merge ref, which the GitHub Releases API rejects — and since no autolabeler rules are configured, the PR trigger wasn't doing useful work.

Supersedes #152.