### PR TITLE
Carry userId in dataloader keys

### DIFF
--- a/src/main/java/com/streamarr/server/graphql/dataloaders/SessionProgressDataLoader.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/SessionProgressDataLoader.java
@@ -2,12 +2,11 @@ package com.streamarr.server.graphql.dataloaders;
 
 import com.netflix.graphql.dgs.DgsDataLoader;
 import com.streamarr.server.domain.streaming.SessionProgress;
-import com.streamarr.server.graphql.CurrentUser;
 import com.streamarr.server.graphql.dto.WatchProgressDto;
 import com.streamarr.server.services.watchprogress.WatchStatusService;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
@@ -16,19 +15,36 @@ import org.dataloader.MappedBatchLoader;
 
 @DgsDataLoader(name = "watchProgress")
 @RequiredArgsConstructor
-public class SessionProgressDataLoader implements MappedBatchLoader<UUID, WatchProgressDto> {
+public class SessionProgressDataLoader
+    implements MappedBatchLoader<SessionProgressLoaderKey, WatchProgressDto> {
 
   private final WatchStatusService watchStatusService;
 
   @Override
-  public CompletionStage<Map<UUID, WatchProgressDto>> load(Set<UUID> mediaFileIds) {
+  public CompletionStage<Map<SessionProgressLoaderKey, WatchProgressDto>> load(
+      Set<SessionProgressLoaderKey> keys) {
     return CompletableFuture.supplyAsync(
-        () ->
-            watchStatusService
-                .getProgressForMediaFiles(CurrentUser.id(), mediaFileIds)
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> toDto(e.getValue()))));
+        () -> {
+          var result = new HashMap<SessionProgressLoaderKey, WatchProgressDto>();
+          var keysByUser =
+              keys.stream().collect(Collectors.groupingBy(SessionProgressLoaderKey::userId));
+
+          for (var entry : keysByUser.entrySet()) {
+            var mediaFileIds =
+                entry.getValue().stream().map(SessionProgressLoaderKey::mediaFileId).toList();
+            var progressMap =
+                watchStatusService.getProgressForMediaFiles(entry.getKey(), mediaFileIds);
+
+            for (var key : entry.getValue()) {
+              var progress = progressMap.get(key.mediaFileId());
+              if (progress != null) {
+                result.put(key, toDto(progress));
+              }
+            }
+          }
+
+          return result;
+        });
   }
 
   private static WatchProgressDto toDto(SessionProgress wp) {

--- a/src/main/java/com/streamarr/server/graphql/dataloaders/SessionProgressLoaderKey.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/SessionProgressLoaderKey.java
@@ -1,0 +1,5 @@
+package com.streamarr.server.graphql.dataloaders;
+
+import java.util.UUID;
+
+public record SessionProgressLoaderKey(UUID userId, UUID mediaFileId) {}

--- a/src/main/java/com/streamarr/server/graphql/dataloaders/WatchStatusDataLoader.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/WatchStatusDataLoader.java
@@ -3,7 +3,6 @@ package com.streamarr.server.graphql.dataloaders;
 import com.netflix.graphql.dgs.DgsDataLoader;
 import com.streamarr.server.domain.streaming.CollectableScope;
 import com.streamarr.server.domain.streaming.WatchStatus;
-import com.streamarr.server.graphql.CurrentUser;
 import com.streamarr.server.services.watchprogress.WatchStatusService;
 import java.util.HashMap;
 import java.util.List;
@@ -27,15 +26,14 @@ public class WatchStatusDataLoader implements MappedBatchLoader<WatchStatusLoade
       Set<WatchStatusLoaderKey> keys) {
     return CompletableFuture.supplyAsync(
         () -> {
-          var userId = CurrentUser.id();
-
           var result = new HashMap<WatchStatusLoaderKey, WatchStatus>();
-          var keysByScope =
-              keys.stream().collect(Collectors.groupingBy(WatchStatusLoaderKey::scope));
+          var keysByBatch =
+              keys.stream()
+                  .collect(Collectors.groupingBy(key -> new Batch(key.userId(), key.scope())));
 
-          for (var entry : keysByScope.entrySet()) {
+          for (var entry : keysByBatch.entrySet()) {
             var entityIds = entry.getValue().stream().map(WatchStatusLoaderKey::entityId).toList();
-            var statusMap = loadByScope(userId, entry.getKey(), entityIds);
+            var statusMap = loadByScope(entry.getKey().userId(), entry.getKey().scope(), entityIds);
 
             for (var key : entry.getValue()) {
               result.put(key, statusMap.getOrDefault(key.entityId(), WatchStatus.UNWATCHED));
@@ -45,6 +43,8 @@ public class WatchStatusDataLoader implements MappedBatchLoader<WatchStatusLoade
           return result;
         });
   }
+
+  private record Batch(UUID userId, CollectableScope scope) {}
 
   private Map<UUID, WatchStatus> loadByScope(
       UUID userId, CollectableScope scope, List<UUID> entityIds) {

--- a/src/main/java/com/streamarr/server/graphql/dataloaders/WatchStatusLoaderKey.java
+++ b/src/main/java/com/streamarr/server/graphql/dataloaders/WatchStatusLoaderKey.java
@@ -3,4 +3,4 @@ package com.streamarr.server.graphql.dataloaders;
 import com.streamarr.server.domain.streaming.CollectableScope;
 import java.util.UUID;
 
-public record WatchStatusLoaderKey(UUID entityId, CollectableScope scope) {}
+public record WatchStatusLoaderKey(UUID userId, UUID entityId, CollectableScope scope) {}

--- a/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolver.java
@@ -9,6 +9,8 @@ import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.domain.streaming.CollectableScope;
 import com.streamarr.server.domain.streaming.WatchStatus;
+import com.streamarr.server.graphql.CurrentUser;
+import com.streamarr.server.graphql.dataloaders.SessionProgressLoaderKey;
 import com.streamarr.server.graphql.dataloaders.WatchStatusLoaderKey;
 import com.streamarr.server.graphql.dto.WatchProgressDto;
 import graphql.schema.DataFetchingEnvironment;
@@ -64,11 +66,14 @@ public class WatchProgressFieldResolver {
       return CompletableFuture.completedFuture(null);
     }
 
-    DataLoader<UUID, WatchProgressDto> loader = dfe.getDataLoader("watchProgress");
-    var mediaFileIds = files.stream().map(MediaFile::getId).toList();
+    DataLoader<SessionProgressLoaderKey, WatchProgressDto> loader =
+        dfe.getDataLoader("watchProgress");
+    var userId = CurrentUser.id();
+    var keys =
+        files.stream().map(file -> new SessionProgressLoaderKey(userId, file.getId())).toList();
 
     return loader
-        .loadMany(mediaFileIds)
+        .loadMany(keys)
         .thenApply(
             results ->
                 results.stream()
@@ -80,6 +85,6 @@ public class WatchProgressFieldResolver {
   private CompletableFuture<WatchStatus> loadWatchStatus(
       DataFetchingEnvironment dfe, UUID entityId, CollectableScope scope) {
     DataLoader<WatchStatusLoaderKey, WatchStatus> loader = dfe.getDataLoader("watchStatus");
-    return loader.load(new WatchStatusLoaderKey(entityId, scope));
+    return loader.load(new WatchStatusLoaderKey(CurrentUser.id(), entityId, scope));
   }
 }

--- a/src/test/java/com/streamarr/server/graphql/dataloaders/SessionProgressDataLoaderTest.java
+++ b/src/test/java/com/streamarr/server/graphql/dataloaders/SessionProgressDataLoaderTest.java
@@ -44,31 +44,48 @@ class SessionProgressDataLoaderTest {
   @Test
   @DisplayName("Should return progress for each media file ID when batch loading")
   void shouldReturnProgressForEachMediaFileIdWhenBatchLoading() throws Exception {
-    var mediaFileId1 = UUID.randomUUID();
-    var mediaFileId2 = UUID.randomUUID();
+    var key1 = new SessionProgressLoaderKey(USER_ID, UUID.randomUUID());
+    var key2 = new SessionProgressLoaderKey(USER_ID, UUID.randomUUID());
     sessionProgressRepository.save(
-        progressBuilder(USER_ID, mediaFileId1)
+        progressBuilder(USER_ID, key1.mediaFileId())
             .positionSeconds(300)
             .percentComplete(50.0)
             .durationSeconds(600)
             .build());
     sessionProgressRepository.save(
-        progressBuilder(USER_ID, mediaFileId2)
+        progressBuilder(USER_ID, key2.mediaFileId())
             .positionSeconds(600)
             .percentComplete(75.0)
             .durationSeconds(800)
             .build());
 
-    var result = dataLoader.load(Set.of(mediaFileId1, mediaFileId2)).toCompletableFuture().get();
+    var result = dataLoader.load(Set.of(key1, key2)).toCompletableFuture().get();
 
-    assertThat(result.get(mediaFileId1)).isNotNull();
-    assertThat(result.get(mediaFileId1).positionSeconds()).isEqualTo(300);
-    assertThat(result.get(mediaFileId1).percentComplete()).isEqualTo(50.0);
-    assertThat(result.get(mediaFileId1).durationSeconds()).isEqualTo(600);
-    assertThat(result.get(mediaFileId2)).isNotNull();
-    assertThat(result.get(mediaFileId2).positionSeconds()).isEqualTo(600);
-    assertThat(result.get(mediaFileId2).percentComplete()).isEqualTo(75.0);
-    assertThat(result.get(mediaFileId2).durationSeconds()).isEqualTo(800);
+    assertThat(result.get(key1)).isNotNull();
+    assertThat(result.get(key1).positionSeconds()).isEqualTo(300);
+    assertThat(result.get(key1).percentComplete()).isEqualTo(50.0);
+    assertThat(result.get(key1).durationSeconds()).isEqualTo(600);
+    assertThat(result.get(key2)).isNotNull();
+    assertThat(result.get(key2).positionSeconds()).isEqualTo(600);
+    assertThat(result.get(key2).percentComplete()).isEqualTo(75.0);
+    assertThat(result.get(key2).durationSeconds()).isEqualTo(800);
+  }
+
+  @Test
+  @DisplayName("Should scope progress to each user when keys span multiple users")
+  void shouldScopeProgressToEachUserWhenKeysSpanMultipleUsers() throws Exception {
+    var mediaFileId = UUID.randomUUID();
+    sessionProgressRepository.save(
+        progressBuilder(USER_ID, mediaFileId).positionSeconds(300).build());
+
+    var mine = new SessionProgressLoaderKey(USER_ID, mediaFileId);
+    var theirs = new SessionProgressLoaderKey(UUID.randomUUID(), mediaFileId);
+
+    var result = dataLoader.load(Set.of(mine, theirs)).toCompletableFuture().get();
+
+    assertThat(result.get(mine)).isNotNull();
+    assertThat(result.get(mine).positionSeconds()).isEqualTo(300);
+    assertThat(result.get(theirs)).isNull();
   }
 
   @Test
@@ -76,7 +93,7 @@ class SessionProgressDataLoaderTest {
   void shouldResolveNullWhenMediaFileHasNoProgress() throws Exception {
     var loader = DataLoaderFactory.newMappedDataLoader(dataLoader);
 
-    var future = loader.load(UUID.randomUUID());
+    var future = loader.load(new SessionProgressLoaderKey(USER_ID, UUID.randomUUID()));
     loader.dispatch();
 
     assertThat(future.get()).isNull();

--- a/src/test/java/com/streamarr/server/graphql/dataloaders/WatchStatusDataLoaderTest.java
+++ b/src/test/java/com/streamarr/server/graphql/dataloaders/WatchStatusDataLoaderTest.java
@@ -56,10 +56,29 @@ class WatchStatusDataLoaderTest {
   @Test
   @DisplayName("Should return unwatched when entity has no media files")
   void shouldReturnUnwatchedWhenEntityHasNoMediaFiles() throws Exception {
-    var key = new WatchStatusLoaderKey(UUID.randomUUID(), CollectableScope.DIRECT_MEDIA);
+    var key = new WatchStatusLoaderKey(USER_ID, UUID.randomUUID(), CollectableScope.DIRECT_MEDIA);
     var result = dataLoader.load(Set.of(key)).toCompletableFuture().get();
 
     assertThat(result).containsEntry(key, WatchStatus.UNWATCHED);
+  }
+
+  @Test
+  @DisplayName("Should scope status to each user when keys span multiple users")
+  void shouldScopeStatusToEachUserWhenKeysSpanMultipleUsers() throws Exception {
+    var movie = buildMovie();
+    var mediaFile = mediaFileRepository.save(buildMatchedMediaFile(movie.getId()));
+    sessionProgressRepository.save(
+        progressBuilder(USER_ID, mediaFile.getId()).positionSeconds(300).build());
+
+    var mine = new WatchStatusLoaderKey(USER_ID, movie.getId(), CollectableScope.DIRECT_MEDIA);
+    var theirs =
+        new WatchStatusLoaderKey(UUID.randomUUID(), movie.getId(), CollectableScope.DIRECT_MEDIA);
+
+    var result = dataLoader.load(Set.of(mine, theirs)).toCompletableFuture().get();
+
+    assertThat(result)
+        .containsEntry(mine, WatchStatus.IN_PROGRESS)
+        .containsEntry(theirs, WatchStatus.UNWATCHED);
   }
 
   @Test
@@ -86,9 +105,9 @@ class WatchStatusDataLoaderTest {
     sessionProgressRepository.save(
         progressBuilder(USER_ID, seriesFile.getId()).positionSeconds(300).build());
 
-    var movieKey = new WatchStatusLoaderKey(movie.getId(), CollectableScope.DIRECT_MEDIA);
-    var seasonKey = new WatchStatusLoaderKey(season.getId(), CollectableScope.SEASON);
-    var seriesKey = new WatchStatusLoaderKey(series.getId(), CollectableScope.SERIES);
+    var movieKey = new WatchStatusLoaderKey(USER_ID, movie.getId(), CollectableScope.DIRECT_MEDIA);
+    var seasonKey = new WatchStatusLoaderKey(USER_ID, season.getId(), CollectableScope.SEASON);
+    var seriesKey = new WatchStatusLoaderKey(USER_ID, series.getId(), CollectableScope.SERIES);
 
     var result =
         dataLoader.load(Set.of(movieKey, seasonKey, seriesKey)).toCompletableFuture().get();


### PR DESCRIPTION
## Summary

Structural preparation for #163 — identity is transported in dataloader keys instead of resolved inside batch functions:

- `WatchStatusLoaderKey` gains a `userId` component; the watch progress loader moves from bare `UUID` keys to a new `SessionProgressLoaderKey(userId, mediaFileId)` record.
- `WatchProgressFieldResolver` resolves the current user once on the request thread and bakes it into the keys.
- Both batch functions group keys by user and no longer call `CurrentUser` — nothing depends on a `SecurityContext` thread-local surviving the hop onto the ForkJoin common pool (`CompletableFuture.supplyAsync`).

No behavior change for current callers; when #163 lands, only the resolver-side identity source changes (`CurrentUser` → `SecurityContextCurrentUserProvider`). Design notes recorded on #163.

## Test plan

- Per-user isolation tests added for both loaders (mixed-user batches resolve independently)
- Full unit suite: 1,235 tests green
- Stacked on `refactor/watch-progress-simplification` (base of this PR)

Refs #163