### PR TITLE
Feature/library watch status filter

### DIFF
--- a/src/main/java/com/streamarr/server/exceptions/SeasonNotFoundException.java
+++ b/src/main/java/com/streamarr/server/exceptions/SeasonNotFoundException.java
@@ -1,0 +1,10 @@
+package com.streamarr.server.exceptions;
+
+import java.util.UUID;
+
+public class SeasonNotFoundException extends RuntimeException {
+
+  public SeasonNotFoundException(UUID seasonId) {
+    super("Season not found: " + seasonId);
+  }
+}

--- a/src/main/java/com/streamarr/server/graphql/dataloaders/AggregateWatchProgressDataLoader.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/AggregateWatchProgressDataLoader.java
@@ -1,0 +1,59 @@
+package com.streamarr.server.graphql.dataloaders;
+
+import com.netflix.graphql.dgs.DgsDataLoader;
+import com.streamarr.server.services.watchprogress.WatchProgressDto;
+import com.streamarr.server.services.watchprogress.WatchStatusService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.dataloader.MappedBatchLoader;
+
+@DgsDataLoader(name = "aggregateWatchProgress")
+@RequiredArgsConstructor
+public class AggregateWatchProgressDataLoader
+    implements MappedBatchLoader<WatchProgressLoaderKey, WatchProgressDto> {
+
+  private final WatchStatusService watchStatusService;
+
+  @Override
+  public CompletionStage<Map<WatchProgressLoaderKey, WatchProgressDto>> load(
+      Set<WatchProgressLoaderKey> keys) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          // TODO(#163): Replace with authenticated user ID from Spring Security
+          var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+          var result = new HashMap<WatchProgressLoaderKey, WatchProgressDto>();
+          var keysByType =
+              keys.stream().collect(Collectors.groupingBy(WatchProgressLoaderKey::entityType));
+
+          for (var entry : keysByType.entrySet()) {
+            var entityIds =
+                entry.getValue().stream().map(WatchProgressLoaderKey::entityId).toList();
+            var progressByEntityId = loadByType(userId, entry.getKey(), entityIds);
+
+            for (var key : entry.getValue()) {
+              result.put(key, progressByEntityId.get(key.entityId()));
+            }
+          }
+
+          return result;
+        });
+  }
+
+  private Map<UUID, WatchProgressDto> loadByType(
+      UUID userId, WatchStatusEntityType entityType, java.util.List<UUID> entityIds) {
+    return switch (entityType) {
+      case SEASON -> watchStatusService.getAggregateProgressForSeasons(userId, entityIds);
+      case SERIES -> watchStatusService.getAggregateProgressForSeries(userId, entityIds);
+      case DIRECT_MEDIA ->
+          throw new UnsupportedOperationException(
+              "DIRECT_MEDIA uses the per-media-file watchProgress loader");
+    };
+  }
+}

--- a/src/main/java/com/streamarr/server/graphql/dataloaders/SessionProgressDataLoader.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/SessionProgressDataLoader.java
@@ -1,8 +1,7 @@
 package com.streamarr.server.graphql.dataloaders;
 
 import com.netflix.graphql.dgs.DgsDataLoader;
-import com.streamarr.server.domain.streaming.SessionProgress;
-import com.streamarr.server.graphql.dto.WatchProgressDto;
+import com.streamarr.server.services.watchprogress.WatchProgressDto;
 import com.streamarr.server.services.watchprogress.WatchStatusService;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,19 +30,10 @@ public class SessionProgressDataLoader implements MappedBatchLoader<UUID, WatchP
           var result = new HashMap<UUID, WatchProgressDto>();
           for (var mediaFileId : mediaFileIds) {
             var wp = progressMap.get(mediaFileId);
-            result.put(mediaFileId, wp != null ? toDto(wp) : null);
+            result.put(mediaFileId, wp != null ? WatchProgressDto.from(wp) : null);
           }
 
           return result;
         });
