### PR TITLE
Add season GraphQL query by id

### DIFF
--- a/src/main/java/com/streamarr/server/graphql/resolvers/SeriesResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/SeriesResolver.java
@@ -5,6 +5,7 @@ import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsQuery;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.exceptions.InvalidIdException;
 import com.streamarr.server.services.SeriesService;
@@ -23,6 +24,11 @@ public class SeriesResolver {
   @DgsQuery
   public Optional<Series> series(String id) {
     return seriesService.findById(parseUuid(id));
+  }
+
+  @DgsQuery
+  public Optional<Season> season(String id) {
+    return seriesService.findSeasonById(parseUuid(id));
   }
 
   @DgsQuery

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -266,6 +266,11 @@ public class SeriesService {
   }
 
   @Transactional(readOnly = true)
+  public Optional<Season> findSeasonById(UUID seasonId) {
+    return seasonRepository.findById(seasonId);
+  }
+
+  @Transactional(readOnly = true)
   public Optional<Episode> findEpisodeById(UUID episodeId) {
     return episodeRepository.findById(episodeId);
   }

--- a/src/main/resources/schema/root-query.graphqls
+++ b/src/main/resources/schema/root-query.graphqls
@@ -1,6 +1,7 @@
 type Query {
     movie(id: ID!): Movie
     series(id: ID!): Series
+    season(id: ID!): Season
     episode(id: ID!): Episode
     rating(id: ID!): Rating!
     library(id: ID!): Library!

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverTest.java
@@ -8,6 +8,7 @@ import com.netflix.graphql.dgs.DgsQueryExecutor;
 import com.netflix.graphql.dgs.test.EnableDgsTest;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.domain.media.Series;
 import com.streamarr.server.services.SeriesService;
 import java.util.List;
@@ -92,6 +93,44 @@ class SeriesResolverTest {
             "data.series.files[0].filepathUri");
 
     assertThat(filepathUri).isEqualTo("/media/shows/Breaking Bad/Season 1/breaking.bad.s01e01.mkv");
+  }
+
+  @Test
+  @DisplayName("Should return season when valid ID provided")
+  void shouldReturnSeasonWhenValidIdProvided() {
+    var seasonId = UUID.randomUUID();
+    var season = Season.builder().title("Season 1").seasonNumber(1).build();
+    season.setId(seasonId);
+
+    when(seriesService.findSeasonById(seasonId)).thenReturn(Optional.of(season));
+
+    String title =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            String.format("{ season(id: \"%s\") { title seasonNumber } }", seasonId),
+            "data.season.title");
+
+    assertThat(title).isEqualTo("Season 1");
+  }
+
+  @Test
+  @DisplayName("Should return null when season not found")
+  void shouldReturnNullWhenSeasonNotFound() {
+    when(seriesService.findSeasonById(any(UUID.class))).thenReturn(Optional.empty());
+
+    Object result =
+        dgsQueryExecutor.executeAndExtractJsonPath(
+            String.format("{ season(id: \"%s\") { title } }", UUID.randomUUID()), "data.season");
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @DisplayName("Should return error when invalid season ID provided")
+  void shouldReturnErrorWhenInvalidSeasonIdProvided() {
+    var result = dgsQueryExecutor.execute("{ season(id: \"not-a-uuid\") { title } }");
+
+    assertThat(result.getErrors()).isNotEmpty();
+    assertThat(result.getErrors().get(0).getMessage()).contains("Invalid ID format");
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/services/SeriesServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/SeriesServiceTest.java
@@ -100,6 +100,32 @@ class SeriesServiceTest {
   }
 
   @Nested
+  @DisplayName("Lookups")
+  class Lookups {
+
+    @Test
+    @DisplayName("Should return season by ID")
+    void shouldReturnSeasonById() {
+      var series = seriesRepository.save(Series.builder().title("Breaking Bad").build());
+      var season =
+          seasonRepository.save(
+              Season.builder().title("Season 1").seasonNumber(1).series(series).build());
+
+      var result = seriesService.findSeasonById(season.getId());
+
+      assertThat(result).contains(season);
+    }
+
+    @Test
+    @DisplayName("Should return empty when season ID is unknown")
+    void shouldReturnEmptyWhenSeasonIdIsUnknown() {
+      var result = seriesService.findSeasonById(UUID.randomUUID());
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
   @DisplayName("Sorting")
   class Sorting {
 


### PR DESCRIPTION
## Summary
- add root GraphQL season(id:) field alongside existing episode(id:)
- wire season lookup through SeriesResolver and SeriesService
- cover season lookup at both resolver and service levels

## Tests
- ./mvnw spotless:apply
- ./mvnw verify

Closes #182