-  }
-
-  private static WatchProgressDto toDto(SessionProgress wp) {
-    return WatchProgressDto.builder()
-        .positionSeconds(wp.getPositionSeconds())
-        .percentComplete(wp.getPercentComplete())
-        .durationSeconds(wp.getDurationSeconds())
-        .lastModifiedOn(wp.getLastModifiedOn())
-        .build();
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/dataloaders/WatchProgressLoaderKey.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/WatchProgressLoaderKey.java
@@ -1,0 +1,5 @@
+package com.streamarr.server.graphql.dataloaders;
+
+import java.util.UUID;
+
+public record WatchProgressLoaderKey(UUID entityId, WatchStatusEntityType entityType) {}

--- a/src/main/java/com/streamarr/server/graphql/dto/WatchProgressDto.java
+++ b/src/main/java/com/streamarr/server/graphql/dto/WatchProgressDto.java
@@ -1,8 +1,0 @@
-package com.streamarr.server.graphql.dto;
-
-import java.time.Instant;
-import lombok.Builder;
-
-@Builder
-public record WatchProgressDto(
-    int positionSeconds, double percentComplete, int durationSeconds, Instant lastModifiedOn) {}

--- a/src/main/java/com/streamarr/server/graphql/inputs/MediaFilterInput.java
+++ b/src/main/java/com/streamarr/server/graphql/inputs/MediaFilterInput.java
@@ -1,6 +1,7 @@
 package com.streamarr.server.graphql.inputs;
 
 import com.streamarr.server.domain.AlphabetLetter;
+import com.streamarr.server.domain.streaming.WatchStatus;
 import java.util.List;
 
 public record MediaFilterInput(
@@ -11,4 +12,5 @@ public record MediaFilterInput(
     List<String> studioIds,
     List<String> directorIds,
     List<String> castMemberIds,
-    Boolean unmatched) {}
+    Boolean unmatched,
+    WatchStatus watchStatus) {}

--- a/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
@@ -25,13 +25,12 @@ public class ContinueWatchingResolver {
 
   @DgsTypeResolver(name = "ContinueWatchingMedia")
   public String resolveContinueWatchingMedia(Object media) {
-    if (media instanceof Movie) {
-      return "Movie";
-    }
-    if (media instanceof Episode) {
-      return "Episode";
-    }
-    throw new IllegalArgumentException(
-        "Unknown continue watching media type: " + media.getClass().getSimpleName());
+    return switch (media) {
+      case Movie ignored -> "Movie";
+      case Episode ignored -> "Episode";
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown continue watching media type: " + media.getClass().getSimpleName());
+    };
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
@@ -1,0 +1,37 @@
+package com.streamarr.server.graphql.resolvers;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.netflix.graphql.dgs.DgsTypeResolver;
+import com.streamarr.server.domain.BaseCollectable;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.services.watchprogress.ContinueWatchingService;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@DgsComponent
+@RequiredArgsConstructor
+public class ContinueWatchingResolver {
+
+  private final ContinueWatchingService continueWatchingService;
+
+  @DgsQuery
+  public List<? extends BaseCollectable<?>> continueWatching(DataFetchingEnvironment dfe) {
+    int first = dfe.getArgumentOrDefault("first", 20);
+    return continueWatchingService.getContinueWatching(first);
+  }
+
+  @DgsTypeResolver(name = "ContinueWatchingMedia")
+  public String resolveContinueWatchingMedia(Object media) {
+    if (media instanceof Movie) {
+      return "Movie";
+    }
+    if (media instanceof Episode) {
+      return "Episode";
+    }
+    throw new IllegalArgumentException(
+        "Unknown continue watching media type: " + media.getClass().getSimpleName());
+  }
+}

--- a/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
@@ -18,7 +18,7 @@ public class ContinueWatchingResolver {
   private final ContinueWatchingService continueWatchingService;
 
   @DgsQuery
-  public List<? extends BaseCollectable<?>> continueWatching(DataFetchingEnvironment dfe) {
+  public List<BaseCollectable<?>> continueWatching(DataFetchingEnvironment dfe) {
     int first = dfe.getArgumentOrDefault("first", 20);
     return continueWatchingService.getContinueWatching(first);
   }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
@@ -29,15 +29,12 @@ public class ContinueWatchingResolver {
 
   @DgsTypeResolver(name = "ContinueWatchingMedia")
   public String resolveContinueWatchingMedia(Object media) {
-    if (media instanceof Movie) {
-      return "Movie";
-    }
-
-    if (media instanceof Episode) {
-      return "Episode";
-    }
-
-    throw new IllegalArgumentException(
-        "Unknown continue watching media type: " + media.getClass().getSimpleName());
+    return switch (media) {
+      case Movie _ -> "Movie";
+      case Episode _ -> "Episode";
+      default ->
+          throw new IllegalArgumentException(
+              "Unknown continue watching media type: " + media.getClass().getSimpleName());
+    };
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolver.java
@@ -29,12 +29,15 @@ public class ContinueWatchingResolver {
 
   @DgsTypeResolver(name = "ContinueWatchingMedia")
   public String resolveContinueWatchingMedia(Object media) {
-    return switch (media) {
-      case Movie ignored -> "Movie";
-      case Episode ignored -> "Episode";
-      default ->
-          throw new IllegalArgumentException(
-              "Unknown continue watching media type: " + media.getClass().getSimpleName());
-    };
+    if (media instanceof Movie) {
+      return "Movie";
+    }
+
+    if (media instanceof Episode) {
+      return "Episode";
+    }
+
+    throw new IllegalArgumentException(
+        "Unknown continue watching media type: " + media.getClass().getSimpleName());
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolver.java
@@ -3,7 +3,7 @@ package com.streamarr.server.graphql.resolvers;
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import com.streamarr.server.domain.media.Episode;
-import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.services.SeriesService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
@@ -11,13 +11,13 @@ import lombok.RequiredArgsConstructor;
 
 @DgsComponent
 @RequiredArgsConstructor
-public class SeasonFieldResolver {
+public class EpisodeFieldResolver {
 
   private final SeriesService seriesService;
 
-  @DgsData(parentType = "Season", field = "episodes")
-  public List<Episode> episodes(DataFetchingEnvironment dfe) {
-    Season season = dfe.getSource();
-    return seriesService.findEpisodes(season.getId());
+  @DgsData(parentType = "Episode", field = "files")
+  public List<MediaFile> files(DataFetchingEnvironment dfe) {
+    Episode episode = dfe.getSource();
+    return seriesService.findMediaFiles(episode.getId());
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/LibraryResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/LibraryResolver.java
@@ -116,7 +116,8 @@ public class LibraryResolver {
           .studioIds(parseUuidList(filter.studioIds()))
           .directorIds(parseUuidList(filter.directorIds()))
           .castMemberIds(parseUuidList(filter.castMemberIds()))
-          .unmatched(filter.unmatched());
+          .unmatched(filter.unmatched())
+          .watchStatus(filter.watchStatus());
     }
 
     var effectiveFilter = builder.build();

--- a/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
@@ -22,6 +22,12 @@ public class SeasonFieldResolver {
     return seriesService.findEpisodes(season.getId());
   }
 
+  @DgsData(parentType = "Episode", field = "season")
+  public Season episodeSeason(DataFetchingEnvironment dfe) {
+    Episode episode = dfe.getSource();
+    return seriesService.findSeason(episode.getSeason().getId());
+  }
+
   @DgsData(parentType = "Episode", field = "files")
   public List<MediaFile> episodeFiles(DataFetchingEnvironment dfe) {
     Episode episode = dfe.getSource();

--- a/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
@@ -5,6 +5,7 @@ import com.netflix.graphql.dgs.DgsData;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.services.SeriesService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
@@ -15,6 +16,12 @@ import lombok.RequiredArgsConstructor;
 public class SeasonFieldResolver {
 
   private final SeriesService seriesService;
+
+  @DgsData(parentType = "Season", field = "series")
+  public Series seasonSeries(DataFetchingEnvironment dfe) {
+    Season season = dfe.getSource();
+    return seriesService.findById(season.getSeries().getId()).orElseThrow();
+  }
 
   @DgsData(parentType = "Season", field = "episodes")
   public List<Episode> episodes(DataFetchingEnvironment dfe) {

--- a/src/main/java/com/streamarr/server/graphql/resolvers/SeriesResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/SeriesResolver.java
@@ -3,6 +3,7 @@ package com.streamarr.server.graphql.resolvers;
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsQuery;
+import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.exceptions.InvalidIdException;
@@ -22,6 +23,11 @@ public class SeriesResolver {
   @DgsQuery
   public Optional<Series> series(String id) {
     return seriesService.findById(parseUuid(id));
+  }
+
+  @DgsQuery
+  public Optional<Episode> episode(String id) {
+    return seriesService.findEpisodeById(parseUuid(id));
   }
 
   @DgsData(parentType = "Series", field = "files")

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -11,27 +11,31 @@ import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.graphql.dataloaders.WatchStatusEntityType;
 import com.streamarr.server.graphql.dataloaders.WatchStatusLoaderKey;
 import com.streamarr.server.graphql.dto.WatchProgressDto;
+import com.streamarr.server.repositories.media.MediaFileRepository;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
 import org.dataloader.DataLoader;
 
 @DgsComponent
+@RequiredArgsConstructor
 public class WatchProgressFieldResolver {
+
+  private final MediaFileRepository mediaFileRepository;
 
   @DgsData(parentType = "Movie", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> movieWatchProgress(DataFetchingEnvironment dfe) {
     Movie movie = dfe.getSource();
-    return loadProgress(dfe, movie.getFiles());
+    return loadProgress(dfe, movie.getId());
   }
 
   @DgsData(parentType = "Episode", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> episodeWatchProgress(DataFetchingEnvironment dfe) {
     Episode episode = dfe.getSource();
-    return loadProgress(dfe, episode.getFiles());
+    return loadProgress(dfe, episode.getId());
   }
 
   @DgsData(parentType = "Movie", field = "watchStatus")
@@ -59,8 +63,9 @@ public class WatchProgressFieldResolver {
   }
 
   private CompletableFuture<WatchProgressDto> loadProgress(
-      DataFetchingEnvironment dfe, Set<MediaFile> files) {
-    if (files == null || files.isEmpty()) {
+      DataFetchingEnvironment dfe, UUID entityId) {
+    var files = mediaFileRepository.findByMediaId(entityId);
+    if (files.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
 

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -61,6 +61,27 @@ public class WatchProgressFieldResolver {
                     .orElse(null));
   }
 
+  @DgsData(parentType = "Season", field = "watchProgress")
+  public CompletableFuture<WatchProgressDto> seasonWatchProgress(DataFetchingEnvironment dfe) {
+    Season season = dfe.getSource();
+    var files = seriesService.findSeasonEpisodeMediaFiles(season.getId());
+    if (files.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader("watchProgress");
+    var mediaFileIds = files.stream().map(MediaFile::getId).toList();
+
+    return loader
+        .loadMany(mediaFileIds)
+        .thenApply(
+            results ->
+                results.stream()
+                    .filter(Objects::nonNull)
+                    .max(Comparator.comparing(WatchProgressDto::lastModifiedOn))
+                    .orElse(null));
+  }
+
   @DgsData(parentType = "Movie", field = "watchStatus")
   public CompletableFuture<WatchStatus> movieWatchStatus(DataFetchingEnvironment dfe) {
     Movie movie = dfe.getSource();

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -11,10 +11,11 @@ import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.graphql.dataloaders.WatchStatusEntityType;
 import com.streamarr.server.graphql.dataloaders.WatchStatusLoaderKey;
 import com.streamarr.server.graphql.dto.WatchProgressDto;
-import com.streamarr.server.repositories.media.MediaFileRepository;
+import com.streamarr.server.services.MovieService;
 import com.streamarr.server.services.SeriesService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -27,61 +28,31 @@ public class WatchProgressFieldResolver {
 
   private static final String WATCH_PROGRESS_LOADER = "watchProgress";
 
-  private final MediaFileRepository mediaFileRepository;
+  private final MovieService movieService;
   private final SeriesService seriesService;
 
   @DgsData(parentType = "Movie", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> movieWatchProgress(DataFetchingEnvironment dfe) {
     Movie movie = dfe.getSource();
-    return loadProgress(dfe, movie.getId());
+    return loadProgress(dfe, movieService.findMediaFiles(movie.getId()));
   }
 
   @DgsData(parentType = "Episode", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> episodeWatchProgress(DataFetchingEnvironment dfe) {
     Episode episode = dfe.getSource();
-    return loadProgress(dfe, episode.getId());
+    return loadProgress(dfe, seriesService.findMediaFiles(episode.getId()));
   }
 
   @DgsData(parentType = "Series", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> seriesWatchProgress(DataFetchingEnvironment dfe) {
     Series series = dfe.getSource();
-    var files = seriesService.findAllEpisodeMediaFiles(series.getId());
-    if (files.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
-    }
-
-    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader(WATCH_PROGRESS_LOADER);
-    var mediaFileIds = files.stream().map(MediaFile::getId).toList();
-
-    return loader
-        .loadMany(mediaFileIds)
-        .thenApply(
-            results ->
-                results.stream()
-                    .filter(Objects::nonNull)
-                    .max(Comparator.comparing(WatchProgressDto::lastModifiedOn))
-                    .orElse(null));
+    return loadProgress(dfe, seriesService.findAllEpisodeMediaFiles(series.getId()));
   }
 
   @DgsData(parentType = "Season", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> seasonWatchProgress(DataFetchingEnvironment dfe) {
     Season season = dfe.getSource();
-    var files = seriesService.findSeasonEpisodeMediaFiles(season.getId());
-    if (files.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
-    }
-
-    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader(WATCH_PROGRESS_LOADER);
-    var mediaFileIds = files.stream().map(MediaFile::getId).toList();
-
-    return loader
-        .loadMany(mediaFileIds)
-        .thenApply(
-            results ->
-                results.stream()
-                    .filter(Objects::nonNull)
-                    .max(Comparator.comparing(WatchProgressDto::lastModifiedOn))
-                    .orElse(null));
+    return loadProgress(dfe, seriesService.findSeasonEpisodeMediaFiles(season.getId()));
   }
 
   @DgsData(parentType = "Movie", field = "watchStatus")
@@ -109,8 +80,7 @@ public class WatchProgressFieldResolver {
   }
 
   private CompletableFuture<WatchProgressDto> loadProgress(
-      DataFetchingEnvironment dfe, UUID entityId) {
-    var files = mediaFileRepository.findByMediaId(entityId);
+      DataFetchingEnvironment dfe, List<MediaFile> files) {
     if (files.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -25,6 +25,8 @@ import org.dataloader.DataLoader;
 @RequiredArgsConstructor
 public class WatchProgressFieldResolver {
 
+  private static final String WATCH_PROGRESS_LOADER = "watchProgress";
+
   private final MediaFileRepository mediaFileRepository;
   private final SeriesService seriesService;
 
@@ -48,7 +50,7 @@ public class WatchProgressFieldResolver {
       return CompletableFuture.completedFuture(null);
     }
 
-    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader("watchProgress");
+    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader(WATCH_PROGRESS_LOADER);
     var mediaFileIds = files.stream().map(MediaFile::getId).toList();
 
     return loader
@@ -69,7 +71,7 @@ public class WatchProgressFieldResolver {
       return CompletableFuture.completedFuture(null);
     }
 
-    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader("watchProgress");
+    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader(WATCH_PROGRESS_LOADER);
     var mediaFileIds = files.stream().map(MediaFile::getId).toList();
 
     return loader
@@ -113,7 +115,7 @@ public class WatchProgressFieldResolver {
       return CompletableFuture.completedFuture(null);
     }
 
-    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader("watchProgress");
+    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader(WATCH_PROGRESS_LOADER);
     var mediaFileIds = files.stream().map(MediaFile::getId).toList();
 
     return loader

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -8,11 +8,12 @@ import com.streamarr.server.domain.media.Movie;
 import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.domain.streaming.WatchStatus;
+import com.streamarr.server.graphql.dataloaders.WatchProgressLoaderKey;
 import com.streamarr.server.graphql.dataloaders.WatchStatusEntityType;
 import com.streamarr.server.graphql.dataloaders.WatchStatusLoaderKey;
-import com.streamarr.server.graphql.dto.WatchProgressDto;
 import com.streamarr.server.services.MovieService;
 import com.streamarr.server.services.SeriesService;
+import com.streamarr.server.services.watchprogress.WatchProgressDto;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Comparator;
 import java.util.List;
@@ -27,6 +28,8 @@ import org.dataloader.DataLoader;
 public class WatchProgressFieldResolver {
 
   private static final String WATCH_PROGRESS_LOADER = "watchProgress";
+  private static final String AGGREGATE_WATCH_PROGRESS_LOADER = "aggregateWatchProgress";
+  private static final String WATCH_STATUS_LOADER = "watchStatus";
 
   private final MovieService movieService;
   private final SeriesService seriesService;
@@ -46,13 +49,13 @@ public class WatchProgressFieldResolver {
   @DgsData(parentType = "Series", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> seriesWatchProgress(DataFetchingEnvironment dfe) {
     Series series = dfe.getSource();
-    return loadProgress(dfe, seriesService.findAllEpisodeMediaFiles(series.getId()));
+    return loadAggregateProgress(dfe, series.getId(), WatchStatusEntityType.SERIES);
   }
 
   @DgsData(parentType = "Season", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> seasonWatchProgress(DataFetchingEnvironment dfe) {
     Season season = dfe.getSource();
-    return loadProgress(dfe, seriesService.findSeasonEpisodeMediaFiles(season.getId()));
+    return loadAggregateProgress(dfe, season.getId(), WatchStatusEntityType.SEASON);
   }
 
   @DgsData(parentType = "Movie", field = "watchStatus")
@@ -98,9 +101,16 @@ public class WatchProgressFieldResolver {
                     .orElse(null));
   }
 
+  private CompletableFuture<WatchProgressDto> loadAggregateProgress(
+      DataFetchingEnvironment dfe, UUID entityId, WatchStatusEntityType entityType) {
+    DataLoader<WatchProgressLoaderKey, WatchProgressDto> loader =
+        dfe.getDataLoader(AGGREGATE_WATCH_PROGRESS_LOADER);
+    return loader.load(new WatchProgressLoaderKey(entityId, entityType));
+  }
+
   private CompletableFuture<WatchStatus> loadWatchStatus(
       DataFetchingEnvironment dfe, UUID entityId, WatchStatusEntityType entityType) {
-    DataLoader<WatchStatusLoaderKey, WatchStatus> loader = dfe.getDataLoader("watchStatus");
+    DataLoader<WatchStatusLoaderKey, WatchStatus> loader = dfe.getDataLoader(WATCH_STATUS_LOADER);
     return loader.load(new WatchStatusLoaderKey(entityId, entityType));
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -12,6 +12,7 @@ import com.streamarr.server.graphql.dataloaders.WatchStatusEntityType;
 import com.streamarr.server.graphql.dataloaders.WatchStatusLoaderKey;
 import com.streamarr.server.graphql.dto.WatchProgressDto;
 import com.streamarr.server.repositories.media.MediaFileRepository;
+import com.streamarr.server.services.SeriesService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Comparator;
 import java.util.Objects;
@@ -25,6 +26,7 @@ import org.dataloader.DataLoader;
 public class WatchProgressFieldResolver {
 
   private final MediaFileRepository mediaFileRepository;
+  private final SeriesService seriesService;
 
   @DgsData(parentType = "Movie", field = "watchProgress")
   public CompletableFuture<WatchProgressDto> movieWatchProgress(DataFetchingEnvironment dfe) {
@@ -36,6 +38,27 @@ public class WatchProgressFieldResolver {
   public CompletableFuture<WatchProgressDto> episodeWatchProgress(DataFetchingEnvironment dfe) {
     Episode episode = dfe.getSource();
     return loadProgress(dfe, episode.getId());
+  }
+
+  @DgsData(parentType = "Series", field = "watchProgress")
+  public CompletableFuture<WatchProgressDto> seriesWatchProgress(DataFetchingEnvironment dfe) {
+    Series series = dfe.getSource();
+    var files = seriesService.findAllEpisodeMediaFiles(series.getId());
+    if (files.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader("watchProgress");
+    var mediaFileIds = files.stream().map(MediaFile::getId).toList();
+
+    return loader
+        .loadMany(mediaFileIds)
+        .thenApply(
+            results ->
+                results.stream()
+                    .filter(Objects::nonNull)
+                    .max(Comparator.comparing(WatchProgressDto::lastModifiedOn))
+                    .orElse(null));
   }
 
   @DgsData(parentType = "Movie", field = "watchStatus")

--- a/src/main/java/com/streamarr/server/repositories/JooqQueryHelper.java
+++ b/src/main/java/com/streamarr/server/repositories/JooqQueryHelper.java
@@ -14,6 +14,7 @@ import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.services.pagination.MediaFilter;
 import com.streamarr.server.services.pagination.OrderMediaBy;
 import jakarta.persistence.EntityManager;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collection;
@@ -145,7 +146,9 @@ public class JooqQueryHelper {
   }
 
   public boolean isNullableSortField(OrderMediaBy sortBy) {
-    return sortBy == OrderMediaBy.RELEASE_DATE || sortBy == OrderMediaBy.RUNTIME;
+    return sortBy == OrderMediaBy.RELEASE_DATE
+        || sortBy == OrderMediaBy.RUNTIME
+        || sortBy == OrderMediaBy.LAST_WATCHED;
   }
 
   public Object coerceSortValue(MediaFilter filter) {
@@ -156,6 +159,7 @@ public class JooqQueryHelper {
     return switch (filter.getSortBy()) {
       case RELEASE_DATE -> value instanceof LocalDate d ? d : LocalDate.parse(value.toString());
       case RUNTIME -> value instanceof Integer i ? i : Integer.parseInt(value.toString());
+      case LAST_WATCHED -> value instanceof Instant i ? i : Instant.parse(value.toString());
       default -> value;
     };
   }

--- a/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustom.java
+++ b/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustom.java
@@ -2,8 +2,12 @@ package com.streamarr.server.repositories.media;
 
 import com.streamarr.server.domain.media.Movie;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface MovieRepositoryCustom {
 
@@ -12,4 +16,6 @@ public interface MovieRepositoryCustom {
   List<Movie> findFirstWithFilter(MediaPaginationOptions options);
 
   Optional<Movie> findByTmdbId(String tmdbId);
+
+  Map<UUID, Instant> findLastWatchedByMovieIds(Collection<UUID> movieIds);
 }

--- a/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
@@ -182,6 +182,8 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON;
       case RELEASE_DATE -> Tables.MOVIE.RELEASE_DATE;
       case RUNTIME -> Tables.MOVIE.RUNTIME;
+      case LAST_WATCHED ->
+          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
     };
   }
 
@@ -193,6 +195,8 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON.sort(direction);
       case RELEASE_DATE -> Tables.MOVIE.RELEASE_DATE.sort(direction).nullsLast();
       case RUNTIME -> Tables.MOVIE.RUNTIME.sort(direction).nullsLast();
+      case LAST_WATCHED ->
+          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
     };
   }
 }

--- a/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
@@ -1,9 +1,13 @@
 package com.streamarr.server.repositories.media;
 
+import static org.jooq.impl.DSL.exists;
 import static org.jooq.impl.DSL.inline;
 import static org.jooq.impl.DSL.noCondition;
+import static org.jooq.impl.DSL.not;
+import static org.jooq.impl.DSL.select;
 
 import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.jooq.generated.enums.ExternalSourceType;
 import com.streamarr.server.repositories.JooqQueryHelper;
@@ -15,6 +19,7 @@ import jakarta.persistence.PersistenceContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -172,8 +177,48 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
                 filter.getCastMemberIds()));
 
     condition = condition.and(JooqQueryHelper.unmatchedCondition(filter.getUnmatched()));
+    condition = condition.and(watchStatusCondition(filter.getWatchStatus()));
 
     return condition;
+  }
+
+  private Condition watchStatusCondition(WatchStatus watchStatus) {
+    if (watchStatus == null) {
+      return noCondition();
+    }
+
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    var isWatched =
+        exists(
+            select(Tables.WATCH_HISTORY.ID)
+                .from(Tables.WATCH_HISTORY)
+                .where(
+                    Tables.WATCH_HISTORY
+                        .COLLECTABLE_ID
+                        .eq(Tables.BASE_COLLECTABLE.ID)
+                        .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                        .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
+
+    var hasProgress =
+        exists(
+            select(Tables.SESSION_PROGRESS.ID)
+                .from(Tables.SESSION_PROGRESS)
+                .innerJoin(Tables.MEDIA_FILE)
+                .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+                .where(
+                    Tables.MEDIA_FILE
+                        .MEDIA_ID
+                        .eq(Tables.BASE_COLLECTABLE.ID)
+                        .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId))
+                        .and(Tables.SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))));
+
+    return switch (watchStatus) {
+      case WATCHED -> isWatched;
+      case IN_PROGRESS -> not(isWatched).and(hasProgress);
+      case UNWATCHED -> not(isWatched).and(not(hasProgress));
+    };
   }
 
   private Field<?> sortField(MediaFilter filter) {

--- a/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.streamarr.server.repositories.media;
 
 import static org.jooq.impl.DSL.exists;
 import static org.jooq.impl.DSL.inline;
+import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.noCondition;
 import static org.jooq.impl.DSL.not;
 import static org.jooq.impl.DSL.select;
@@ -221,14 +222,29 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
     };
   }
 
+  private Field<?> lastWatchedField() {
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    return select(max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON))
+        .from(Tables.SESSION_PROGRESS)
+        .innerJoin(Tables.MEDIA_FILE)
+        .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+        .where(
+            Tables.MEDIA_FILE
+                .MEDIA_ID
+                .eq(Tables.BASE_COLLECTABLE.ID)
+                .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId)))
+        .asField();
+  }
+
   private Field<?> sortField(MediaFilter filter) {
     return switch (filter.getSortBy()) {
       case TITLE -> Tables.BASE_COLLECTABLE.TITLE_SORT;
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON;
       case RELEASE_DATE -> Tables.MOVIE.RELEASE_DATE;
       case RUNTIME -> Tables.MOVIE.RUNTIME;
-      case LAST_WATCHED ->
-          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
+      case LAST_WATCHED -> lastWatchedField();
     };
   }
 
@@ -240,8 +256,7 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON.sort(direction);
       case RELEASE_DATE -> Tables.MOVIE.RELEASE_DATE.sort(direction).nullsLast();
       case RUNTIME -> Tables.MOVIE.RUNTIME.sort(direction).nullsLast();
-      case LAST_WATCHED ->
-          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
+      case LAST_WATCHED -> lastWatchedField().sort(direction).nullsLast();
     };
   }
 }

--- a/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/MovieRepositoryCustomImpl.java
@@ -17,8 +17,12 @@ import com.streamarr.server.services.pagination.MediaPaginationOptions;
 import com.streamarr.server.services.pagination.PaginationDirection;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -236,6 +240,32 @@ public class MovieRepositoryCustomImpl implements MovieRepositoryCustom {
                 .eq(Tables.BASE_COLLECTABLE.ID)
                 .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId)))
         .asField();
+  }
+
+  @Override
+  public Map<UUID, Instant> findLastWatchedByMovieIds(Collection<UUID> movieIds) {
+    if (movieIds == null || movieIds.isEmpty()) {
+      return Map.of();
+    }
+
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    var maxField = max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON);
+
+    return context
+        .select(Tables.MEDIA_FILE.MEDIA_ID, maxField)
+        .from(Tables.SESSION_PROGRESS)
+        .innerJoin(Tables.MEDIA_FILE)
+        .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+        .where(
+            Tables.MEDIA_FILE.MEDIA_ID.in(movieIds).and(Tables.SESSION_PROGRESS.USER_ID.eq(userId)))
+        .groupBy(Tables.MEDIA_FILE.MEDIA_ID)
+        .fetchMap(Tables.MEDIA_FILE.MEDIA_ID, r -> toInstant(r.get(maxField)));
+  }
+
+  private static Instant toInstant(OffsetDateTime value) {
+    return value == null ? null : value.toInstant();
   }
 
   private Field<?> sortField(MediaFilter filter) {

--- a/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustom.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustom.java
@@ -2,8 +2,12 @@ package com.streamarr.server.repositories.media;
 
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface SeriesRepositoryCustom {
 
@@ -12,4 +16,6 @@ public interface SeriesRepositoryCustom {
   List<Series> seekWithFilter(MediaPaginationOptions options);
 
   List<Series> findFirstWithFilter(MediaPaginationOptions options);
+
+  Map<UUID, Instant> findLastWatchedBySeriesIds(Collection<UUID> seriesIds);
 }

--- a/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
@@ -196,82 +196,82 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
     // TODO(#163): Replace with authenticated user ID from Spring Security
     var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-    // Subquery: series has at least one episode
-    var hasEpisodes =
-        exists(
-            select(Tables.EPISODE.ID)
-                .from(Tables.EPISODE)
-                .innerJoin(Tables.SEASON)
-                .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
-                .where(Tables.SEASON.SERIES_ID.eq(Tables.BASE_COLLECTABLE.ID)));
-
-    // Subquery: all episodes are watched (no unwatched episode exists)
-    var allEpisodesWatched =
-        not(
-            exists(
-                select(Tables.EPISODE.ID)
-                    .from(Tables.EPISODE)
-                    .innerJoin(Tables.SEASON)
-                    .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
-                    .where(
-                        Tables.SEASON
-                            .SERIES_ID
-                            .eq(Tables.BASE_COLLECTABLE.ID)
-                            .and(
-                                not(
-                                    exists(
-                                        select(Tables.WATCH_HISTORY.ID)
-                                            .from(Tables.WATCH_HISTORY)
-                                            .where(
-                                                Tables.WATCH_HISTORY
-                                                    .COLLECTABLE_ID
-                                                    .eq(Tables.EPISODE.ID)
-                                                    .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
-                                                    .and(
-                                                        Tables.WATCH_HISTORY.DISMISSED_AT
-                                                            .isNull()))))))));
-
-    // Subquery: any episode is watched
-    var anyEpisodeWatched =
-        exists(
-            select(Tables.WATCH_HISTORY.ID)
-                .from(Tables.WATCH_HISTORY)
-                .innerJoin(Tables.EPISODE)
-                .on(Tables.WATCH_HISTORY.COLLECTABLE_ID.eq(Tables.EPISODE.ID))
-                .innerJoin(Tables.SEASON)
-                .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
-                .where(
-                    Tables.SEASON
-                        .SERIES_ID
-                        .eq(Tables.BASE_COLLECTABLE.ID)
-                        .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
-                        .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
-
-    // Subquery: any episode has progress
-    var anyEpisodeHasProgress =
-        exists(
-            select(Tables.SESSION_PROGRESS.ID)
-                .from(Tables.SESSION_PROGRESS)
-                .innerJoin(Tables.MEDIA_FILE)
-                .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
-                .innerJoin(Tables.EPISODE)
-                .on(Tables.MEDIA_FILE.MEDIA_ID.eq(Tables.EPISODE.ID))
-                .innerJoin(Tables.SEASON)
-                .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
-                .where(
-                    Tables.SEASON
-                        .SERIES_ID
-                        .eq(Tables.BASE_COLLECTABLE.ID)
-                        .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId))
-                        .and(Tables.SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))));
-
-    var hasAnyWatchActivity = anyEpisodeWatched.or(anyEpisodeHasProgress);
+    var fullyWatched = seriesHasEpisodes().and(not(seriesHasUnwatchedEpisode(userId)));
+    var hasAnyWatchActivity = anyEpisodeWatched(userId).or(anyEpisodeHasProgress(userId));
 
     return switch (watchStatus) {
-      case WATCHED -> hasEpisodes.and(allEpisodesWatched);
-      case IN_PROGRESS -> hasAnyWatchActivity.and(not(hasEpisodes.and(allEpisodesWatched)));
+      case WATCHED -> fullyWatched;
+      case IN_PROGRESS -> hasAnyWatchActivity.and(not(fullyWatched));
       case UNWATCHED -> not(hasAnyWatchActivity);
     };
+  }
+
+  private static Condition seriesHasEpisodes() {
+    return exists(
+        select(Tables.EPISODE.ID)
+            .from(Tables.EPISODE)
+            .innerJoin(Tables.SEASON)
+            .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+            .where(Tables.SEASON.SERIES_ID.eq(Tables.BASE_COLLECTABLE.ID)));
+  }
+
+  private static Condition seriesHasUnwatchedEpisode(UUID userId) {
+    return exists(
+        select(Tables.EPISODE.ID)
+            .from(Tables.EPISODE)
+            .innerJoin(Tables.SEASON)
+            .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+            .where(
+                Tables.SEASON
+                    .SERIES_ID
+                    .eq(Tables.BASE_COLLECTABLE.ID)
+                    .and(not(episodeIsWatched(userId)))));
+  }
+
+  private static Condition episodeIsWatched(UUID userId) {
+    return exists(
+        select(Tables.WATCH_HISTORY.ID)
+            .from(Tables.WATCH_HISTORY)
+            .where(
+                Tables.WATCH_HISTORY
+                    .COLLECTABLE_ID
+                    .eq(Tables.EPISODE.ID)
+                    .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                    .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
+  }
+
+  private static Condition anyEpisodeWatched(UUID userId) {
+    return exists(
+        select(Tables.WATCH_HISTORY.ID)
+            .from(Tables.WATCH_HISTORY)
+            .innerJoin(Tables.EPISODE)
+            .on(Tables.WATCH_HISTORY.COLLECTABLE_ID.eq(Tables.EPISODE.ID))
+            .innerJoin(Tables.SEASON)
+            .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+            .where(
+                Tables.SEASON
+                    .SERIES_ID
+                    .eq(Tables.BASE_COLLECTABLE.ID)
+                    .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                    .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
+  }
+
+  private static Condition anyEpisodeHasProgress(UUID userId) {
+    return exists(
+        select(Tables.SESSION_PROGRESS.ID)
+            .from(Tables.SESSION_PROGRESS)
+            .innerJoin(Tables.MEDIA_FILE)
+            .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+            .innerJoin(Tables.EPISODE)
+            .on(Tables.MEDIA_FILE.MEDIA_ID.eq(Tables.EPISODE.ID))
+            .innerJoin(Tables.SEASON)
+            .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+            .where(
+                Tables.SEASON
+                    .SERIES_ID
+                    .eq(Tables.BASE_COLLECTABLE.ID)
+                    .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId))
+                    .and(Tables.SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))));
   }
 
   private Field<?> lastWatchedField() {

--- a/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
@@ -183,6 +183,8 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON;
       case RELEASE_DATE -> Tables.SERIES.FIRST_AIR_DATE;
       case RUNTIME -> Tables.SERIES.RUNTIME;
+      case LAST_WATCHED ->
+          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
     };
   }
 
@@ -194,6 +196,8 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON.sort(direction);
       case RELEASE_DATE -> Tables.SERIES.FIRST_AIR_DATE.sort(direction).nullsLast();
       case RUNTIME -> Tables.SERIES.RUNTIME.sort(direction).nullsLast();
+      case LAST_WATCHED ->
+          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
     };
   }
 }

--- a/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.streamarr.server.repositories.media;
 
 import static org.jooq.impl.DSL.exists;
 import static org.jooq.impl.DSL.inline;
+import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.noCondition;
 import static org.jooq.impl.DSL.not;
 import static org.jooq.impl.DSL.select;
@@ -269,14 +270,33 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
     };
   }
 
+  private Field<?> lastWatchedField() {
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    return select(max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON))
+        .from(Tables.SESSION_PROGRESS)
+        .innerJoin(Tables.MEDIA_FILE)
+        .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+        .innerJoin(Tables.EPISODE)
+        .on(Tables.MEDIA_FILE.MEDIA_ID.eq(Tables.EPISODE.ID))
+        .innerJoin(Tables.SEASON)
+        .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+        .where(
+            Tables.SEASON
+                .SERIES_ID
+                .eq(Tables.BASE_COLLECTABLE.ID)
+                .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId)))
+        .asField();
+  }
+
   private Field<?> sortField(MediaFilter filter) {
     return switch (filter.getSortBy()) {
       case TITLE -> Tables.BASE_COLLECTABLE.TITLE_SORT;
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON;
       case RELEASE_DATE -> Tables.SERIES.FIRST_AIR_DATE;
       case RUNTIME -> Tables.SERIES.RUNTIME;
-      case LAST_WATCHED ->
-          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
+      case LAST_WATCHED -> lastWatchedField();
     };
   }
 
@@ -288,8 +308,7 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
       case ADDED -> Tables.BASE_COLLECTABLE.CREATED_ON.sort(direction);
       case RELEASE_DATE -> Tables.SERIES.FIRST_AIR_DATE.sort(direction).nullsLast();
       case RUNTIME -> Tables.SERIES.RUNTIME.sort(direction).nullsLast();
-      case LAST_WATCHED ->
-          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
+      case LAST_WATCHED -> lastWatchedField().sort(direction).nullsLast();
     };
   }
 }

--- a/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
@@ -17,8 +17,12 @@ import com.streamarr.server.services.pagination.MediaPaginationOptions;
 import com.streamarr.server.services.pagination.PaginationDirection;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -288,6 +292,36 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
                 .eq(Tables.BASE_COLLECTABLE.ID)
                 .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId)))
         .asField();
+  }
+
+  @Override
+  public Map<UUID, Instant> findLastWatchedBySeriesIds(Collection<UUID> seriesIds) {
+    if (seriesIds == null || seriesIds.isEmpty()) {
+      return Map.of();
+    }
+
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    var maxField = max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON);
+
+    return context
+        .select(Tables.SEASON.SERIES_ID, maxField)
+        .from(Tables.SESSION_PROGRESS)
+        .innerJoin(Tables.MEDIA_FILE)
+        .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+        .innerJoin(Tables.EPISODE)
+        .on(Tables.MEDIA_FILE.MEDIA_ID.eq(Tables.EPISODE.ID))
+        .innerJoin(Tables.SEASON)
+        .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+        .where(
+            Tables.SEASON.SERIES_ID.in(seriesIds).and(Tables.SESSION_PROGRESS.USER_ID.eq(userId)))
+        .groupBy(Tables.SEASON.SERIES_ID)
+        .fetchMap(Tables.SEASON.SERIES_ID, r -> toInstant(r.get(maxField)));
+  }
+
+  private static Instant toInstant(OffsetDateTime value) {
+    return value == null ? null : value.toInstant();
   }
 
   private Field<?> sortField(MediaFilter filter) {

--- a/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeriesRepositoryCustomImpl.java
@@ -1,9 +1,13 @@
 package com.streamarr.server.repositories.media;
 
+import static org.jooq.impl.DSL.exists;
 import static org.jooq.impl.DSL.inline;
 import static org.jooq.impl.DSL.noCondition;
+import static org.jooq.impl.DSL.not;
+import static org.jooq.impl.DSL.select;
 
 import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.jooq.generated.enums.ExternalSourceType;
 import com.streamarr.server.repositories.JooqQueryHelper;
@@ -15,6 +19,7 @@ import jakarta.persistence.PersistenceContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -173,8 +178,95 @@ public class SeriesRepositoryCustomImpl implements SeriesRepositoryCustom {
                 filter.getCastMemberIds()));
 
     condition = condition.and(JooqQueryHelper.unmatchedCondition(filter.getUnmatched()));
+    condition = condition.and(watchStatusCondition(filter.getWatchStatus()));
 
     return condition;
+  }
+
+  private Condition watchStatusCondition(WatchStatus watchStatus) {
+    if (watchStatus == null) {
+      return noCondition();
+    }
+
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    // Subquery: series has at least one episode
+    var hasEpisodes =
+        exists(
+            select(Tables.EPISODE.ID)
+                .from(Tables.EPISODE)
+                .innerJoin(Tables.SEASON)
+                .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+                .where(Tables.SEASON.SERIES_ID.eq(Tables.BASE_COLLECTABLE.ID)));
+
+    // Subquery: all episodes are watched (no unwatched episode exists)
+    var allEpisodesWatched =
+        not(
+            exists(
+                select(Tables.EPISODE.ID)
+                    .from(Tables.EPISODE)
+                    .innerJoin(Tables.SEASON)
+                    .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+                    .where(
+                        Tables.SEASON
+                            .SERIES_ID
+                            .eq(Tables.BASE_COLLECTABLE.ID)
+                            .and(
+                                not(
+                                    exists(
+                                        select(Tables.WATCH_HISTORY.ID)
+                                            .from(Tables.WATCH_HISTORY)
+                                            .where(
+                                                Tables.WATCH_HISTORY
+                                                    .COLLECTABLE_ID
+                                                    .eq(Tables.EPISODE.ID)
+                                                    .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                                                    .and(
+                                                        Tables.WATCH_HISTORY.DISMISSED_AT
+                                                            .isNull()))))))));
+
+    // Subquery: any episode is watched
+    var anyEpisodeWatched =
+        exists(
+            select(Tables.WATCH_HISTORY.ID)
+                .from(Tables.WATCH_HISTORY)
+                .innerJoin(Tables.EPISODE)
+                .on(Tables.WATCH_HISTORY.COLLECTABLE_ID.eq(Tables.EPISODE.ID))
+                .innerJoin(Tables.SEASON)
+                .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+                .where(
+                    Tables.SEASON
+                        .SERIES_ID
+                        .eq(Tables.BASE_COLLECTABLE.ID)
+                        .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                        .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
+
+    // Subquery: any episode has progress
+    var anyEpisodeHasProgress =
+        exists(
+            select(Tables.SESSION_PROGRESS.ID)
+                .from(Tables.SESSION_PROGRESS)
+                .innerJoin(Tables.MEDIA_FILE)
+                .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+                .innerJoin(Tables.EPISODE)
+                .on(Tables.MEDIA_FILE.MEDIA_ID.eq(Tables.EPISODE.ID))
+                .innerJoin(Tables.SEASON)
+                .on(Tables.EPISODE.SEASON_ID.eq(Tables.SEASON.ID))
+                .where(
+                    Tables.SEASON
+                        .SERIES_ID
+                        .eq(Tables.BASE_COLLECTABLE.ID)
+                        .and(Tables.SESSION_PROGRESS.USER_ID.eq(userId))
+                        .and(Tables.SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))));
+
+    var hasAnyWatchActivity = anyEpisodeWatched.or(anyEpisodeHasProgress);
+
+    return switch (watchStatus) {
+      case WATCHED -> hasEpisodes.and(allEpisodesWatched);
+      case IN_PROGRESS -> hasAnyWatchActivity.and(not(hasEpisodes.and(allEpisodesWatched)));
+      case UNWATCHED -> not(hasAnyWatchActivity);
+    };
   }
 
   private Field<?> sortField(MediaFilter filter) {

--- a/src/main/java/com/streamarr/server/repositories/streaming/ContinueWatchingRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/streaming/ContinueWatchingRepository.java
@@ -1,0 +1,9 @@
+package com.streamarr.server.repositories.streaming;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ContinueWatchingRepository {
+
+  List<UUID> findCollectableIds(UUID userId, int limit);
+}

--- a/src/main/java/com/streamarr/server/repositories/streaming/ContinueWatchingRepositoryImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/streaming/ContinueWatchingRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.streamarr.server.repositories.streaming;
+
+import static com.streamarr.server.jooq.generated.tables.SessionProgress.SESSION_PROGRESS;
+import static org.jooq.impl.DSL.exists;
+import static org.jooq.impl.DSL.max;
+import static org.jooq.impl.DSL.not;
+import static org.jooq.impl.DSL.select;
+
+import com.streamarr.server.jooq.generated.Tables;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.SortOrder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ContinueWatchingRepositoryImpl implements ContinueWatchingRepository {
+
+  private final DSLContext dsl;
+
+  @Override
+  public List<UUID> findCollectableIds(UUID userId, int limit) {
+    var isWatched =
+        exists(
+            select(Tables.WATCH_HISTORY.ID)
+                .from(Tables.WATCH_HISTORY)
+                .where(
+                    Tables.WATCH_HISTORY
+                        .COLLECTABLE_ID
+                        .eq(Tables.MEDIA_FILE.MEDIA_ID)
+                        .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                        .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
+
+    return dsl.select(
+            Tables.MEDIA_FILE.MEDIA_ID, max(SESSION_PROGRESS.LAST_MODIFIED_ON).as("last_activity"))
+        .from(SESSION_PROGRESS)
+        .innerJoin(Tables.MEDIA_FILE)
+        .on(SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+        .where(
+            SESSION_PROGRESS
+                .USER_ID
+                .eq(userId)
+                .and(SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))
+                .and(not(isWatched)))
+        .groupBy(Tables.MEDIA_FILE.MEDIA_ID)
+        .orderBy(max(SESSION_PROGRESS.LAST_MODIFIED_ON).sort(SortOrder.DESC))
+        .limit(limit)
+        .fetch(Tables.MEDIA_FILE.MEDIA_ID);
+  }
+}

--- a/src/main/java/com/streamarr/server/repositories/streaming/ContinueWatchingRepositoryImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/streaming/ContinueWatchingRepositoryImpl.java
@@ -22,6 +22,8 @@ public class ContinueWatchingRepositoryImpl implements ContinueWatchingRepositor
 
   @Override
   public List<UUID> findCollectableIds(UUID userId, int limit) {
+    var lastActivity = max(SESSION_PROGRESS.LAST_MODIFIED_ON);
+
     var isWatched =
         exists(
             select(Tables.WATCH_HISTORY.ID)
@@ -33,8 +35,7 @@ public class ContinueWatchingRepositoryImpl implements ContinueWatchingRepositor
                         .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
                         .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
 
-    return dsl.select(
-            Tables.MEDIA_FILE.MEDIA_ID, max(SESSION_PROGRESS.LAST_MODIFIED_ON).as("last_activity"))
+    return dsl.select(Tables.MEDIA_FILE.MEDIA_ID, lastActivity)
         .from(SESSION_PROGRESS)
         .innerJoin(Tables.MEDIA_FILE)
         .on(SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
@@ -45,7 +46,7 @@ public class ContinueWatchingRepositoryImpl implements ContinueWatchingRepositor
                 .and(SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))
                 .and(not(isWatched)))
         .groupBy(Tables.MEDIA_FILE.MEDIA_ID)
-        .orderBy(max(SESSION_PROGRESS.LAST_MODIFIED_ON).sort(SortOrder.DESC))
+        .orderBy(lastActivity.sort(SortOrder.DESC))
         .limit(limit)
         .fetch(Tables.MEDIA_FILE.MEDIA_ID);
   }

--- a/src/main/java/com/streamarr/server/services/MovieService.java
+++ b/src/main/java/com/streamarr/server/services/MovieService.java
@@ -211,8 +211,7 @@ public class MovieService {
       case ADDED -> movie.getCreatedOn();
       case RELEASE_DATE -> movie.getReleaseDate();
       case RUNTIME -> movie.getRuntime();
-      case LAST_WATCHED ->
-          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
+      case LAST_WATCHED -> null;
     };
   }
 }

--- a/src/main/java/com/streamarr/server/services/MovieService.java
+++ b/src/main/java/com/streamarr/server/services/MovieService.java
@@ -211,6 +211,8 @@ public class MovieService {
       case ADDED -> movie.getCreatedOn();
       case RELEASE_DATE -> movie.getReleaseDate();
       case RUNTIME -> movie.getRuntime();
+      case LAST_WATCHED ->
+          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
     };
   }
 }

--- a/src/main/java/com/streamarr/server/services/MovieService.java
+++ b/src/main/java/com/streamarr/server/services/MovieService.java
@@ -21,9 +21,12 @@ import com.streamarr.server.services.metadata.events.MetadataEnrichedEvent;
 import com.streamarr.server.services.pagination.MediaFilter;
 import com.streamarr.server.services.pagination.MediaPage;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
+import com.streamarr.server.services.pagination.OrderMediaBy;
 import com.streamarr.server.services.pagination.PageItem;
 import com.streamarr.server.services.pagination.PaginationService;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -196,22 +199,36 @@ public class MovieService {
             ? movieRepository.seekWithFilter(options)
             : movieRepository.findFirstWithFilter(options);
 
+    var lastWatchedByMovieId = lastWatchedFor(options.getMediaFilter(), movies);
+
     var pageItems =
         movies.stream()
-            .map(movie -> new PageItem<>(movie, getOrderByValue(options.getMediaFilter(), movie)))
+            .map(
+                movie ->
+                    new PageItem<>(
+                        movie,
+                        getOrderByValue(options.getMediaFilter(), movie, lastWatchedByMovieId)))
             .toList();
 
     return paginationService.buildMediaPage(
         pageItems, options.getPaginationOptions(), options.getCursorId());
   }
 
-  private Object getOrderByValue(MediaFilter filter, Movie movie) {
+  private Map<UUID, Instant> lastWatchedFor(MediaFilter filter, List<Movie> movies) {
+    if (filter.getSortBy() != OrderMediaBy.LAST_WATCHED || movies.isEmpty()) {
+      return Map.of();
+    }
+    return movieRepository.findLastWatchedByMovieIds(movies.stream().map(Movie::getId).toList());
+  }
+
+  private Object getOrderByValue(
+      MediaFilter filter, Movie movie, Map<UUID, Instant> lastWatchedByMovieId) {
     return switch (filter.getSortBy()) {
       case TITLE -> movie.getTitleSort();
       case ADDED -> movie.getCreatedOn();
       case RELEASE_DATE -> movie.getReleaseDate();
       case RUNTIME -> movie.getRuntime();
-      case LAST_WATCHED -> null;
+      case LAST_WATCHED -> lastWatchedByMovieId.get(movie.getId());
     };
   }
 }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -309,6 +309,8 @@ public class SeriesService {
       case ADDED -> series.getCreatedOn();
       case RELEASE_DATE -> series.getFirstAirDate();
       case RUNTIME -> series.getRuntime();
+      case LAST_WATCHED ->
+          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
     };
   }
 }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -309,8 +309,7 @@ public class SeriesService {
       case ADDED -> series.getCreatedOn();
       case RELEASE_DATE -> series.getFirstAirDate();
       case RUNTIME -> series.getRuntime();
-      case LAST_WATCHED ->
-          throw new UnsupportedOperationException("LAST_WATCHED not yet implemented");
+      case LAST_WATCHED -> null;
     };
   }
 }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -263,6 +263,11 @@ public class SeriesService {
   }
 
   @Transactional(readOnly = true)
+  public Optional<Episode> findEpisodeById(UUID episodeId) {
+    return episodeRepository.findById(episodeId);
+  }
+
+  @Transactional(readOnly = true)
   public Season findSeason(UUID seasonId) {
     return seasonRepository.findById(seasonId).orElseThrow();
   }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -27,7 +27,6 @@ import com.streamarr.server.services.pagination.OrderMediaBy;
 import com.streamarr.server.services.pagination.PageItem;
 import com.streamarr.server.services.pagination.PaginationService;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -262,34 +261,6 @@ public class SeriesService {
   }
 
   @Transactional(readOnly = true)
-  public List<MediaFile> findAllEpisodeMediaFiles(UUID seriesId) {
-    var seasonIds = seasonRepository.findSeasonIdsBySeriesIds(List.of(seriesId));
-    var allSeasonIds = seasonIds.values().stream().flatMap(Collection::stream).toList();
-    if (allSeasonIds.isEmpty()) {
-      return List.of();
-    }
-
-    var episodeIds = episodeRepository.findEpisodeIdsBySeasonIds(allSeasonIds);
-    var allEpisodeIds = episodeIds.values().stream().flatMap(Collection::stream).toList();
-    if (allEpisodeIds.isEmpty()) {
-      return List.of();
-    }
-
-    return mediaFileRepository.findByMediaIdIn(allEpisodeIds);
-  }
-
-  @Transactional(readOnly = true)
-  public List<MediaFile> findSeasonEpisodeMediaFiles(UUID seasonId) {
-    var episodeIds = episodeRepository.findEpisodeIdsBySeasonIds(List.of(seasonId));
-    var allEpisodeIds = episodeIds.values().stream().flatMap(Collection::stream).toList();
-    if (allEpisodeIds.isEmpty()) {
-      return List.of();
-    }
-
-    return mediaFileRepository.findByMediaIdIn(allEpisodeIds);
-  }
-
-  @Transactional(readOnly = true)
   public List<Season> findSeasons(UUID seriesId) {
     return seasonRepository.findBySeriesId(seriesId);
   }
@@ -297,11 +268,6 @@ public class SeriesService {
   @Transactional(readOnly = true)
   public Optional<Episode> findEpisodeById(UUID episodeId) {
     return episodeRepository.findById(episodeId);
-  }
-
-  @Transactional(readOnly = true)
-  public Season findSeason(UUID seasonId) {
-    return seasonRepository.findById(seasonId).orElseThrow();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -276,6 +276,17 @@ public class SeriesService {
   }
 
   @Transactional(readOnly = true)
+  public List<MediaFile> findSeasonEpisodeMediaFiles(UUID seasonId) {
+    var episodeIds = episodeRepository.findEpisodeIdsBySeasonIds(List.of(seasonId));
+    var allEpisodeIds = episodeIds.values().stream().flatMap(Collection::stream).toList();
+    if (allEpisodeIds.isEmpty()) {
+      return List.of();
+    }
+
+    return mediaFileRepository.findByMediaIdIn(allEpisodeIds);
+  }
+
+  @Transactional(readOnly = true)
   public List<Season> findSeasons(UUID seriesId) {
     return seasonRepository.findBySeriesId(seriesId);
   }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -263,6 +263,11 @@ public class SeriesService {
   }
 
   @Transactional(readOnly = true)
+  public Season findSeason(UUID seasonId) {
+    return seasonRepository.findById(seasonId).orElseThrow();
+  }
+
+  @Transactional(readOnly = true)
   public List<Episode> findEpisodes(UUID seasonId) {
     return episodeRepository.findBySeasonId(seasonId);
   }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -25,6 +25,7 @@ import com.streamarr.server.services.pagination.MediaPage;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
 import com.streamarr.server.services.pagination.PageItem;
 import com.streamarr.server.services.pagination.PaginationService;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -255,6 +256,23 @@ public class SeriesService {
   @Transactional(readOnly = true)
   public List<MediaFile> findMediaFiles(UUID entityId) {
     return mediaFileRepository.findByMediaId(entityId);
+  }
+
+  @Transactional(readOnly = true)
+  public List<MediaFile> findAllEpisodeMediaFiles(UUID seriesId) {
+    var seasonIds = seasonRepository.findSeasonIdsBySeriesIds(List.of(seriesId));
+    var allSeasonIds = seasonIds.values().stream().flatMap(Collection::stream).toList();
+    if (allSeasonIds.isEmpty()) {
+      return List.of();
+    }
+
+    var episodeIds = episodeRepository.findEpisodeIdsBySeasonIds(allSeasonIds);
+    var allEpisodeIds = episodeIds.values().stream().flatMap(Collection::stream).toList();
+    if (allEpisodeIds.isEmpty()) {
+      return List.of();
+    }
+
+    return mediaFileRepository.findByMediaIdIn(allEpisodeIds);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -23,10 +23,13 @@ import com.streamarr.server.services.metadata.series.SeasonDetails;
 import com.streamarr.server.services.pagination.MediaFilter;
 import com.streamarr.server.services.pagination.MediaPage;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
+import com.streamarr.server.services.pagination.OrderMediaBy;
 import com.streamarr.server.services.pagination.PageItem;
 import com.streamarr.server.services.pagination.PaginationService;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -332,23 +335,37 @@ public class SeriesService {
             ? seriesRepository.seekWithFilter(options)
             : seriesRepository.findFirstWithFilter(options);
 
+    var lastWatchedBySeriesId = lastWatchedFor(options.getMediaFilter(), seriesList);
+
     var pageItems =
         seriesList.stream()
             .map(
-                series -> new PageItem<>(series, getOrderByValue(options.getMediaFilter(), series)))
+                series ->
+                    new PageItem<>(
+                        series,
+                        getOrderByValue(options.getMediaFilter(), series, lastWatchedBySeriesId)))
             .toList();
 
     return paginationService.buildMediaPage(
         pageItems, options.getPaginationOptions(), options.getCursorId());
   }
 
-  private Object getOrderByValue(MediaFilter filter, Series series) {
+  private Map<UUID, Instant> lastWatchedFor(MediaFilter filter, List<Series> seriesList) {
+    if (filter.getSortBy() != OrderMediaBy.LAST_WATCHED || seriesList.isEmpty()) {
+      return Map.of();
+    }
+    return seriesRepository.findLastWatchedBySeriesIds(
+        seriesList.stream().map(Series::getId).toList());
+  }
+
+  private Object getOrderByValue(
+      MediaFilter filter, Series series, Map<UUID, Instant> lastWatchedBySeriesId) {
     return switch (filter.getSortBy()) {
       case TITLE -> series.getTitleSort();
       case ADDED -> series.getCreatedOn();
       case RELEASE_DATE -> series.getFirstAirDate();
       case RUNTIME -> series.getRuntime();
-      case LAST_WATCHED -> null;
+      case LAST_WATCHED -> lastWatchedBySeriesId.get(series.getId());
     };
   }
 }

--- a/src/main/java/com/streamarr/server/services/pagination/MediaFilter.java
+++ b/src/main/java/com/streamarr/server/services/pagination/MediaFilter.java
@@ -1,6 +1,7 @@
 package com.streamarr.server.services.pagination;
 
 import com.streamarr.server.domain.AlphabetLetter;
+import com.streamarr.server.domain.streaming.WatchStatus;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -30,6 +31,7 @@ public class MediaFilter {
   private List<UUID> directorIds;
   private List<UUID> castMemberIds;
   private Boolean unmatched;
+  private WatchStatus watchStatus;
 
   private Object previousSortFieldValue;
 }

--- a/src/main/java/com/streamarr/server/services/pagination/OrderMediaBy.java
+++ b/src/main/java/com/streamarr/server/services/pagination/OrderMediaBy.java
@@ -4,5 +4,6 @@ public enum OrderMediaBy {
   TITLE,
   ADDED,
   RELEASE_DATE,
-  RUNTIME;
+  RUNTIME,
+  LAST_WATCHED;
 }

--- a/src/main/java/com/streamarr/server/services/watchprogress/ContinueWatchingService.java
+++ b/src/main/java/com/streamarr/server/services/watchprogress/ContinueWatchingService.java
@@ -1,22 +1,15 @@
 package com.streamarr.server.services.watchprogress;
 
-import static org.jooq.impl.DSL.exists;
-import static org.jooq.impl.DSL.max;
-import static org.jooq.impl.DSL.not;
-import static org.jooq.impl.DSL.select;
-
 import com.streamarr.server.domain.BaseCollectable;
-import com.streamarr.server.domain.media.Episode;
-import com.streamarr.server.domain.media.Movie;
-import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.repositories.media.EpisodeRepository;
 import com.streamarr.server.repositories.media.MovieRepository;
+import com.streamarr.server.repositories.streaming.ContinueWatchingRepository;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.jooq.DSLContext;
-import org.jooq.SortOrder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ContinueWatchingService {
 
-  private final DSLContext context;
+  private final ContinueWatchingRepository continueWatchingRepository;
   private final MovieRepository movieRepository;
   private final EpisodeRepository episodeRepository;
 
@@ -33,60 +26,25 @@ public class ContinueWatchingService {
     // TODO(#163): Replace with authenticated user ID from Spring Security
     var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
-    var isWatched =
-        exists(
-            select(Tables.WATCH_HISTORY.ID)
-                .from(Tables.WATCH_HISTORY)
-                .where(
-                    Tables.WATCH_HISTORY
-                        .COLLECTABLE_ID
-                        .eq(Tables.MEDIA_FILE.MEDIA_ID)
-                        .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
-                        .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
-
-    var collectableIds =
-        context
-            .select(
-                Tables.MEDIA_FILE.MEDIA_ID,
-                max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON).as("last_activity"))
-            .from(Tables.SESSION_PROGRESS)
-            .innerJoin(Tables.MEDIA_FILE)
-            .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
-            .where(
-                Tables.SESSION_PROGRESS
-                    .USER_ID
-                    .eq(userId)
-                    .and(Tables.SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))
-                    .and(not(isWatched)))
-            .groupBy(Tables.MEDIA_FILE.MEDIA_ID)
-            .orderBy(max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON).sort(SortOrder.DESC))
-            .limit(limit)
-            .fetch(Tables.MEDIA_FILE.MEDIA_ID);
+    var collectableIds = continueWatchingRepository.findCollectableIds(userId, limit);
 
     if (collectableIds.isEmpty()) {
       return List.of();
     }
 
-    var movies = movieRepository.findAllById(collectableIds);
-    var episodes = episodeRepository.findAllById(collectableIds);
+    Map<UUID, BaseCollectable<?>> lookup = new HashMap<>();
+    movieRepository.findAllById(collectableIds).forEach(movie -> lookup.put(movie.getId(), movie));
+    episodeRepository
+        .findAllById(collectableIds)
+        .forEach(episode -> lookup.put(episode.getId(), episode));
 
-    var movieMap = movies.stream().collect(java.util.stream.Collectors.toMap(Movie::getId, m -> m));
-    var episodeMap =
-        episodes.stream().collect(java.util.stream.Collectors.toMap(Episode::getId, e -> e));
-
-    var result = new ArrayList<BaseCollectable<?>>();
+    var result = new ArrayList<BaseCollectable<?>>(collectableIds.size());
     for (var id : collectableIds) {
-      var movie = movieMap.get(id);
-      if (movie != null) {
-        result.add(movie);
-        continue;
-      }
-      var episode = episodeMap.get(id);
-      if (episode != null) {
-        result.add(episode);
+      var item = lookup.get(id);
+      if (item != null) {
+        result.add(item);
       }
     }
-
     return result;
   }
 }

--- a/src/main/java/com/streamarr/server/services/watchprogress/ContinueWatchingService.java
+++ b/src/main/java/com/streamarr/server/services/watchprogress/ContinueWatchingService.java
@@ -1,0 +1,92 @@
+package com.streamarr.server.services.watchprogress;
+
+import static org.jooq.impl.DSL.exists;
+import static org.jooq.impl.DSL.max;
+import static org.jooq.impl.DSL.not;
+import static org.jooq.impl.DSL.select;
+
+import com.streamarr.server.domain.BaseCollectable;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.jooq.generated.Tables;
+import com.streamarr.server.repositories.media.EpisodeRepository;
+import com.streamarr.server.repositories.media.MovieRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.SortOrder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ContinueWatchingService {
+
+  private final DSLContext context;
+  private final MovieRepository movieRepository;
+  private final EpisodeRepository episodeRepository;
+
+  @Transactional(readOnly = true)
+  public List<BaseCollectable<?>> getContinueWatching(int limit) {
+    // TODO(#163): Replace with authenticated user ID from Spring Security
+    var userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    var isWatched =
+        exists(
+            select(Tables.WATCH_HISTORY.ID)
+                .from(Tables.WATCH_HISTORY)
+                .where(
+                    Tables.WATCH_HISTORY
+                        .COLLECTABLE_ID
+                        .eq(Tables.MEDIA_FILE.MEDIA_ID)
+                        .and(Tables.WATCH_HISTORY.USER_ID.eq(userId))
+                        .and(Tables.WATCH_HISTORY.DISMISSED_AT.isNull())));
+
+    var collectableIds =
+        context
+            .select(
+                Tables.MEDIA_FILE.MEDIA_ID,
+                max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON).as("last_activity"))
+            .from(Tables.SESSION_PROGRESS)
+            .innerJoin(Tables.MEDIA_FILE)
+            .on(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(Tables.MEDIA_FILE.ID))
+            .where(
+                Tables.SESSION_PROGRESS
+                    .USER_ID
+                    .eq(userId)
+                    .and(Tables.SESSION_PROGRESS.POSITION_SECONDS.greaterThan(0))
+                    .and(not(isWatched)))
+            .groupBy(Tables.MEDIA_FILE.MEDIA_ID)
+            .orderBy(max(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON).sort(SortOrder.DESC))
+            .limit(limit)
+            .fetch(Tables.MEDIA_FILE.MEDIA_ID);
+
+    if (collectableIds.isEmpty()) {
+      return List.of();
+    }
+
+    var movies = movieRepository.findAllById(collectableIds);
+    var episodes = episodeRepository.findAllById(collectableIds);
+
+    var movieMap = movies.stream().collect(java.util.stream.Collectors.toMap(Movie::getId, m -> m));
+    var episodeMap =
+        episodes.stream().collect(java.util.stream.Collectors.toMap(Episode::getId, e -> e));
+
+    var result = new ArrayList<BaseCollectable<?>>();
+    for (var id : collectableIds) {
+      var movie = movieMap.get(id);
+      if (movie != null) {
+        result.add(movie);
+        continue;
+      }
+      var episode = episodeMap.get(id);
+      if (episode != null) {
+        result.add(episode);
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/com/streamarr/server/services/watchprogress/ContinueWatchingService.java
+++ b/src/main/java/com/streamarr/server/services/watchprogress/ContinueWatchingService.java
@@ -4,10 +4,10 @@ import com.streamarr.server.domain.BaseCollectable;
 import com.streamarr.server.repositories.media.EpisodeRepository;
 import com.streamarr.server.repositories.media.MovieRepository;
 import com.streamarr.server.repositories.streaming.ContinueWatchingRepository;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,19 +32,12 @@ public class ContinueWatchingService {
       return List.of();
     }
 
-    Map<UUID, BaseCollectable<?>> lookup = new HashMap<>();
-    movieRepository.findAllById(collectableIds).forEach(movie -> lookup.put(movie.getId(), movie));
+    Map<UUID, BaseCollectable<?>> byId = new HashMap<>();
+    movieRepository.findAllById(collectableIds).forEach(movie -> byId.put(movie.getId(), movie));
     episodeRepository
         .findAllById(collectableIds)
-        .forEach(episode -> lookup.put(episode.getId(), episode));
+        .forEach(episode -> byId.put(episode.getId(), episode));
 
-    var result = new ArrayList<BaseCollectable<?>>(collectableIds.size());
-    for (var id : collectableIds) {
-      var item = lookup.get(id);
-      if (item != null) {
-        result.add(item);
-      }
-    }
-    return result;
+    return collectableIds.stream().map(byId::get).filter(Objects::nonNull).toList();
   }
 }

--- a/src/main/java/com/streamarr/server/services/watchprogress/WatchProgressDto.java
+++ b/src/main/java/com/streamarr/server/services/watchprogress/WatchProgressDto.java
@@ -1,0 +1,19 @@
+package com.streamarr.server.services.watchprogress;
+
+import com.streamarr.server.domain.streaming.SessionProgress;
+import java.time.Instant;
+import lombok.Builder;
+
+@Builder
+public record WatchProgressDto(
+    int positionSeconds, double percentComplete, int durationSeconds, Instant lastModifiedOn) {
+
+  public static WatchProgressDto from(SessionProgress sessionProgress) {
+    return WatchProgressDto.builder()
+        .positionSeconds(sessionProgress.getPositionSeconds())
+        .percentComplete(sessionProgress.getPercentComplete())
+        .durationSeconds(sessionProgress.getDurationSeconds())
+        .lastModifiedOn(sessionProgress.getLastModifiedOn())
+        .build();
+  }
+}

--- a/src/main/java/com/streamarr/server/services/watchprogress/WatchStatusService.java
+++ b/src/main/java/com/streamarr/server/services/watchprogress/WatchStatusService.java
@@ -13,9 +13,11 @@ import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
 import com.streamarr.server.services.watchprogress.events.WatchStatusChangedEvent;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -183,6 +185,62 @@ public class WatchStatusService {
               seriesEpisodeIds, data.watchedEpisodeIds(), mediaFileIds, data.progressMap()));
     }
     return result;
+  }
+
+  public Map<UUID, WatchProgressDto> getAggregateProgressForSeasons(
+      UUID userId, Collection<UUID> seasonIds) {
+    var episodeIdsBySeasonId = episodeRepository.findEpisodeIdsBySeasonIds(seasonIds);
+    if (episodeIdsBySeasonId.isEmpty()) {
+      return Map.of();
+    }
+
+    var allEpisodeIds = episodeIdsBySeasonId.values().stream().flatMap(Collection::stream).toList();
+    var data = fetchEpisodeMediaData(userId, allEpisodeIds);
+
+    var result = new HashMap<UUID, WatchProgressDto>();
+    for (var entry : episodeIdsBySeasonId.entrySet()) {
+      var mediaFileIds = collectMediaFileIds(entry.getValue(), data);
+      result.put(entry.getKey(), pickLatestProgress(mediaFileIds, data.progressMap()));
+    }
+    return result;
+  }
+
+  public Map<UUID, WatchProgressDto> getAggregateProgressForSeries(
+      UUID userId, Collection<UUID> seriesIds) {
+    var seasonIdsBySeriesId = seasonRepository.findSeasonIdsBySeriesIds(seriesIds);
+    if (seasonIdsBySeriesId.isEmpty()) {
+      return Map.of();
+    }
+
+    var allSeasonIds = seasonIdsBySeriesId.values().stream().flatMap(Collection::stream).toList();
+    var episodeIdsBySeasonId = episodeRepository.findEpisodeIdsBySeasonIds(allSeasonIds);
+    if (episodeIdsBySeasonId.isEmpty()) {
+      return Map.of();
+    }
+
+    var allEpisodeIds = episodeIdsBySeasonId.values().stream().flatMap(Collection::stream).toList();
+    var data = fetchEpisodeMediaData(userId, allEpisodeIds);
+
+    var result = new HashMap<UUID, WatchProgressDto>();
+    for (var seriesEntry : seasonIdsBySeriesId.entrySet()) {
+      var seriesEpisodeIds =
+          seriesEntry.getValue().stream()
+              .flatMap(seasonId -> episodeIdsBySeasonId.getOrDefault(seasonId, List.of()).stream())
+              .toList();
+      var mediaFileIds = collectMediaFileIds(seriesEpisodeIds, data);
+      result.put(seriesEntry.getKey(), pickLatestProgress(mediaFileIds, data.progressMap()));
+    }
+    return result;
+  }
+
+  private static WatchProgressDto pickLatestProgress(
+      List<UUID> mediaFileIds, Map<UUID, SessionProgress> progressMap) {
+    return mediaFileIds.stream()
+        .map(progressMap::get)
+        .filter(Objects::nonNull)
+        .max(Comparator.comparing(SessionProgress::getLastModifiedOn))
+        .map(WatchProgressDto::from)
+        .orElse(null);
   }
 
   private record EpisodeMediaData(

--- a/src/main/resources/schema/episode.graphqls
+++ b/src/main/resources/schema/episode.graphqls
@@ -5,6 +5,7 @@ type Episode {
     overview: String
     airDate: String
     runtime: Int
+    season: Season!
     files: [MediaFile]!
     images(type: ImageType): [Image]!
     watchProgress: WatchProgress

--- a/src/main/resources/schema/library.graphqls
+++ b/src/main/resources/schema/library.graphqls
@@ -43,6 +43,7 @@ enum OrderMediaBy {
     ADDED
     RELEASE_DATE
     RUNTIME
+    LAST_WATCHED
 }
 
 enum SortDirection {
@@ -64,6 +65,7 @@ input MediaFilter {
     directorIds: [ID!]
     castMemberIds: [ID!]
     unmatched: Boolean
+    watchStatus: WatchStatus
 }
 
 enum AlphabetLetter {

--- a/src/main/resources/schema/root-query.graphqls
+++ b/src/main/resources/schema/root-query.graphqls
@@ -1,6 +1,7 @@
 type Query {
     movie(id: ID!): Movie
     series(id: ID!): Series
+    episode(id: ID!): Episode
     rating(id: ID!): Rating!
     library(id: ID!): Library!
     libraries: [Library!]!

--- a/src/main/resources/schema/root-query.graphqls
+++ b/src/main/resources/schema/root-query.graphqls
@@ -4,4 +4,5 @@ type Query {
     rating(id: ID!): Rating!
     library(id: ID!): Library!
     libraries: [Library!]!
+    continueWatching(first: Int): [ContinueWatchingMedia!]!
 }

--- a/src/main/resources/schema/season.graphqls
+++ b/src/main/resources/schema/season.graphqls
@@ -7,5 +7,6 @@ type Season {
     series: Series!
     episodes: [Episode]!
     images(type: ImageType): [Image]!
+    watchProgress: WatchProgress
     watchStatus: WatchStatus!
 }

--- a/src/main/resources/schema/season.graphqls
+++ b/src/main/resources/schema/season.graphqls
@@ -4,6 +4,7 @@ type Season {
     seasonNumber: Int!
     overview: String
     airDate: String
+    series: Series!
     episodes: [Episode]!
     images(type: ImageType): [Image]!
     watchStatus: WatchStatus!

--- a/src/main/resources/schema/series.graphqls
+++ b/src/main/resources/schema/series.graphqls
@@ -19,5 +19,6 @@ type Series implements BaseCollectable {
     seasons: [Season]!
     files: [MediaFile]!
     images(type: ImageType): [Image]!
+    watchProgress: WatchProgress
     watchStatus: WatchStatus!
 }

--- a/src/main/resources/schema/streaming.graphqls
+++ b/src/main/resources/schema/streaming.graphqls
@@ -49,3 +49,5 @@ type WatchProgress {
     percentComplete: Float!
     durationSeconds: Int!
 }
+
+union ContinueWatchingMedia = Movie | Episode

--- a/src/test/java/com/streamarr/server/fakes/FakeMovieRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeMovieRepository.java
@@ -158,6 +158,8 @@ public class FakeMovieRepository extends FakeJpaRepository<Movie> implements Mov
               isDesc
                   ? Comparator.comparing(Movie::getTitle, Comparator.reverseOrder())
                   : Comparator.comparing(Movie::getTitle);
+          case LAST_WATCHED ->
+              throw new UnsupportedOperationException("LAST_WATCHED not yet implemented in fake");
         };
 
     Comparator<Movie> idComparator = Comparator.comparing(Movie::getId);

--- a/src/test/java/com/streamarr/server/fakes/FakeMovieRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeMovieRepository.java
@@ -7,10 +7,13 @@ import com.streamarr.server.services.pagination.MediaFilter;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
 import com.streamarr.server.services.pagination.OrderMediaBy;
 import com.streamarr.server.services.pagination.PaginationDirection;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -185,5 +188,10 @@ public class FakeMovieRepository extends FakeJpaRepository<Movie> implements Mov
   @Override
   public List<Movie> findByLibraryIdWithExternalIds(UUID libraryId) {
     return findByLibrary_Id(libraryId);
+  }
+
+  @Override
+  public Map<UUID, Instant> findLastWatchedByMovieIds(Collection<UUID> movieIds) {
+    throw new UnsupportedOperationException("LAST_WATCHED not yet implemented in fake");
   }
 }

--- a/src/test/java/com/streamarr/server/fakes/FakeSeriesRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeSeriesRepository.java
@@ -7,10 +7,13 @@ import com.streamarr.server.services.pagination.MediaFilter;
 import com.streamarr.server.services.pagination.MediaPaginationOptions;
 import com.streamarr.server.services.pagination.OrderMediaBy;
 import com.streamarr.server.services.pagination.PaginationDirection;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -78,6 +81,11 @@ public class FakeSeriesRepository extends FakeJpaRepository<Series> implements S
   @Override
   public List<Series> findByLibraryIdWithExternalIds(UUID libraryId) {
     return findByLibrary_Id(libraryId);
+  }
+
+  @Override
+  public Map<UUID, Instant> findLastWatchedBySeriesIds(Collection<UUID> seriesIds) {
+    throw new UnsupportedOperationException("LAST_WATCHED not yet implemented in fake");
   }
 
   private Stream<Series> filterByLibrary(MediaFilter filter) {

--- a/src/test/java/com/streamarr/server/fakes/FakeSeriesRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeSeriesRepository.java
@@ -171,6 +171,8 @@ public class FakeSeriesRepository extends FakeJpaRepository<Series> implements S
               isDesc
                   ? Comparator.comparing(Series::getTitle, Comparator.reverseOrder())
                   : Comparator.comparing(Series::getTitle);
+          case LAST_WATCHED ->
+              throw new UnsupportedOperationException("LAST_WATCHED not yet implemented in fake");
         };
 
     Comparator<Series> idComparator = Comparator.comparing(Series::getId);

--- a/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverTest.java
@@ -2,6 +2,7 @@ package com.streamarr.server.graphql.resolvers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
@@ -99,7 +100,7 @@ class ContinueWatchingResolverTest {
     @Test
     @DisplayName("Should throw for unsupported media type")
     void shouldThrowForUnsupportedMediaType() {
-      var resolver = new ContinueWatchingResolver(null);
+      var resolver = new ContinueWatchingResolver(mock(ContinueWatchingService.class));
       var unsupported = new Object();
 
       assertThatThrownBy(() -> resolver.resolveContinueWatchingMedia(unsupported))

--- a/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverTest.java
@@ -1,0 +1,110 @@
+package com.streamarr.server.graphql.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.services.watchprogress.ContinueWatchingService;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@EnableDgsTest
+@SpringBootTest(classes = {ContinueWatchingResolver.class})
+@DisplayName("Continue Watching Resolver Tests")
+class ContinueWatchingResolverTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+  @MockitoBean private ContinueWatchingService continueWatchingService;
+
+  @Nested
+  @DisplayName("continueWatching query")
+  class ContinueWatchingQueryTests {
+
+    @Test
+    @DisplayName("Should delegate to service with first parameter")
+    void shouldDelegateToServiceWithFirstParameter() {
+      var movie = Movie.builder().title("Test Movie").titleSort("Test Movie").build();
+      movie.setId(UUID.randomUUID());
+
+      when(continueWatchingService.getContinueWatching(eq(10))).thenReturn(List.of(movie));
+
+      List<String> titles =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              "{ continueWatching(first: 10) { ... on Movie { title } } }",
+              "data.continueWatching[*].title");
+
+      assertThat(titles).containsExactly("Test Movie");
+    }
+
+    @Test
+    @DisplayName("Should return empty list when no items in progress")
+    void shouldReturnEmptyListWhenNoItemsInProgress() {
+      when(continueWatchingService.getContinueWatching(eq(20))).thenReturn(List.of());
+
+      List<Object> results =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              "{ continueWatching(first: 20) { ... on Movie { title } } }",
+              "data.continueWatching");
+
+      assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should resolve Movie type in union")
+    void shouldResolveMovieTypeInUnion() {
+      var movie = Movie.builder().title("Movie Item").titleSort("Movie Item").build();
+      movie.setId(UUID.randomUUID());
+
+      when(continueWatchingService.getContinueWatching(eq(20))).thenReturn(List.of(movie));
+
+      String typename =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              "{ continueWatching(first: 20) { __typename } }",
+              "data.continueWatching[0].__typename");
+
+      assertThat(typename).isEqualTo("Movie");
+    }
+
+    @Test
+    @DisplayName("Should resolve Episode type in union")
+    void shouldResolveEpisodeTypeInUnion() {
+      var episode = Episode.builder().title("Episode Item").episodeNumber(1).build();
+      episode.setId(UUID.randomUUID());
+
+      when(continueWatchingService.getContinueWatching(eq(20))).thenReturn(List.of(episode));
+
+      String typename =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              "{ continueWatching(first: 20) { __typename } }",
+              "data.continueWatching[0].__typename");
+
+      assertThat(typename).isEqualTo("Episode");
+    }
+  }
+
+  @Nested
+  @DisplayName("Type Resolver")
+  class TypeResolverTests {
+
+    @Test
+    @DisplayName("Should throw for unsupported media type")
+    void shouldThrowForUnsupportedMediaType() {
+      var resolver = new ContinueWatchingResolver(null);
+
+      assertThatThrownBy(() -> resolver.resolveContinueWatchingMedia(new Object()))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Unknown continue watching media type");
+    }
+  }
+}

--- a/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverTest.java
@@ -2,7 +2,6 @@ package com.streamarr.server.graphql.resolvers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
@@ -37,7 +36,7 @@ class ContinueWatchingResolverTest {
       var movie = Movie.builder().title("Test Movie").titleSort("Test Movie").build();
       movie.setId(UUID.randomUUID());
 
-      when(continueWatchingService.getContinueWatching(eq(10))).thenReturn(List.of(movie));
+      when(continueWatchingService.getContinueWatching(10)).thenReturn(List.of(movie));
 
       List<String> titles =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -50,7 +49,7 @@ class ContinueWatchingResolverTest {
     @Test
     @DisplayName("Should return empty list when no items in progress")
     void shouldReturnEmptyListWhenNoItemsInProgress() {
-      when(continueWatchingService.getContinueWatching(eq(20))).thenReturn(List.of());
+      when(continueWatchingService.getContinueWatching(20)).thenReturn(List.of());
 
       List<Object> results =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -66,7 +65,7 @@ class ContinueWatchingResolverTest {
       var movie = Movie.builder().title("Movie Item").titleSort("Movie Item").build();
       movie.setId(UUID.randomUUID());
 
-      when(continueWatchingService.getContinueWatching(eq(20))).thenReturn(List.of(movie));
+      when(continueWatchingService.getContinueWatching(20)).thenReturn(List.of(movie));
 
       String typename =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -82,7 +81,7 @@ class ContinueWatchingResolverTest {
       var episode = Episode.builder().title("Episode Item").episodeNumber(1).build();
       episode.setId(UUID.randomUUID());
 
-      when(continueWatchingService.getContinueWatching(eq(20))).thenReturn(List.of(episode));
+      when(continueWatchingService.getContinueWatching(20)).thenReturn(List.of(episode));
 
       String typename =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -101,8 +100,9 @@ class ContinueWatchingResolverTest {
     @DisplayName("Should throw for unsupported media type")
     void shouldThrowForUnsupportedMediaType() {
       var resolver = new ContinueWatchingResolver(null);
+      var unsupported = new Object();
 
-      assertThatThrownBy(() -> resolver.resolveContinueWatchingMedia(new Object()))
+      assertThatThrownBy(() -> resolver.resolveContinueWatchingMedia(unsupported))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("Unknown continue watching media type");
     }

--- a/src/test/java/com/streamarr/server/graphql/resolvers/LibraryResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/LibraryResolverTest.java
@@ -33,6 +33,7 @@ import com.streamarr.server.services.pagination.PaginationService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.jooq.SortOrder;
 import org.junit.jupiter.api.DisplayName;
@@ -400,8 +401,10 @@ class LibraryResolverTest {
     }
 
     @Test
-    @DisplayName("Should delegate watch status filter to movie service when watchStatus provided")
-    void shouldDelegateWatchStatusFilterToMovieServiceWhenWatchStatusProvided() {
+    @DisplayName(
+        "Should forward watchStatus filter to movie service when watchStatus provided in"
+            + " GraphQL filter input")
+    void shouldForwardWatchStatusFilterToMovieServiceWhenWatchStatusProvidedInGraphqlFilterInput() {
       var libraryId = UUID.randomUUID();
       var library = buildMovieLibrary(libraryId);
 
@@ -409,16 +412,15 @@ class LibraryResolverTest {
       movie.setId(UUID.randomUUID());
 
       var page = new MediaPage<>(List.of(new PageItem<>(movie, "In Progress Movie")), false, false);
+      var capturedOptions = new AtomicReference<MediaPaginationOptions>();
 
       when(libraryRepository.findById(libraryId)).thenReturn(Optional.of(library));
-
-      when(movieService.getMoviesWithFilter(
-              argThat(
-                  (MediaPaginationOptions opts) -> {
-                    var f = opts.getMediaFilter();
-                    return f.getWatchStatus() == WatchStatus.IN_PROGRESS;
-                  })))
-          .thenReturn(page);
+      when(movieService.getMoviesWithFilter(any(MediaPaginationOptions.class)))
+          .thenAnswer(
+              invocation -> {
+                capturedOptions.set(invocation.getArgument(0));
+                return page;
+              });
 
       String title =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -430,6 +432,16 @@ class LibraryResolverTest {
               "data.library.items.edges[0].node.title");
 
       assertThat(title).isEqualTo("In Progress Movie");
+      assertThat(capturedOptions.get())
+          .as(
+              "MovieService must receive the MediaPaginationOptions produced from the GraphQL input")
+          .isNotNull();
+      assertThat(capturedOptions.get().getMediaFilter().getWatchStatus())
+          .as("watchStatus must be forwarded from GraphQL filter to MediaFilter")
+          .isEqualTo(WatchStatus.IN_PROGRESS);
+      assertThat(capturedOptions.get().getMediaFilter().getLibraryId())
+          .as("libraryId must be forwarded from parent library to MediaFilter")
+          .isEqualTo(libraryId);
     }
 
     @Test

--- a/src/test/java/com/streamarr/server/graphql/resolvers/LibraryResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/LibraryResolverTest.java
@@ -17,6 +17,7 @@ import com.streamarr.server.domain.LibraryStatus;
 import com.streamarr.server.domain.media.MediaType;
 import com.streamarr.server.domain.media.Movie;
 import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.exceptions.UnsupportedMediaTypeException;
 import com.streamarr.server.graphql.cursor.CursorUtil;
 import com.streamarr.server.graphql.cursor.CursorValidator;
@@ -396,6 +397,39 @@ class LibraryResolverTest {
               "data.library.items.edges[0].node.title");
 
       assertThat(title).isEqualTo("Filtered Movie");
+    }
+
+    @Test
+    @DisplayName("Should delegate watch status filter to movie service when watchStatus provided")
+    void shouldDelegateWatchStatusFilterToMovieServiceWhenWatchStatusProvided() {
+      var libraryId = UUID.randomUUID();
+      var library = buildMovieLibrary(libraryId);
+
+      var movie = Movie.builder().title("In Progress Movie").titleSort("In Progress Movie").build();
+      movie.setId(UUID.randomUUID());
+
+      var page = new MediaPage<>(List.of(new PageItem<>(movie, "In Progress Movie")), false, false);
+
+      when(libraryRepository.findById(libraryId)).thenReturn(Optional.of(library));
+
+      when(movieService.getMoviesWithFilter(
+              argThat(
+                  (MediaPaginationOptions opts) -> {
+                    var f = opts.getMediaFilter();
+                    return f.getWatchStatus() == WatchStatus.IN_PROGRESS;
+                  })))
+          .thenReturn(page);
+
+      String title =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              String.format(
+                  """
+                  { library(id: "%s") { items(first: 10, filter: {watchStatus: IN_PROGRESS}) { edges { node { ... on Movie { title } } } } } }
+                  """,
+                  libraryId),
+              "data.library.items.edges[0].node.title");
+
+      assertThat(title).isEqualTo("In Progress Movie");
     }
 
     @Test

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolverTest.java
@@ -23,7 +23,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 @Tag("UnitTest")
 @EnableDgsTest
 @SpringBootTest(
-    classes = {SeasonFieldResolver.class, SeriesFieldResolver.class, SeriesResolver.class})
+    classes = {
+      SeasonFieldResolver.class,
+      EpisodeFieldResolver.class,
+      SeriesFieldResolver.class,
+      SeriesResolver.class
+    })
 @DisplayName("Season Field Resolver Tests")
 class SeasonFieldResolverTest {
 

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.services.SeriesService;
@@ -91,5 +92,34 @@ class SeriesResolverTest {
             "data.series.files[0].filepathUri");
 
     assertThat(filepathUri).isEqualTo("/media/shows/Breaking Bad/Season 1/breaking.bad.s01e01.mkv");
+  }
+
+  @Test
+  @DisplayName("Should return episode when valid ID provided")
+  void shouldReturnEpisodeWhenValidIdProvided() {
+    var episodeId = UUID.randomUUID();
+    var episode = Episode.builder().title("Pilot").episodeNumber(1).build();
+    episode.setId(episodeId);
+
+    when(seriesService.findEpisodeById(episodeId)).thenReturn(Optional.of(episode));
+
+    String title =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            String.format("{ episode(id: \"%s\") { title episodeNumber } }", episodeId),
+            "data.episode.title");
+
+    assertThat(title).isEqualTo("Pilot");
+  }
+
+  @Test
+  @DisplayName("Should return null when episode not found")
+  void shouldReturnNullWhenEpisodeNotFound() {
+    when(seriesService.findEpisodeById(any(UUID.class))).thenReturn(Optional.empty());
+
+    Object result =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            String.format("{ episode(id: \"%s\") { title } }", UUID.randomUUID()), "data.episode");
+
+    assertThat(result).isNull();
   }
 }

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -133,6 +133,7 @@ class WatchProgressFieldResolverTest {
       var mediaFile = buildMediaFile();
       mediaFile.setMediaId(movie.getId());
       mediaFileRepository.save(mediaFile);
+      when(movieService.findMediaFiles(movie.getId())).thenReturn(List.of(mediaFile));
 
       sessionProgressRepository.save(
           SessionProgress.builder()
@@ -159,6 +160,7 @@ class WatchProgressFieldResolverTest {
     @DisplayName("Should return null watch progress when movie has no files")
     void shouldReturnNullWatchProgressWhenMovieHasNoFiles() {
       var movie = setupMovie();
+      when(movieService.findMediaFiles(movie.getId())).thenReturn(List.of());
 
       Object watchProgress =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -176,6 +178,7 @@ class WatchProgressFieldResolverTest {
       var mediaFile = buildMediaFile();
       mediaFile.setMediaId(movie.getId());
       mediaFileRepository.save(mediaFile);
+      when(movieService.findMediaFiles(movie.getId())).thenReturn(List.of(mediaFile));
 
       Object watchProgress =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -199,6 +202,7 @@ class WatchProgressFieldResolverTest {
       var mediaFile = buildMediaFile();
       mediaFile.setMediaId(movie.getId());
       mediaFileRepository.save(mediaFile);
+      when(movieService.findMediaFiles(movie.getId())).thenReturn(List.of(mediaFile));
 
       sessionProgressRepository.save(
           SessionProgress.builder()
@@ -245,6 +249,7 @@ class WatchProgressFieldResolverTest {
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
       when(seriesService.findEpisodes(seasonId)).thenReturn(List.of(episode));
+      when(seriesService.findMediaFiles(episodeId)).thenReturn(List.of(mediaFile));
 
       sessionProgressRepository.save(
           SessionProgress.builder()

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -365,6 +365,77 @@ class WatchProgressFieldResolverTest {
   }
 
   @Nested
+  @DisplayName("Season Watch Progress")
+  class SeasonWatchProgressTests {
+
+    @Test
+    @DisplayName("Should return most recent episode progress for season")
+    void shouldReturnMostRecentEpisodeProgressForSeason() {
+      var seriesId = UUID.randomUUID();
+      var series = Series.builder().title("Test Series").build();
+      series.setId(seriesId);
+
+      var seasonId = UUID.randomUUID();
+      var season = Season.builder().title("Season 1").seasonNumber(1).build();
+      season.setId(seasonId);
+
+      var mediaFile = buildMediaFile();
+      mediaFile.setMediaId(UUID.randomUUID());
+      mediaFileRepository.save(mediaFile);
+
+      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
+      when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
+      when(seriesService.findSeasonEpisodeMediaFiles(seasonId)).thenReturn(List.of(mediaFile));
+
+      sessionProgressRepository.save(
+          SessionProgress.builder()
+              .sessionId(UUID.randomUUID())
+              .userId(USER_ID)
+              .mediaFileId(mediaFile.getId())
+              .positionSeconds(600)
+              .percentComplete(50.0)
+              .durationSeconds(1200)
+              .build());
+
+      var context =
+          dgsQueryExecutor.executeAndGetDocumentContext(
+              String.format(
+                  "{ series(id: \"%s\") { seasons { watchProgress { positionSeconds percentComplete } } } }",
+                  seriesId));
+
+      assertThat(context.<Integer>read("data.series.seasons[0].watchProgress.positionSeconds"))
+          .isEqualTo(600);
+      assertThat(context.<Double>read("data.series.seasons[0].watchProgress.percentComplete"))
+          .isEqualTo(50.0);
+    }
+
+    @Test
+    @DisplayName("Should return null watch progress when season has no episode progress")
+    void shouldReturnNullWatchProgressWhenSeasonHasNoEpisodeProgress() {
+      var seriesId = UUID.randomUUID();
+      var series = Series.builder().title("Test Series").build();
+      series.setId(seriesId);
+
+      var seasonId = UUID.randomUUID();
+      var season = Season.builder().title("Season 1").seasonNumber(1).build();
+      season.setId(seasonId);
+
+      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
+      when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
+      when(seriesService.findSeasonEpisodeMediaFiles(seasonId)).thenReturn(List.of());
+
+      Object watchProgress =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              String.format(
+                  "{ series(id: \"%s\") { seasons { watchProgress { positionSeconds } } } }",
+                  seriesId),
+              "data.series.seasons[0].watchProgress");
+
+      assertThat(watchProgress).isNull();
+    }
+  }
+
+  @Nested
   @DisplayName("Series Watch Status")
   class SeriesWatchStatusTests {
 

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.domain.AuditFieldSetter;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.Movie;
@@ -23,6 +24,7 @@ import com.streamarr.server.graphql.dataloaders.WatchStatusDataLoader;
 import com.streamarr.server.services.MovieService;
 import com.streamarr.server.services.SeriesService;
 import com.streamarr.server.services.watchprogress.WatchStatusService;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -377,8 +379,10 @@ class WatchProgressFieldResolverTest {
   class SeasonWatchProgressTests {
 
     @Test
-    @DisplayName("Should return most recent episode progress for season")
-    void shouldReturnMostRecentEpisodeProgressForSeason() {
+    @DisplayName(
+        "Should return progress from most recently modified episode when season has multiple"
+            + " progresses")
+    void shouldReturnProgressFromMostRecentlyModifiedEpisodeWhenSeasonHasMultipleProgresses() {
       var seriesId = UUID.randomUUID();
       var series = Series.builder().title("Test Series").build();
       series.setId(seriesId);
@@ -386,37 +390,61 @@ class WatchProgressFieldResolverTest {
       var season = Season.builder().title("Season 1").seasonNumber(1).build();
       season.setId(UUID.randomUUID());
 
-      var episode = Episode.builder().episodeNumber(1).season(season).build();
-      episode.setId(UUID.randomUUID());
-      episodeRepository.save(episode);
+      var olderEpisode = Episode.builder().episodeNumber(1).season(season).build();
+      olderEpisode.setId(UUID.randomUUID());
+      episodeRepository.save(olderEpisode);
 
-      var mediaFile = buildMediaFile();
-      mediaFile.setMediaId(episode.getId());
-      mediaFileRepository.save(mediaFile);
+      var newerEpisode = Episode.builder().episodeNumber(2).season(season).build();
+      newerEpisode.setId(UUID.randomUUID());
+      episodeRepository.save(newerEpisode);
+
+      var olderFile = buildMediaFile();
+      olderFile.setMediaId(olderEpisode.getId());
+      mediaFileRepository.save(olderFile);
+
+      var newerFile = buildMediaFile();
+      newerFile.setMediaId(newerEpisode.getId());
+      mediaFileRepository.save(newerFile);
 
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
 
-      sessionProgressRepository.save(
-          SessionProgress.builder()
-              .sessionId(UUID.randomUUID())
-              .userId(USER_ID)
-              .mediaFileId(mediaFile.getId())
-              .positionSeconds(600)
-              .percentComplete(50.0)
-              .durationSeconds(1200)
-              .build());
+      var olderProgress =
+          sessionProgressRepository.save(
+              SessionProgress.builder()
+                  .sessionId(UUID.randomUUID())
+                  .userId(USER_ID)
+                  .mediaFileId(olderFile.getId())
+                  .positionSeconds(300)
+                  .percentComplete(10.0)
+                  .durationSeconds(3000)
+                  .build());
+      AuditFieldSetter.setLastModifiedOn(olderProgress, Instant.parse("2026-01-01T00:00:00Z"));
+
+      var newerProgress =
+          sessionProgressRepository.save(
+              SessionProgress.builder()
+                  .sessionId(UUID.randomUUID())
+                  .userId(USER_ID)
+                  .mediaFileId(newerFile.getId())
+                  .positionSeconds(900)
+                  .percentComplete(75.0)
+                  .durationSeconds(1200)
+                  .build());
+      AuditFieldSetter.setLastModifiedOn(newerProgress, Instant.parse("2026-02-01T00:00:00Z"));
 
       var context =
           dgsQueryExecutor.executeAndGetDocumentContext(
               String.format(
-                  "{ series(id: \"%s\") { seasons { watchProgress { positionSeconds percentComplete } } } }",
+                  "{ series(id: \"%s\") { seasons { watchProgress { positionSeconds percentComplete durationSeconds } } } }",
                   seriesId));
 
       assertThat(context.<Integer>read("data.series.seasons[0].watchProgress.positionSeconds"))
-          .isEqualTo(600);
+          .isEqualTo(900);
       assertThat(context.<Double>read("data.series.seasons[0].watchProgress.percentComplete"))
-          .isEqualTo(50.0);
+          .isEqualTo(75.0);
+      assertThat(context.<Integer>read("data.series.seasons[0].watchProgress.durationSeconds"))
+          .isEqualTo(1200);
     }
 
     @Test
@@ -470,34 +498,62 @@ class WatchProgressFieldResolverTest {
   class SeriesWatchProgressTests {
 
     @Test
-    @DisplayName("Should return most recent episode progress for series")
-    void shouldReturnMostRecentEpisodeProgressForSeries() {
+    @DisplayName(
+        "Should return progress from most recently modified episode when series spans multiple"
+            + " seasons")
+    void shouldReturnProgressFromMostRecentlyModifiedEpisodeWhenSeriesSpansMultipleSeasons() {
       var series = Series.builder().title("Test Series").build();
       series.setId(UUID.randomUUID());
 
-      var season = Season.builder().seasonNumber(1).series(series).build();
-      season.setId(UUID.randomUUID());
-      seasonRepository.save(season);
+      var seasonOne = Season.builder().seasonNumber(1).series(series).build();
+      seasonOne.setId(UUID.randomUUID());
+      seasonRepository.save(seasonOne);
 
-      var episode = Episode.builder().episodeNumber(1).season(season).build();
-      episode.setId(UUID.randomUUID());
-      episodeRepository.save(episode);
+      var seasonTwo = Season.builder().seasonNumber(2).series(series).build();
+      seasonTwo.setId(UUID.randomUUID());
+      seasonRepository.save(seasonTwo);
 
-      var mediaFile = buildMediaFile();
-      mediaFile.setMediaId(episode.getId());
-      mediaFileRepository.save(mediaFile);
+      var olderEpisode = Episode.builder().episodeNumber(1).season(seasonOne).build();
+      olderEpisode.setId(UUID.randomUUID());
+      episodeRepository.save(olderEpisode);
+
+      var newerEpisode = Episode.builder().episodeNumber(1).season(seasonTwo).build();
+      newerEpisode.setId(UUID.randomUUID());
+      episodeRepository.save(newerEpisode);
+
+      var olderFile = buildMediaFile();
+      olderFile.setMediaId(olderEpisode.getId());
+      mediaFileRepository.save(olderFile);
+
+      var newerFile = buildMediaFile();
+      newerFile.setMediaId(newerEpisode.getId());
+      mediaFileRepository.save(newerFile);
 
       when(seriesService.findById(series.getId())).thenReturn(Optional.of(series));
 
-      sessionProgressRepository.save(
-          SessionProgress.builder()
-              .sessionId(UUID.randomUUID())
-              .userId(USER_ID)
-              .mediaFileId(mediaFile.getId())
-              .positionSeconds(900)
-              .percentComplete(25.0)
-              .durationSeconds(3600)
-              .build());
+      var olderProgress =
+          sessionProgressRepository.save(
+              SessionProgress.builder()
+                  .sessionId(UUID.randomUUID())
+                  .userId(USER_ID)
+                  .mediaFileId(olderFile.getId())
+                  .positionSeconds(300)
+                  .percentComplete(10.0)
+                  .durationSeconds(3000)
+                  .build());
+      AuditFieldSetter.setLastModifiedOn(olderProgress, Instant.parse("2026-01-01T00:00:00Z"));
+
+      var newerProgress =
+          sessionProgressRepository.save(
+              SessionProgress.builder()
+                  .sessionId(UUID.randomUUID())
+                  .userId(USER_ID)
+                  .mediaFileId(newerFile.getId())
+                  .positionSeconds(900)
+                  .percentComplete(25.0)
+                  .durationSeconds(3600)
+                  .build());
+      AuditFieldSetter.setLastModifiedOn(newerProgress, Instant.parse("2026-02-01T00:00:00Z"));
 
       var context =
           dgsQueryExecutor.executeAndGetDocumentContext(
@@ -507,6 +563,8 @@ class WatchProgressFieldResolverTest {
 
       assertThat(context.<Integer>read("data.series.watchProgress.positionSeconds")).isEqualTo(900);
       assertThat(context.<Double>read("data.series.watchProgress.percentComplete")).isEqualTo(25.0);
+      assertThat(context.<Integer>read("data.series.watchProgress.durationSeconds"))
+          .isEqualTo(3600);
     }
 
     @Test

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -386,6 +386,63 @@ class WatchProgressFieldResolverTest {
     }
   }
 
+  @Nested
+  @DisplayName("Season-Series Navigation")
+  class SeasonSeriesNavigationTests {
+
+    @Test
+    @DisplayName("Should resolve series from season")
+    void shouldResolveSeriesFromSeason() {
+      var seriesId = UUID.randomUUID();
+      var series = Series.builder().title("Parent Series").build();
+      series.setId(seriesId);
+
+      var seasonId = UUID.randomUUID();
+      var season = Season.builder().title("Season 1").seasonNumber(1).series(series).build();
+      season.setId(seasonId);
+
+      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
+      when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
+
+      String seriesTitle =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              String.format("{ series(id: \"%s\") { seasons { series { title } } } }", seriesId),
+              "data.series.seasons[0].series.title");
+
+      assertThat(seriesTitle).isEqualTo("Parent Series");
+    }
+
+    @Test
+    @DisplayName("Should resolve season from episode")
+    void shouldResolveSeasonFromEpisode() {
+      var seriesId = UUID.randomUUID();
+      var series = Series.builder().title("Test Series").build();
+      series.setId(seriesId);
+
+      var seasonId = UUID.randomUUID();
+      var season = Season.builder().title("Season 1").seasonNumber(1).series(series).build();
+      season.setId(seasonId);
+
+      var episodeId = UUID.randomUUID();
+      var episode = Episode.builder().title("Pilot").episodeNumber(1).season(season).build();
+      episode.setId(episodeId);
+
+      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
+      when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
+      when(seriesService.findEpisodes(seasonId)).thenReturn(List.of(episode));
+      when(seriesService.findSeason(seasonId)).thenReturn(season);
+
+      Integer seasonNumber =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              String.format(
+                  "{ series(id: \"%s\") { seasons { episodes { season { seasonNumber } } } } }",
+                  seriesId),
+              "data.series.seasons[0].episodes[0].season.seasonNumber");
+
+      assertThat(seasonNumber).isEqualTo(1);
+    }
+  }
+
   private Movie setupMovie() {
     var movieId = UUID.randomUUID();
     var movie = Movie.builder().title("Test Movie").build();

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -131,9 +131,8 @@ class WatchProgressFieldResolverTest {
     void shouldReturnWatchProgressWhenMovieHasMediaFiles() {
       var movie = setupMovie();
       var mediaFile = buildMediaFile();
-      movie.getFiles().add(mediaFile);
-
-      when(movieService.findMediaFiles(movie.getId())).thenReturn(List.of(mediaFile));
+      mediaFile.setMediaId(movie.getId());
+      mediaFileRepository.save(mediaFile);
 
       sessionProgressRepository.save(
           SessionProgress.builder()
@@ -175,9 +174,8 @@ class WatchProgressFieldResolverTest {
     void shouldReturnNullWatchProgressWhenNoProgressExists() {
       var movie = setupMovie();
       var mediaFile = buildMediaFile();
-      movie.getFiles().add(mediaFile);
-
-      when(movieService.findMediaFiles(movie.getId())).thenReturn(List.of(mediaFile));
+      mediaFile.setMediaId(movie.getId());
+      mediaFileRepository.save(mediaFile);
 
       Object watchProgress =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -241,12 +239,12 @@ class WatchProgressFieldResolverTest {
       episode.setId(episodeId);
 
       var mediaFile = buildMediaFile();
-      episode.getFiles().add(mediaFile);
+      mediaFile.setMediaId(episodeId);
+      mediaFileRepository.save(mediaFile);
 
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
       when(seriesService.findEpisodes(seasonId)).thenReturn(List.of(episode));
-      when(seriesService.findMediaFiles(episodeId)).thenReturn(List.of(mediaFile));
 
       sessionProgressRepository.save(
           SessionProgress.builder()

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -387,6 +387,65 @@ class WatchProgressFieldResolverTest {
   }
 
   @Nested
+  @DisplayName("Series Watch Progress")
+  class SeriesWatchProgressTests {
+
+    @Test
+    @DisplayName("Should return most recent episode progress for series")
+    void shouldReturnMostRecentEpisodeProgressForSeries() {
+      var seriesId = UUID.randomUUID();
+      var series = Series.builder().title("Test Series").build();
+      series.setId(seriesId);
+
+      var episodeId = UUID.randomUUID();
+      var mediaFile = buildMediaFile();
+      mediaFile.setMediaId(episodeId);
+      mediaFileRepository.save(mediaFile);
+
+      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
+      when(seriesService.findAllEpisodeMediaFiles(seriesId)).thenReturn(List.of(mediaFile));
+
+      sessionProgressRepository.save(
+          SessionProgress.builder()
+              .sessionId(UUID.randomUUID())
+              .userId(USER_ID)
+              .mediaFileId(mediaFile.getId())
+              .positionSeconds(900)
+              .percentComplete(25.0)
+              .durationSeconds(3600)
+              .build());
+
+      var context =
+          dgsQueryExecutor.executeAndGetDocumentContext(
+              String.format(
+                  "{ series(id: \"%s\") { watchProgress { positionSeconds percentComplete durationSeconds } } }",
+                  seriesId));
+
+      assertThat(context.<Integer>read("data.series.watchProgress.positionSeconds")).isEqualTo(900);
+      assertThat(context.<Double>read("data.series.watchProgress.percentComplete")).isEqualTo(25.0);
+    }
+
+    @Test
+    @DisplayName("Should return null watch progress when series has no episode progress")
+    void shouldReturnNullWatchProgressWhenSeriesHasNoEpisodeProgress() {
+      var seriesId = UUID.randomUUID();
+      var series = Series.builder().title("Test Series").build();
+      series.setId(seriesId);
+
+      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
+      when(seriesService.findAllEpisodeMediaFiles(seriesId)).thenReturn(List.of());
+
+      Object watchProgress =
+          dgsQueryExecutor.executeAndExtractJsonPath(
+              String.format(
+                  "{ series(id: \"%s\") { watchProgress { positionSeconds } } }", seriesId),
+              "data.series.watchProgress");
+
+      assertThat(watchProgress).isNull();
+    }
+  }
+
+  @Nested
   @DisplayName("Season-Series Navigation")
   class SeasonSeriesNavigationTests {
 

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -17,6 +17,7 @@ import com.streamarr.server.fakes.FakeMediaFileRepository;
 import com.streamarr.server.fakes.FakeSeasonRepository;
 import com.streamarr.server.fakes.FakeSessionProgressRepository;
 import com.streamarr.server.fakes.FakeWatchHistoryRepository;
+import com.streamarr.server.graphql.dataloaders.AggregateWatchProgressDataLoader;
 import com.streamarr.server.graphql.dataloaders.SessionProgressDataLoader;
 import com.streamarr.server.graphql.dataloaders.WatchStatusDataLoader;
 import com.streamarr.server.services.MovieService;
@@ -42,11 +43,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     classes = {
       WatchProgressFieldResolver.class,
       SessionProgressDataLoader.class,
+      AggregateWatchProgressDataLoader.class,
       WatchStatusDataLoader.class,
       MovieResolver.class,
       SeriesResolver.class,
       SeriesFieldResolver.class,
       SeasonFieldResolver.class,
+      EpisodeFieldResolver.class,
       WatchProgressFieldResolverTest.TestConfig.class
     })
 @DisplayName("Watch Progress Field Resolver Tests")
@@ -380,17 +383,19 @@ class WatchProgressFieldResolverTest {
       var series = Series.builder().title("Test Series").build();
       series.setId(seriesId);
 
-      var seasonId = UUID.randomUUID();
       var season = Season.builder().title("Season 1").seasonNumber(1).build();
-      season.setId(seasonId);
+      season.setId(UUID.randomUUID());
+
+      var episode = Episode.builder().episodeNumber(1).season(season).build();
+      episode.setId(UUID.randomUUID());
+      episodeRepository.save(episode);
 
       var mediaFile = buildMediaFile();
-      mediaFile.setMediaId(UUID.randomUUID());
+      mediaFile.setMediaId(episode.getId());
       mediaFileRepository.save(mediaFile);
 
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
-      when(seriesService.findSeasonEpisodeMediaFiles(seasonId)).thenReturn(List.of(mediaFile));
 
       sessionProgressRepository.save(
           SessionProgress.builder()
@@ -421,13 +426,11 @@ class WatchProgressFieldResolverTest {
       var series = Series.builder().title("Test Series").build();
       series.setId(seriesId);
 
-      var seasonId = UUID.randomUUID();
       var season = Season.builder().title("Season 1").seasonNumber(1).build();
-      season.setId(seasonId);
+      season.setId(UUID.randomUUID());
 
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
-      when(seriesService.findSeasonEpisodeMediaFiles(seasonId)).thenReturn(List.of());
 
       Object watchProgress =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -469,17 +472,22 @@ class WatchProgressFieldResolverTest {
     @Test
     @DisplayName("Should return most recent episode progress for series")
     void shouldReturnMostRecentEpisodeProgressForSeries() {
-      var seriesId = UUID.randomUUID();
       var series = Series.builder().title("Test Series").build();
-      series.setId(seriesId);
+      series.setId(UUID.randomUUID());
 
-      var episodeId = UUID.randomUUID();
+      var season = Season.builder().seasonNumber(1).series(series).build();
+      season.setId(UUID.randomUUID());
+      seasonRepository.save(season);
+
+      var episode = Episode.builder().episodeNumber(1).season(season).build();
+      episode.setId(UUID.randomUUID());
+      episodeRepository.save(episode);
+
       var mediaFile = buildMediaFile();
-      mediaFile.setMediaId(episodeId);
+      mediaFile.setMediaId(episode.getId());
       mediaFileRepository.save(mediaFile);
 
-      when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
-      when(seriesService.findAllEpisodeMediaFiles(seriesId)).thenReturn(List.of(mediaFile));
+      when(seriesService.findById(series.getId())).thenReturn(Optional.of(series));
 
       sessionProgressRepository.save(
           SessionProgress.builder()
@@ -495,7 +503,7 @@ class WatchProgressFieldResolverTest {
           dgsQueryExecutor.executeAndGetDocumentContext(
               String.format(
                   "{ series(id: \"%s\") { watchProgress { positionSeconds percentComplete durationSeconds } } }",
-                  seriesId));
+                  series.getId()));
 
       assertThat(context.<Integer>read("data.series.watchProgress.positionSeconds")).isEqualTo(900);
       assertThat(context.<Double>read("data.series.watchProgress.percentComplete")).isEqualTo(25.0);
@@ -509,7 +517,6 @@ class WatchProgressFieldResolverTest {
       series.setId(seriesId);
 
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
-      when(seriesService.findAllEpisodeMediaFiles(seriesId)).thenReturn(List.of());
 
       Object watchProgress =
           dgsQueryExecutor.executeAndExtractJsonPath(
@@ -565,7 +572,6 @@ class WatchProgressFieldResolverTest {
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
       when(seriesService.findEpisodes(seasonId)).thenReturn(List.of(episode));
-      when(seriesService.findSeason(seasonId)).thenReturn(season);
 
       Integer seasonNumber =
           dgsQueryExecutor.executeAndExtractJsonPath(

--- a/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
@@ -13,6 +13,7 @@ import com.streamarr.server.domain.streaming.SessionProgress;
 import com.streamarr.server.domain.streaming.WatchHistory;
 import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.repositories.LibraryRepository;
 import com.streamarr.server.repositories.media.MovieRepository;
 import com.streamarr.server.repositories.streaming.SessionProgressRepository;
@@ -20,9 +21,11 @@ import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
 import com.streamarr.server.services.pagination.MediaFilter;
 import com.streamarr.server.services.pagination.OrderMediaBy;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.jooq.DSLContext;
 import org.jooq.SortOrder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +45,7 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
   @Autowired private SessionProgressRepository sessionProgressRepository;
   @Autowired private WatchHistoryRepository watchHistoryRepository;
   @Autowired private MovieService movieService;
+  @Autowired private DSLContext dsl;
 
   private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
@@ -170,31 +174,30 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
 
       var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
 
-      // inProgressMovie has session_progress (most recent activity),
-      // watchedMovie has no session_progress (only watch_history — not used for sort),
-      // unwatchedMovie has no activity at all (null, sorts last)
-      assertThat(page.items())
-          .extracting(item -> item.item().getTitle())
-          .startsWith("In Progress Movie");
-      assertThat(page.items())
-          .extracting(item -> item.item().getTitle())
-          .last()
-          .satisfies(title -> assertThat(title).isIn("Watched Movie", "Unwatched Movie"));
+      // inProgressMovie has session_progress (most recent activity).
+      // watchedMovie has no session_progress (only watch_history — not used for sort).
+      // unwatchedMovie has no activity at all.
+      // Both nulls sort last under nullsLast; order between them is not guaranteed.
+      var titles = page.items().stream().map(item -> item.item().getTitle()).toList();
+      assertThat(titles).hasSize(3);
+      assertThat(titles.getFirst()).isEqualTo("In Progress Movie");
+      assertThat(titles.subList(1, 3))
+          .containsExactlyInAnyOrder("Watched Movie", "Unwatched Movie");
     }
 
     @Test
     @DisplayName("Should paginate forward using cursor when sorted by LAST_WATCHED DESC")
-    void shouldPaginateForwardUsingCursorWhenSortedByLastWatchedDesc() throws InterruptedException {
+    void shouldPaginateForwardUsingCursorWhenSortedByLastWatchedDesc() {
       var paginationLibrary =
           libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
 
-      // Create three movies with distinct session_progress timestamps.
-      // Small sleeps ensure Postgres assigns strictly increasing last_modified_on values.
+      var baseline = Instant.parse("2026-01-01T00:00:00Z");
       var first = createMovieWithSessionProgress(paginationLibrary, "First");
-      Thread.sleep(5);
       var second = createMovieWithSessionProgress(paginationLibrary, "Second");
-      Thread.sleep(5);
       var third = createMovieWithSessionProgress(paginationLibrary, "Third");
+      pinSessionProgressTimestamp(first, baseline);
+      pinSessionProgressTimestamp(second, baseline.plusSeconds(1));
+      pinSessionProgressTimestamp(third, baseline.plusSeconds(2));
 
       var filter =
           MediaFilter.builder()
@@ -228,6 +231,14 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
               .map(pi -> pi.item().getId())
               .toList();
       assertThat(allIds).doesNotHaveDuplicates();
+    }
+
+    private void pinSessionProgressTimestamp(Movie movie, Instant timestamp) {
+      var mediaFileId = movie.getFiles().iterator().next().getId();
+      dsl.update(Tables.SESSION_PROGRESS)
+          .set(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON, timestamp.atOffset(ZoneOffset.UTC))
+          .where(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(mediaFileId))
+          .execute();
     }
 
     private Movie createMovieWithSessionProgress(Library lib, String title) {

--- a/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
@@ -1,5 +1,6 @@
 package com.streamarr.server.services;
 
+import static com.streamarr.server.fixtures.PaginationFixture.buildForwardContinuation;
 import static com.streamarr.server.fixtures.PaginationFixture.buildForwardOptions;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +22,7 @@ import com.streamarr.server.services.pagination.OrderMediaBy;
 import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.jooq.SortOrder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -178,6 +180,85 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
           .extracting(item -> item.item().getTitle())
           .last()
           .satisfies(title -> assertThat(title).isIn("Watched Movie", "Unwatched Movie"));
+    }
+
+    @Test
+    @DisplayName("Should paginate forward using cursor when sorted by LAST_WATCHED DESC")
+    void shouldPaginateForwardUsingCursorWhenSortedByLastWatchedDesc() throws InterruptedException {
+      var paginationLibrary =
+          libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
+
+      // Create three movies with distinct session_progress timestamps.
+      // Small sleeps ensure Postgres assigns strictly increasing last_modified_on values.
+      var first = createMovieWithSessionProgress(paginationLibrary, "First");
+      Thread.sleep(5);
+      var second = createMovieWithSessionProgress(paginationLibrary, "Second");
+      Thread.sleep(5);
+      var third = createMovieWithSessionProgress(paginationLibrary, "Third");
+
+      var filter =
+          MediaFilter.builder()
+              .libraryId(paginationLibrary.getId())
+              .sortBy(OrderMediaBy.LAST_WATCHED)
+              .sortDirection(SortOrder.DESC)
+              .build();
+
+      var page1 = movieService.getMoviesWithFilter(buildForwardOptions(1, filter));
+      assertThat(page1.items()).hasSize(1);
+      assertThat(page1.items().getFirst().item().getId()).isEqualTo(third.getId());
+      assertThat(page1.hasNextPage()).isTrue();
+
+      var page2 =
+          movieService.getMoviesWithFilter(
+              buildForwardContinuation(1, filter, page1.items().getLast()));
+      assertThat(page2.items()).hasSize(1);
+      assertThat(page2.items().getFirst().item().getId()).isEqualTo(second.getId());
+      assertThat(page2.hasNextPage()).isTrue();
+
+      var page3 =
+          movieService.getMoviesWithFilter(
+              buildForwardContinuation(1, filter, page2.items().getLast()));
+      assertThat(page3.items()).hasSize(1);
+      assertThat(page3.items().getFirst().item().getId()).isEqualTo(first.getId());
+      assertThat(page3.hasNextPage()).isFalse();
+
+      var allIds =
+          Stream.of(page1, page2, page3)
+              .flatMap(p -> p.items().stream())
+              .map(pi -> pi.item().getId())
+              .toList();
+      assertThat(allIds).doesNotHaveDuplicates();
+    }
+
+    private Movie createMovieWithSessionProgress(Library lib, String title) {
+      var file =
+          MediaFile.builder()
+              .libraryId(lib.getId())
+              .status(MediaFileStatus.MATCHED)
+              .filename(title.toLowerCase() + ".mkv")
+              .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+              .build();
+
+      var movie =
+          movieRepository.saveAndFlush(
+              Movie.builder()
+                  .title(title)
+                  .titleSort(title)
+                  .files(Set.of(file))
+                  .library(lib)
+                  .build());
+
+      sessionProgressRepository.saveAndFlush(
+          SessionProgress.builder()
+              .sessionId(UUID.randomUUID())
+              .userId(USER_ID)
+              .mediaFileId(movie.getFiles().iterator().next().getId())
+              .positionSeconds(600)
+              .percentComplete(25.0)
+              .durationSeconds(2400)
+              .build());
+
+      return movie;
     }
   }
 }

--- a/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
@@ -46,7 +46,6 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
   private Library library;
   private Movie watchedMovie;
   private Movie inProgressMovie;
-  private Movie unwatchedMovie;
 
   @BeforeAll
   void setup() {
@@ -54,7 +53,7 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
 
     watchedMovie = createMovieWithFile("Watched Movie");
     inProgressMovie = createMovieWithFile("In Progress Movie");
-    unwatchedMovie = createMovieWithFile("Unwatched Movie");
+    createMovieWithFile("Unwatched Movie");
 
     // Mark watchedMovie as WATCHED via watch_history
     watchHistoryRepository.saveAndFlush(

--- a/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
@@ -1,0 +1,153 @@
+package com.streamarr.server.services;
+
+import static com.streamarr.server.fixtures.PaginationFixture.buildForwardOptions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.MediaFileStatus;
+import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.domain.streaming.SessionProgress;
+import com.streamarr.server.domain.streaming.WatchHistory;
+import com.streamarr.server.domain.streaming.WatchStatus;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.MovieRepository;
+import com.streamarr.server.repositories.streaming.SessionProgressRepository;
+import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
+import com.streamarr.server.services.pagination.MediaFilter;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Movie Service Watch Status Filter Integration Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
+
+  @Autowired private MovieRepository movieRepository;
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private SessionProgressRepository sessionProgressRepository;
+  @Autowired private WatchHistoryRepository watchHistoryRepository;
+  @Autowired private MovieService movieService;
+
+  private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  private Library library;
+  private Movie watchedMovie;
+  private Movie inProgressMovie;
+  private Movie unwatchedMovie;
+
+  @BeforeAll
+  void setup() {
+    library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
+
+    watchedMovie = createMovieWithFile("Watched Movie");
+    inProgressMovie = createMovieWithFile("In Progress Movie");
+    unwatchedMovie = createMovieWithFile("Unwatched Movie");
+
+    // Mark watchedMovie as WATCHED via watch_history
+    watchHistoryRepository.saveAndFlush(
+        WatchHistory.builder()
+            .userId(USER_ID)
+            .collectableId(watchedMovie.getId())
+            .watchedAt(Instant.now())
+            .durationSeconds(7200)
+            .build());
+
+    // Mark inProgressMovie as IN_PROGRESS via session_progress
+    var inProgressFileId = inProgressMovie.getFiles().iterator().next().getId();
+    sessionProgressRepository.saveAndFlush(
+        SessionProgress.builder()
+            .sessionId(UUID.randomUUID())
+            .userId(USER_ID)
+            .mediaFileId(inProgressFileId)
+            .positionSeconds(1800)
+            .percentComplete(25.0)
+            .durationSeconds(7200)
+            .build());
+
+    // unwatchedMovie has no watch_history or session_progress — stays UNWATCHED
+  }
+
+  private Movie createMovieWithFile(String title) {
+    var file =
+        MediaFile.builder()
+            .libraryId(library.getId())
+            .status(MediaFileStatus.MATCHED)
+            .filename(title.toLowerCase().replace(' ', '-') + ".mkv")
+            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .build();
+
+    return movieRepository.saveAndFlush(
+        Movie.builder().title(title).titleSort(title).files(Set.of(file)).library(library).build());
+  }
+
+  @Nested
+  @DisplayName("Watch Status Filter")
+  class WatchStatusFilterTests {
+
+    @Test
+    @DisplayName("Should return only watched movies when filtering by WATCHED status")
+    void shouldReturnOnlyWatchedMoviesWhenFilteringByWatchedStatus() {
+      var filter =
+          MediaFilter.builder().libraryId(library.getId()).watchStatus(WatchStatus.WATCHED).build();
+
+      var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("Watched Movie");
+    }
+
+    @Test
+    @DisplayName("Should return only in-progress movies when filtering by IN_PROGRESS status")
+    void shouldReturnOnlyInProgressMoviesWhenFilteringByInProgressStatus() {
+      var filter =
+          MediaFilter.builder()
+              .libraryId(library.getId())
+              .watchStatus(WatchStatus.IN_PROGRESS)
+              .build();
+
+      var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("In Progress Movie");
+    }
+
+    @Test
+    @DisplayName("Should return only unwatched movies when filtering by UNWATCHED status")
+    void shouldReturnOnlyUnwatchedMoviesWhenFilteringByUnwatchedStatus() {
+      var filter =
+          MediaFilter.builder()
+              .libraryId(library.getId())
+              .watchStatus(WatchStatus.UNWATCHED)
+              .build();
+
+      var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("Unwatched Movie");
+    }
+
+    @Test
+    @DisplayName("Should return all movies when no watch status filter specified")
+    void shouldReturnAllMoviesWhenNoWatchStatusFilterSpecified() {
+      var filter = MediaFilter.builder().libraryId(library.getId()).build();
+
+      var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items()).hasSize(3);
+    }
+  }
+}

--- a/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/MovieServiceWatchStatusIT.java
@@ -17,9 +17,11 @@ import com.streamarr.server.repositories.media.MovieRepository;
 import com.streamarr.server.repositories.streaming.SessionProgressRepository;
 import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
 import com.streamarr.server.services.pagination.MediaFilter;
+import com.streamarr.server.services.pagination.OrderMediaBy;
 import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
+import org.jooq.SortOrder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -148,6 +150,35 @@ class MovieServiceWatchStatusIT extends AbstractIntegrationTest {
       var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
 
       assertThat(page.items()).hasSize(3);
+    }
+  }
+
+  @Nested
+  @DisplayName("Last Watched Sort")
+  class LastWatchedSortTests {
+
+    @Test
+    @DisplayName("Should return movies ordered by most recently watched DESC")
+    void shouldReturnMoviesOrderedByMostRecentlyWatchedDesc() {
+      var filter =
+          MediaFilter.builder()
+              .libraryId(library.getId())
+              .sortBy(OrderMediaBy.LAST_WATCHED)
+              .sortDirection(SortOrder.DESC)
+              .build();
+
+      var page = movieService.getMoviesWithFilter(buildForwardOptions(20, filter));
+
+      // inProgressMovie has session_progress (most recent activity),
+      // watchedMovie has no session_progress (only watch_history — not used for sort),
+      // unwatchedMovie has no activity at all (null, sorts last)
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .startsWith("In Progress Movie");
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .last()
+          .satisfies(title -> assertThat(title).isIn("Watched Movie", "Unwatched Movie"));
     }
   }
 }

--- a/src/test/java/com/streamarr/server/services/SeriesServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/SeriesServiceWatchStatusIT.java
@@ -54,7 +54,7 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
   void setup() {
     library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
 
-    // Watched Series: all episodes watched
+    // Watched Series: all episodes in watch_history
     var watched = createSeriesWithEpisodes("Watched Series", 2);
     for (var episodeId : watched.episodeIds()) {
       watchHistoryRepository.saveAndFlush(
@@ -66,19 +66,52 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
               .build());
     }
 
-    // In-Progress Series: one episode has session progress
-    var inProgress = createSeriesWithEpisodes("In Progress Series", 2);
+    // Watched-With-Residual-Progress Series: all episodes watched AND one has session_progress.
+    // Exercises the WATCHED rule precedence over IN_PROGRESS.
+    var watchedWithProgress = createSeriesWithEpisodes("Watched With Residual Progress", 2);
+    for (var episodeId : watchedWithProgress.episodeIds()) {
+      watchHistoryRepository.saveAndFlush(
+          WatchHistory.builder()
+              .userId(USER_ID)
+              .collectableId(episodeId)
+              .watchedAt(Instant.now())
+              .durationSeconds(3600)
+              .build());
+    }
     sessionProgressRepository.saveAndFlush(
         SessionProgress.builder()
             .sessionId(UUID.randomUUID())
             .userId(USER_ID)
-            .mediaFileId(inProgress.firstEpisodeFileId())
+            .mediaFileId(watchedWithProgress.firstEpisodeFileId())
+            .positionSeconds(60)
+            .percentComplete(2.0)
+            .durationSeconds(3600)
+            .build());
+
+    // In-Progress Series (via session_progress): one episode has progress, none in watch_history
+    var sessionInProgress = createSeriesWithEpisodes("Session In Progress Series", 2);
+    sessionProgressRepository.saveAndFlush(
+        SessionProgress.builder()
+            .sessionId(UUID.randomUUID())
+            .userId(USER_ID)
+            .mediaFileId(sessionInProgress.firstEpisodeFileId())
             .positionSeconds(900)
             .percentComplete(25.0)
             .durationSeconds(3600)
             .build());
 
-    // Unwatched Series: no watch activity
+    // Partially-Watched Series: one episode watched via watch_history, one untouched.
+    // The critical boundary: partial watch_history must NOT count as WATCHED.
+    var partiallyWatched = createSeriesWithEpisodes("Partially Watched Series", 2);
+    watchHistoryRepository.saveAndFlush(
+        WatchHistory.builder()
+            .userId(USER_ID)
+            .collectableId(partiallyWatched.episodeIds().getFirst())
+            .watchedAt(Instant.now())
+            .durationSeconds(3600)
+            .build());
+
+    // Unwatched Series: no watch activity at all
     createSeriesWithEpisodes("Unwatched Series", 2);
   }
 
@@ -128,8 +161,11 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
   class WatchStatusFilterTests {
 
     @Test
-    @DisplayName("Should return only watched series when filtering by WATCHED status")
-    void shouldReturnOnlyWatchedSeriesWhenFilteringByWatchedStatus() {
+    @DisplayName(
+        "Should return only fully-watched series and exclude partially-watched"
+            + " when filtering by WATCHED status")
+    void
+        shouldReturnOnlyFullyWatchedSeriesAndExcludePartiallyWatchedWhenFilteringByWatchedStatus() {
       var filter =
           MediaFilter.builder().libraryId(library.getId()).watchStatus(WatchStatus.WATCHED).build();
 
@@ -137,12 +173,14 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
 
       assertThat(page.items())
           .extracting(item -> item.item().getTitle())
-          .containsExactly("Watched Series");
+          .containsExactlyInAnyOrder("Watched Series", "Watched With Residual Progress");
     }
 
     @Test
-    @DisplayName("Should return only in-progress series when filtering by IN_PROGRESS status")
-    void shouldReturnOnlyInProgressSeriesWhenFilteringByInProgressStatus() {
+    @DisplayName(
+        "Should return partially-watched and session-in-progress series"
+            + " when filtering by IN_PROGRESS status")
+    void shouldReturnPartiallyWatchedAndSessionInProgressSeriesWhenFilteringByInProgressStatus() {
       var filter =
           MediaFilter.builder()
               .libraryId(library.getId())
@@ -153,12 +191,12 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
 
       assertThat(page.items())
           .extracting(item -> item.item().getTitle())
-          .containsExactly("In Progress Series");
+          .containsExactlyInAnyOrder("Session In Progress Series", "Partially Watched Series");
     }
 
     @Test
-    @DisplayName("Should return only unwatched series when filtering by UNWATCHED status")
-    void shouldReturnOnlyUnwatchedSeriesWhenFilteringByUnwatchedStatus() {
+    @DisplayName("Should return only series with no watch activity when filtering by UNWATCHED")
+    void shouldReturnOnlySeriesWithNoWatchActivityWhenFilteringByUnwatched() {
       var filter =
           MediaFilter.builder()
               .libraryId(library.getId())
@@ -170,6 +208,23 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
       assertThat(page.items())
           .extracting(item -> item.item().getTitle())
           .containsExactly("Unwatched Series");
+    }
+
+    @Test
+    @DisplayName("Should return all seeded series when no watch status filter is applied")
+    void shouldReturnAllSeededSeriesWhenNoWatchStatusFilterIsApplied() {
+      var filter = MediaFilter.builder().libraryId(library.getId()).build();
+
+      var page = seriesService.getSeriesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactlyInAnyOrder(
+              "Watched Series",
+              "Watched With Residual Progress",
+              "Session In Progress Series",
+              "Partially Watched Series",
+              "Unwatched Series");
     }
   }
 }

--- a/src/test/java/com/streamarr/server/services/SeriesServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/SeriesServiceWatchStatusIT.java
@@ -1,0 +1,175 @@
+package com.streamarr.server.services;
+
+import static com.streamarr.server.fixtures.PaginationFixture.buildForwardOptions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.MediaFileStatus;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.streaming.SessionProgress;
+import com.streamarr.server.domain.streaming.WatchHistory;
+import com.streamarr.server.domain.streaming.WatchStatus;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.EpisodeRepository;
+import com.streamarr.server.repositories.media.SeasonRepository;
+import com.streamarr.server.repositories.media.SeriesRepository;
+import com.streamarr.server.repositories.streaming.SessionProgressRepository;
+import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
+import com.streamarr.server.services.pagination.MediaFilter;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Series Service Watch Status Filter Integration Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
+
+  @Autowired private SeriesRepository seriesRepository;
+  @Autowired private SeasonRepository seasonRepository;
+  @Autowired private EpisodeRepository episodeRepository;
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private SessionProgressRepository sessionProgressRepository;
+  @Autowired private WatchHistoryRepository watchHistoryRepository;
+  @Autowired private SeriesService seriesService;
+
+  private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  private Library library;
+
+  @BeforeAll
+  void setup() {
+    library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+
+    // Watched Series: all episodes watched
+    var watched = createSeriesWithEpisodes("Watched Series", 2);
+    for (var episodeId : watched.episodeIds()) {
+      watchHistoryRepository.saveAndFlush(
+          WatchHistory.builder()
+              .userId(USER_ID)
+              .collectableId(episodeId)
+              .watchedAt(Instant.now())
+              .durationSeconds(3600)
+              .build());
+    }
+
+    // In-Progress Series: one episode has session progress
+    var inProgress = createSeriesWithEpisodes("In Progress Series", 2);
+    sessionProgressRepository.saveAndFlush(
+        SessionProgress.builder()
+            .sessionId(UUID.randomUUID())
+            .userId(USER_ID)
+            .mediaFileId(inProgress.firstEpisodeFileId())
+            .positionSeconds(900)
+            .percentComplete(25.0)
+            .durationSeconds(3600)
+            .build());
+
+    // Unwatched Series: no watch activity
+    createSeriesWithEpisodes("Unwatched Series", 2);
+  }
+
+  private record SeriesFixture(List<UUID> episodeIds, UUID firstEpisodeFileId) {}
+
+  private SeriesFixture createSeriesWithEpisodes(String title, int episodeCount) {
+    var series =
+        seriesRepository.saveAndFlush(
+            Series.builder().title(title).titleSort(title).library(library).build());
+
+    var season =
+        seasonRepository.saveAndFlush(
+            Season.builder().seasonNumber(1).series(series).library(library).build());
+
+    var episodeIds = new java.util.ArrayList<UUID>();
+    UUID firstFileId = null;
+
+    for (int i = 1; i <= episodeCount; i++) {
+      var file =
+          MediaFile.builder()
+              .libraryId(library.getId())
+              .status(MediaFileStatus.MATCHED)
+              .filename(title.toLowerCase().replace(' ', '-') + "-s01e0" + i + ".mkv")
+              .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+              .build();
+
+      var episode =
+          episodeRepository.saveAndFlush(
+              Episode.builder()
+                  .episodeNumber(i)
+                  .season(season)
+                  .library(library)
+                  .files(Set.of(file))
+                  .build());
+
+      episodeIds.add(episode.getId());
+      if (firstFileId == null) {
+        firstFileId = episode.getFiles().iterator().next().getId();
+      }
+    }
+
+    return new SeriesFixture(episodeIds, firstFileId);
+  }
+
+  @Nested
+  @DisplayName("Watch Status Filter")
+  class WatchStatusFilterTests {
+
+    @Test
+    @DisplayName("Should return only watched series when filtering by WATCHED status")
+    void shouldReturnOnlyWatchedSeriesWhenFilteringByWatchedStatus() {
+      var filter =
+          MediaFilter.builder().libraryId(library.getId()).watchStatus(WatchStatus.WATCHED).build();
+
+      var page = seriesService.getSeriesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("Watched Series");
+    }
+
+    @Test
+    @DisplayName("Should return only in-progress series when filtering by IN_PROGRESS status")
+    void shouldReturnOnlyInProgressSeriesWhenFilteringByInProgressStatus() {
+      var filter =
+          MediaFilter.builder()
+              .libraryId(library.getId())
+              .watchStatus(WatchStatus.IN_PROGRESS)
+              .build();
+
+      var page = seriesService.getSeriesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("In Progress Series");
+    }
+
+    @Test
+    @DisplayName("Should return only unwatched series when filtering by UNWATCHED status")
+    void shouldReturnOnlyUnwatchedSeriesWhenFilteringByUnwatchedStatus() {
+      var filter =
+          MediaFilter.builder()
+              .libraryId(library.getId())
+              .watchStatus(WatchStatus.UNWATCHED)
+              .build();
+
+      var page = seriesService.getSeriesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("Unwatched Series");
+    }
+  }
+}

--- a/src/test/java/com/streamarr/server/services/SeriesServiceWatchStatusIT.java
+++ b/src/test/java/com/streamarr/server/services/SeriesServiceWatchStatusIT.java
@@ -1,5 +1,6 @@
 package com.streamarr.server.services;
 
+import static com.streamarr.server.fixtures.PaginationFixture.buildForwardContinuation;
 import static com.streamarr.server.fixtures.PaginationFixture.buildForwardOptions;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +15,7 @@ import com.streamarr.server.domain.streaming.SessionProgress;
 import com.streamarr.server.domain.streaming.WatchHistory;
 import com.streamarr.server.domain.streaming.WatchStatus;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.repositories.LibraryRepository;
 import com.streamarr.server.repositories.media.EpisodeRepository;
 import com.streamarr.server.repositories.media.SeasonRepository;
@@ -21,10 +23,15 @@ import com.streamarr.server.repositories.media.SeriesRepository;
 import com.streamarr.server.repositories.streaming.SessionProgressRepository;
 import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
 import com.streamarr.server.services.pagination.MediaFilter;
+import com.streamarr.server.services.pagination.OrderMediaBy;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Stream;
+import org.jooq.DSLContext;
+import org.jooq.SortOrder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,6 +52,7 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
   @Autowired private SessionProgressRepository sessionProgressRepository;
   @Autowired private WatchHistoryRepository watchHistoryRepository;
   @Autowired private SeriesService seriesService;
+  @Autowired private DSLContext dsl;
 
   private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
@@ -115,45 +123,12 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
     createSeriesWithEpisodes("Unwatched Series", 2);
   }
 
-  private record SeriesFixture(List<UUID> episodeIds, UUID firstEpisodeFileId) {}
+  private record SeriesFixture(UUID seriesId, List<UUID> episodeIds, UUID firstEpisodeFileId) {}
+
+  private record SeriesProgressFixture(UUID seriesId, UUID mediaFileId) {}
 
   private SeriesFixture createSeriesWithEpisodes(String title, int episodeCount) {
-    var series =
-        seriesRepository.saveAndFlush(
-            Series.builder().title(title).titleSort(title).library(library).build());
-
-    var season =
-        seasonRepository.saveAndFlush(
-            Season.builder().seasonNumber(1).series(series).library(library).build());
-
-    var episodeIds = new java.util.ArrayList<UUID>();
-    UUID firstFileId = null;
-
-    for (int i = 1; i <= episodeCount; i++) {
-      var file =
-          MediaFile.builder()
-              .libraryId(library.getId())
-              .status(MediaFileStatus.MATCHED)
-              .filename(title.toLowerCase().replace(' ', '-') + "-s01e0" + i + ".mkv")
-              .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
-              .build();
-
-      var episode =
-          episodeRepository.saveAndFlush(
-              Episode.builder()
-                  .episodeNumber(i)
-                  .season(season)
-                  .library(library)
-                  .files(Set.of(file))
-                  .build());
-
-      episodeIds.add(episode.getId());
-      if (firstFileId == null) {
-        firstFileId = episode.getFiles().iterator().next().getId();
-      }
-    }
-
-    return new SeriesFixture(episodeIds, firstFileId);
+    return createSeriesWithEpisodes(library, title, episodeCount);
   }
 
   @Nested
@@ -232,5 +207,149 @@ class SeriesServiceWatchStatusIT extends AbstractIntegrationTest {
               "Partially Watched Series",
               "Unwatched Series");
     }
+  }
+
+  @Nested
+  @DisplayName("Last Watched Sort")
+  class LastWatchedSortTests {
+
+    @Test
+    @DisplayName("Should return series ordered by most recently watched DESC")
+    void shouldReturnSeriesOrderedByMostRecentlyWatchedDesc() {
+      var sortLibrary =
+          libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+
+      var baseline = Instant.parse("2026-01-01T00:00:00Z");
+      var older = createSeriesWithSessionProgress(sortLibrary, "Older Series");
+      var newer = createSeriesWithSessionProgress(sortLibrary, "Newer Series");
+      createSeriesWithEpisodes(sortLibrary, "No Progress Series", 1);
+      pinSessionProgressTimestamp(older.mediaFileId(), baseline);
+      pinSessionProgressTimestamp(newer.mediaFileId(), baseline.plusSeconds(1));
+
+      var filter =
+          MediaFilter.builder()
+              .libraryId(sortLibrary.getId())
+              .userId(USER_ID)
+              .sortBy(OrderMediaBy.LAST_WATCHED)
+              .sortDirection(SortOrder.DESC)
+              .build();
+
+      var page = seriesService.getSeriesWithFilter(buildForwardOptions(20, filter));
+
+      assertThat(page.items())
+          .extracting(item -> item.item().getTitle())
+          .containsExactly("Newer Series", "Older Series", "No Progress Series");
+    }
+
+    @Test
+    @DisplayName("Should paginate forward using cursor when sorted by LAST_WATCHED DESC")
+    void shouldPaginateForwardUsingCursorWhenSortedByLastWatchedDesc() {
+      var paginationLibrary =
+          libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+
+      var baseline = Instant.parse("2026-01-01T00:00:00Z");
+      var first = createSeriesWithSessionProgress(paginationLibrary, "First");
+      var second = createSeriesWithSessionProgress(paginationLibrary, "Second");
+      var third = createSeriesWithSessionProgress(paginationLibrary, "Third");
+      pinSessionProgressTimestamp(first.mediaFileId(), baseline);
+      pinSessionProgressTimestamp(second.mediaFileId(), baseline.plusSeconds(1));
+      pinSessionProgressTimestamp(third.mediaFileId(), baseline.plusSeconds(2));
+
+      var filter =
+          MediaFilter.builder()
+              .libraryId(paginationLibrary.getId())
+              .userId(USER_ID)
+              .sortBy(OrderMediaBy.LAST_WATCHED)
+              .sortDirection(SortOrder.DESC)
+              .build();
+
+      var page1 = seriesService.getSeriesWithFilter(buildForwardOptions(1, filter));
+      assertThat(page1.items()).hasSize(1);
+      assertThat(page1.items().getFirst().item().getId()).isEqualTo(third.seriesId());
+      assertThat(page1.hasNextPage()).isTrue();
+
+      var page2 =
+          seriesService.getSeriesWithFilter(
+              buildForwardContinuation(1, filter, page1.items().getLast()));
+      assertThat(page2.items()).hasSize(1);
+      assertThat(page2.items().getFirst().item().getId()).isEqualTo(second.seriesId());
+      assertThat(page2.hasNextPage()).isTrue();
+
+      var page3 =
+          seriesService.getSeriesWithFilter(
+              buildForwardContinuation(1, filter, page2.items().getLast()));
+      assertThat(page3.items()).hasSize(1);
+      assertThat(page3.items().getFirst().item().getId()).isEqualTo(first.seriesId());
+      assertThat(page3.hasNextPage()).isFalse();
+
+      var allIds =
+          Stream.of(page1, page2, page3)
+              .flatMap(p -> p.items().stream())
+              .map(pi -> pi.item().getId())
+              .toList();
+      assertThat(allIds).doesNotHaveDuplicates();
+    }
+
+    private void pinSessionProgressTimestamp(UUID mediaFileId, Instant timestamp) {
+      dsl.update(Tables.SESSION_PROGRESS)
+          .set(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON, timestamp.atOffset(ZoneOffset.UTC))
+          .where(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(mediaFileId))
+          .execute();
+    }
+
+    private SeriesProgressFixture createSeriesWithSessionProgress(Library lib, String title) {
+      var fixture = createSeriesWithEpisodes(lib, title, 1);
+
+      sessionProgressRepository.saveAndFlush(
+          SessionProgress.builder()
+              .sessionId(UUID.randomUUID())
+              .userId(USER_ID)
+              .mediaFileId(fixture.firstEpisodeFileId())
+              .positionSeconds(600)
+              .percentComplete(25.0)
+              .durationSeconds(2400)
+              .build());
+
+      return new SeriesProgressFixture(fixture.seriesId(), fixture.firstEpisodeFileId());
+    }
+  }
+
+  private SeriesFixture createSeriesWithEpisodes(Library lib, String title, int episodeCount) {
+    var series =
+        seriesRepository.saveAndFlush(
+            Series.builder().title(title).titleSort(title).library(lib).build());
+
+    var season =
+        seasonRepository.saveAndFlush(
+            Season.builder().seasonNumber(1).series(series).library(lib).build());
+
+    var episodeIds = new java.util.ArrayList<UUID>();
+    UUID firstFileId = null;
+
+    for (int i = 1; i <= episodeCount; i++) {
+      var file =
+          MediaFile.builder()
+              .libraryId(lib.getId())
+              .status(MediaFileStatus.MATCHED)
+              .filename(title.toLowerCase().replace(' ', '-') + "-s01e0" + i + ".mkv")
+              .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+              .build();
+
+      var episode =
+          episodeRepository.saveAndFlush(
+              Episode.builder()
+                  .episodeNumber(i)
+                  .season(season)
+                  .library(lib)
+                  .files(Set.of(file))
+                  .build());
+
+      episodeIds.add(episode.getId());
+      if (firstFileId == null) {
+        firstFileId = episode.getFiles().iterator().next().getId();
+      }
+    }
+
+    return new SeriesFixture(series.getId(), episodeIds, firstFileId);
   }
 }

--- a/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
@@ -190,6 +190,7 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
                   })
               .toList();
 
+      assertThat(titles).isNotEmpty();
       assertThat(titles).doesNotContain("Watched Movie");
     }
 
@@ -208,6 +209,7 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
                   })
               .toList();
 
+      assertThat(titles).isNotEmpty();
       assertThat(titles).doesNotContain("Unwatched Movie");
     }
 

--- a/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
@@ -1,0 +1,242 @@
+package com.streamarr.server.services.watchprogress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.MediaFileStatus;
+import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.streaming.SessionProgress;
+import com.streamarr.server.domain.streaming.WatchHistory;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.EpisodeRepository;
+import com.streamarr.server.repositories.media.MovieRepository;
+import com.streamarr.server.repositories.media.SeasonRepository;
+import com.streamarr.server.repositories.media.SeriesRepository;
+import com.streamarr.server.repositories.streaming.SessionProgressRepository;
+import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Continue Watching Service Integration Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ContinueWatchingServiceIT extends AbstractIntegrationTest {
+
+  @Autowired private ContinueWatchingService continueWatchingService;
+  @Autowired private MovieRepository movieRepository;
+  @Autowired private SeriesRepository seriesRepository;
+  @Autowired private SeasonRepository seasonRepository;
+  @Autowired private EpisodeRepository episodeRepository;
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private SessionProgressRepository sessionProgressRepository;
+  @Autowired private WatchHistoryRepository watchHistoryRepository;
+
+  private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  private Library movieLibrary;
+  private Library seriesLibrary;
+  private Movie inProgressMovie;
+  private Episode inProgressEpisode;
+
+  @BeforeAll
+  void setup() {
+    movieLibrary = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
+    seriesLibrary = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+
+    // In-progress movie: has session progress
+    inProgressMovie = createMovieWithProgress("In Progress Movie", 1800, 25.0, 7200);
+
+    // Watched movie: has watch_history (should be excluded)
+    var watchedMovie = createMovieWithFile("Watched Movie");
+    watchHistoryRepository.saveAndFlush(
+        WatchHistory.builder()
+            .userId(USER_ID)
+            .collectableId(watchedMovie.getId())
+            .watchedAt(Instant.now())
+            .durationSeconds(7200)
+            .build());
+
+    // Unwatched movie: no activity (should be excluded)
+    createMovieWithFile("Unwatched Movie");
+
+    // In-progress episode: has session progress
+    inProgressEpisode = createEpisodeWithProgress("In Progress Episode", 900, 15.0, 3600);
+  }
+
+  private Movie createMovieWithFile(String title) {
+    var file =
+        MediaFile.builder()
+            .libraryId(movieLibrary.getId())
+            .status(MediaFileStatus.MATCHED)
+            .filename(title.toLowerCase().replace(' ', '-') + ".mkv")
+            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .build();
+
+    return movieRepository.saveAndFlush(
+        Movie.builder()
+            .title(title)
+            .titleSort(title)
+            .files(Set.of(file))
+            .library(movieLibrary)
+            .build());
+  }
+
+  private Movie createMovieWithProgress(
+      String title, int positionSeconds, double percentComplete, int durationSeconds) {
+    var movie = createMovieWithFile(title);
+    var fileId = movie.getFiles().iterator().next().getId();
+
+    sessionProgressRepository.saveAndFlush(
+        SessionProgress.builder()
+            .sessionId(UUID.randomUUID())
+            .userId(USER_ID)
+            .mediaFileId(fileId)
+            .positionSeconds(positionSeconds)
+            .percentComplete(percentComplete)
+            .durationSeconds(durationSeconds)
+            .build());
+
+    return movie;
+  }
+
+  private Episode createEpisodeWithProgress(
+      String title, int positionSeconds, double percentComplete, int durationSeconds) {
+    var series =
+        seriesRepository.saveAndFlush(
+            Series.builder()
+                .title("Test Series")
+                .titleSort("Test Series")
+                .library(seriesLibrary)
+                .build());
+
+    var season =
+        seasonRepository.saveAndFlush(
+            Season.builder().seasonNumber(1).series(series).library(seriesLibrary).build());
+
+    var file =
+        MediaFile.builder()
+            .libraryId(seriesLibrary.getId())
+            .status(MediaFileStatus.MATCHED)
+            .filename(title.toLowerCase().replace(' ', '-') + ".mkv")
+            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .build();
+
+    var episode =
+        episodeRepository.saveAndFlush(
+            Episode.builder()
+                .episodeNumber(1)
+                .title(title)
+                .season(season)
+                .library(seriesLibrary)
+                .files(Set.of(file))
+                .build());
+
+    var fileId = episode.getFiles().iterator().next().getId();
+
+    sessionProgressRepository.saveAndFlush(
+        SessionProgress.builder()
+            .sessionId(UUID.randomUUID())
+            .userId(USER_ID)
+            .mediaFileId(fileId)
+            .positionSeconds(positionSeconds)
+            .percentComplete(percentComplete)
+            .durationSeconds(durationSeconds)
+            .build());
+
+    return episode;
+  }
+
+  @Nested
+  @DisplayName("getContinueWatching")
+  class GetContinueWatchingTests {
+
+    @Test
+    @DisplayName("Should return in-progress movies and episodes")
+    void shouldReturnInProgressMoviesAndEpisodes() {
+      var results = continueWatchingService.getContinueWatching(20);
+
+      assertThat(results).hasSizeGreaterThanOrEqualTo(2);
+
+      var ids = results.stream().map(item -> item.getId()).toList();
+      assertThat(ids).contains(inProgressMovie.getId(), inProgressEpisode.getId());
+    }
+
+    @Test
+    @DisplayName("Should exclude watched items from results")
+    void shouldExcludeWatchedItemsFromResults() {
+      var results = continueWatchingService.getContinueWatching(20);
+
+      var titles =
+          results.stream()
+              .map(
+                  item -> {
+                    if (item instanceof Movie m) return m.getTitle();
+                    if (item instanceof Episode e) return e.getTitle();
+                    return null;
+                  })
+              .toList();
+
+      assertThat(titles).doesNotContain("Watched Movie");
+    }
+
+    @Test
+    @DisplayName("Should exclude unwatched items with no progress")
+    void shouldExcludeUnwatchedItemsWithNoProgress() {
+      var results = continueWatchingService.getContinueWatching(20);
+
+      var titles =
+          results.stream()
+              .map(
+                  item -> {
+                    if (item instanceof Movie m) return m.getTitle();
+                    if (item instanceof Episode e) return e.getTitle();
+                    return null;
+                  })
+              .toList();
+
+      assertThat(titles).doesNotContain("Unwatched Movie");
+    }
+
+    @Test
+    @DisplayName("Should return empty list when no in-progress items exist")
+    void shouldReturnEmptyListWhenNoInProgressItemsExist() {
+      // Use limit 0 to simulate no results
+      var results = continueWatchingService.getContinueWatching(0);
+
+      assertThat(results).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Should respect limit parameter")
+    void shouldRespectLimitParameter() {
+      var results = continueWatchingService.getContinueWatching(1);
+
+      assertThat(results).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Should order by most recent activity descending")
+    void shouldOrderByMostRecentActivityDescending() {
+      var results = continueWatchingService.getContinueWatching(20);
+
+      // The most recently created session progress should come first
+      // inProgressEpisode was created after inProgressMovie in setup
+      assertThat(results).hasSizeGreaterThanOrEqualTo(2);
+      assertThat(results.getFirst().getId()).isEqualTo(inProgressEpisode.getId());
+    }
+  }
+}

--- a/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
@@ -214,9 +214,8 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should return empty list when no in-progress items exist")
-    void shouldReturnEmptyListWhenNoInProgressItemsExist() {
-      // Use limit 0 to simulate no results
+    @DisplayName("Should return empty list when limit is zero")
+    void shouldReturnEmptyListWhenLimitIsZero() {
       var results = continueWatchingService.getContinueWatching(0);
 
       assertThat(results).isEmpty();

--- a/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
@@ -3,6 +3,7 @@ package com.streamarr.server.services.watchprogress;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.BaseCollectable;
 import com.streamarr.server.domain.Library;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
@@ -13,6 +14,7 @@ import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.domain.streaming.SessionProgress;
 import com.streamarr.server.domain.streaming.WatchHistory;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.jooq.generated.Tables;
 import com.streamarr.server.repositories.LibraryRepository;
 import com.streamarr.server.repositories.media.EpisodeRepository;
 import com.streamarr.server.repositories.media.MovieRepository;
@@ -21,8 +23,10 @@ import com.streamarr.server.repositories.media.SeriesRepository;
 import com.streamarr.server.repositories.streaming.SessionProgressRepository;
 import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Set;
 import java.util.UUID;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -44,24 +48,40 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
   @Autowired private LibraryRepository libraryRepository;
   @Autowired private SessionProgressRepository sessionProgressRepository;
   @Autowired private WatchHistoryRepository watchHistoryRepository;
+  @Autowired private DSLContext dsl;
 
   private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final Instant MOVIE_ACTIVITY_AT = Instant.parse("2026-01-01T00:00:00Z");
+  private static final Instant EPISODE_ACTIVITY_AT = Instant.parse("2026-02-01T00:00:00Z");
 
   private Library movieLibrary;
   private Library seriesLibrary;
   private Movie inProgressMovie;
+  private UUID inProgressMovieFileId;
+  private Movie watchedMovie;
+  private Movie unwatchedMovie;
   private Episode inProgressEpisode;
+  private UUID inProgressEpisodeFileId;
 
   @BeforeAll
   void setup() {
+    // TODO(#163): replace this pre-delete with a per-class user ID once auth lands.
+    dsl.deleteFrom(Tables.SESSION_PROGRESS)
+        .where(Tables.SESSION_PROGRESS.USER_ID.eq(USER_ID))
+        .execute();
+    dsl.deleteFrom(Tables.WATCH_HISTORY)
+        .where(Tables.WATCH_HISTORY.USER_ID.eq(USER_ID))
+        .execute();
+
     movieLibrary = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
     seriesLibrary = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
 
     // In-progress movie: has session progress
     inProgressMovie = createMovieWithProgress("In Progress Movie", 1800, 25.0, 7200);
+    inProgressMovieFileId = inProgressMovie.getFiles().iterator().next().getId();
 
     // Watched movie: has watch_history (should be excluded)
-    var watchedMovie = createMovieWithFile("Watched Movie");
+    watchedMovie = createMovieWithFile("Watched Movie");
     watchHistoryRepository.saveAndFlush(
         WatchHistory.builder()
             .userId(USER_ID)
@@ -71,10 +91,22 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
             .build());
 
     // Unwatched movie: no activity (should be excluded)
-    createMovieWithFile("Unwatched Movie");
+    unwatchedMovie = createMovieWithFile("Unwatched Movie");
 
     // In-progress episode: has session progress
     inProgressEpisode = createEpisodeWithProgress("In Progress Episode", 900, 15.0, 3600);
+    inProgressEpisodeFileId = inProgressEpisode.getFiles().iterator().next().getId();
+
+    // Pin LAST_MODIFIED_ON explicitly so ordering is deterministic regardless of clock resolution.
+    pinSessionProgressTimestamp(inProgressMovieFileId, MOVIE_ACTIVITY_AT);
+    pinSessionProgressTimestamp(inProgressEpisodeFileId, EPISODE_ACTIVITY_AT);
+  }
+
+  private void pinSessionProgressTimestamp(UUID mediaFileId, Instant timestamp) {
+    dsl.update(Tables.SESSION_PROGRESS)
+        .set(Tables.SESSION_PROGRESS.LAST_MODIFIED_ON, timestamp.atOffset(ZoneOffset.UTC))
+        .where(Tables.SESSION_PROGRESS.MEDIA_FILE_ID.eq(mediaFileId))
+        .execute();
   }
 
   private Movie createMovieWithFile(String title) {
@@ -165,79 +197,60 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
   class GetContinueWatchingTests {
 
     @Test
-    @DisplayName("Should return in-progress movies and episodes")
-    void shouldReturnInProgressMoviesAndEpisodes() {
+    @DisplayName("Should return exactly the in-progress movie and episode when querying")
+    void shouldReturnExactlyTheInProgressMovieAndEpisodeWhenQuerying() {
       var results = continueWatchingService.getContinueWatching(20);
 
-      assertThat(results).hasSizeGreaterThanOrEqualTo(2);
-
-      var ids = results.stream().map(item -> item.getId()).toList();
-      assertThat(ids).contains(inProgressMovie.getId(), inProgressEpisode.getId());
+      assertThat(results)
+          .extracting(BaseCollectable::getId)
+          .containsExactlyInAnyOrder(inProgressMovie.getId(), inProgressEpisode.getId());
     }
 
     @Test
-    @DisplayName("Should exclude watched items from results")
-    void shouldExcludeWatchedItemsFromResults() {
+    @DisplayName("Should not include the watched movie when querying")
+    void shouldNotIncludeTheWatchedMovieWhenQuerying() {
       var results = continueWatchingService.getContinueWatching(20);
 
-      var titles =
-          results.stream()
-              .map(
-                  item -> {
-                    if (item instanceof Movie m) return m.getTitle();
-                    if (item instanceof Episode e) return e.getTitle();
-                    return null;
-                  })
-              .toList();
-
-      assertThat(titles).isNotEmpty();
-      assertThat(titles).doesNotContain("Watched Movie");
+      assertThat(results).extracting(BaseCollectable::getId).doesNotContain(watchedMovie.getId());
     }
 
     @Test
-    @DisplayName("Should exclude unwatched items with no progress")
-    void shouldExcludeUnwatchedItemsWithNoProgress() {
+    @DisplayName("Should not include the unwatched movie with no session progress when querying")
+    void shouldNotIncludeTheUnwatchedMovieWithNoSessionProgressWhenQuerying() {
       var results = continueWatchingService.getContinueWatching(20);
 
-      var titles =
-          results.stream()
-              .map(
-                  item -> {
-                    if (item instanceof Movie m) return m.getTitle();
-                    if (item instanceof Episode e) return e.getTitle();
-                    return null;
-                  })
-              .toList();
-
-      assertThat(titles).isNotEmpty();
-      assertThat(titles).doesNotContain("Unwatched Movie");
+      assertThat(results).extracting(BaseCollectable::getId).doesNotContain(unwatchedMovie.getId());
     }
 
     @Test
-    @DisplayName("Should return empty list when limit is zero")
-    void shouldReturnEmptyListWhenLimitIsZero() {
+    @DisplayName("Should return empty list when called with limit zero")
+    void shouldReturnEmptyListWhenCalledWithLimitZero() {
       var results = continueWatchingService.getContinueWatching(0);
 
       assertThat(results).isEmpty();
     }
 
     @Test
-    @DisplayName("Should respect limit parameter")
-    void shouldRespectLimitParameter() {
+    @DisplayName("Should return only the most recent item when called with limit one")
+    void shouldReturnOnlyTheMostRecentItemWhenCalledWithLimitOne() {
       var results = continueWatchingService.getContinueWatching(1);
 
-      assertThat(results).hasSize(1);
+      assertThat(results)
+          .extracting(BaseCollectable::getId)
+          .containsExactly(inProgressEpisode.getId());
     }
 
     @Test
-    @DisplayName("Should order by most recent activity descending")
-    void shouldOrderByMostRecentActivityDescending() {
+    @DisplayName(
+        "Should order items by session progress last modified descending when querying"
+            + " with pinned timestamps")
+    void shouldOrderItemsBySessionProgressLastModifiedDescendingWhenQueryingWithPinnedTimestamps() {
       var results = continueWatchingService.getContinueWatching(20);
 
-      // The most recently created session progress should come first
-      // inProgressEpisode was created after inProgressMovie in setup
-      assertThat(results).hasSizeGreaterThanOrEqualTo(2);
-      assertThat(results.getFirst().getId()).isEqualTo(inProgressEpisode.getId());
+      // EPISODE_ACTIVITY_AT (Feb) > MOVIE_ACTIVITY_AT (Jan) — episode must come first.
+      assertThat(results)
+          .extracting(BaseCollectable::getId)
+          .containsExactly(inProgressEpisode.getId(), inProgressMovie.getId());
     }
   }
 }

--- a/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
@@ -65,7 +65,7 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
 
   @BeforeAll
   void setup() {
-    // Clean existing placeholder-user records before seeding per-class fixtures.
+    // TODO(#163): replace this cleanup with per-class user IDs once auth lands.
     dsl.deleteFrom(Tables.SESSION_PROGRESS)
         .where(Tables.SESSION_PROGRESS.USER_ID.eq(USER_ID))
         .execute();

--- a/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/ContinueWatchingServiceIT.java
@@ -65,7 +65,7 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
 
   @BeforeAll
   void setup() {
-    // TODO(#163): replace this pre-delete with a per-class user ID once auth lands.
+    // Clean existing placeholder-user records before seeding per-class fixtures.
     dsl.deleteFrom(Tables.SESSION_PROGRESS)
         .where(Tables.SESSION_PROGRESS.USER_ID.eq(USER_ID))
         .execute();
@@ -209,7 +209,10 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
     void shouldNotIncludeTheWatchedMovieWhenQuerying() {
       var results = continueWatchingService.getContinueWatching(USER_ID, 20);
 
-      assertThat(results).extracting(BaseCollectable::getId).doesNotContain(watchedMovie.getId());
+      assertThat(results)
+          .isNotEmpty()
+          .extracting(BaseCollectable::getId)
+          .doesNotContain(watchedMovie.getId());
     }
 
     @Test
@@ -217,7 +220,10 @@ class ContinueWatchingServiceIT extends AbstractIntegrationTest {
     void shouldNotIncludeTheUnwatchedMovieWithNoSessionProgressWhenQuerying() {
       var results = continueWatchingService.getContinueWatching(USER_ID, 20);
 
-      assertThat(results).extracting(BaseCollectable::getId).doesNotContain(unwatchedMovie.getId());
+      assertThat(results)
+          .isNotEmpty()
+          .extracting(BaseCollectable::getId)
+          .doesNotContain(unwatchedMovie.getId());
     }
 
     @Test


### PR DESCRIPTION
Adds user-scoped watch status filtering for library media, including last-watched sorting.

Also keeps watch-progress loaders and continue-watching tied to the current user, and validates continueWatching pagination.