### PR TITLE
Fix season graph traversal and episode ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ Use Spring's `ApplicationEventPublisher` to decouple side effects from core oper
 
 ## Persistence (JPA + jOOQ Hybrid)
 - Spring Data JPA repositories own CRUD; complex or conflict-handling queries use jOOQ via the Spring Data fragment convention: `{Repository}Custom` interface + `{Repository}CustomImpl` class with an injected `DSLContext` — Spring Data auto-discovers the impl by naming convention
+- **No `@Query` JPQL**: every repository query is either a derived method (`findBySeriesIdOrderBySeasonNumber`) or jOOQ on the `{Repository}Custom` fragment. JPQL strings break silently on entity refactors; derived signatures are validated at startup and jOOQ at compile time. Existing `@Query` in `CompanyRepository`/`GenreRepository` is legacy — don't copy it
 - **Reads**: jOOQ builds the SQL, but execute through `JooqQueryHelper.nativeQuery(…)` (JPA `EntityManager` native query) so results map to JPA entities — don't `context.fetch*()` for entity reads
 - **Writes**: execute jOOQ DSL directly (`context.update(…).returning()`, `INSERT … ON CONFLICT`) and map records to entities manually
 - **Pagination**: keyset/seek (`row(fields)` comparisons, NULLS LAST) fetching `limit + 2` to detect adjacent pages — no OFFSET pagination

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ Use Spring's `ApplicationEventPublisher` to decouple side effects from core oper
 
 ## Persistence (JPA + jOOQ Hybrid)
 - Spring Data JPA repositories own CRUD; complex or conflict-handling queries use jOOQ via the Spring Data fragment convention: `{Repository}Custom` interface + `{Repository}CustomImpl` class with an injected `DSLContext` — Spring Data auto-discovers the impl by naming convention
-- **No `@Query` JPQL**: every repository query is either a derived method (`findBySeriesIdOrderBySeasonNumber`) or jOOQ on the `{Repository}Custom` fragment. JPQL strings break silently on entity refactors; derived signatures are validated at startup and jOOQ at compile time. Existing `@Query` in `CompanyRepository`/`GenreRepository` is legacy — don't copy it
+- **No `@Query` JPQL**: every repository query is either a derived method (`findBySeriesIdOrderBySeasonNumber`) or jOOQ on the `{Repository}Custom` fragment. JPQL strings break silently on entity refactors; derived signatures are validated at startup and jOOQ at compile time. Remaining `@Query` usages are legacy (tracked in #193) — don't copy them
 - **Reads**: jOOQ builds the SQL, but execute through `JooqQueryHelper.nativeQuery(…)` (JPA `EntityManager` native query) so results map to JPA entities — don't `context.fetch*()` for entity reads
 - **Writes**: execute jOOQ DSL directly (`context.update(…).returning()`, `INSERT … ON CONFLICT`) and map records to entities manually
 - **Pagination**: keyset/seek (`row(fields)` comparisons, NULLS LAST) fetching `limit + 2` to detect adjacent pages — no OFFSET pagination

--- a/src/main/java/com/streamarr/server/exceptions/SeasonNotFoundException.java
+++ b/src/main/java/com/streamarr/server/exceptions/SeasonNotFoundException.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 public class SeasonNotFoundException extends RuntimeException {
 
-  public SeasonNotFoundException(UUID seasonId) {
-    super("Season not found: " + seasonId);
+  public SeasonNotFoundException(UUID seasonId, UUID episodeId) {
+    super("Season not found: " + seasonId + " (referenced by episode " + episodeId + ")");
   }
 }

--- a/src/main/java/com/streamarr/server/exceptions/SeriesNotFoundException.java
+++ b/src/main/java/com/streamarr/server/exceptions/SeriesNotFoundException.java
@@ -1,0 +1,10 @@
+package com.streamarr.server.exceptions;
+
+import java.util.UUID;
+
+public class SeriesNotFoundException extends RuntimeException {
+
+  public SeriesNotFoundException(UUID seriesId) {
+    super("Series not found: " + seriesId);
+  }
+}

--- a/src/main/java/com/streamarr/server/exceptions/SeriesNotFoundException.java
+++ b/src/main/java/com/streamarr/server/exceptions/SeriesNotFoundException.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 public class SeriesNotFoundException extends RuntimeException {
 
-  public SeriesNotFoundException(UUID seriesId) {
-    super("Series not found: " + seriesId);
+  public SeriesNotFoundException(UUID seriesId, UUID seasonId) {
+    super("Series not found: " + seriesId + " (referenced by season " + seasonId + ")");
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolver.java
@@ -4,6 +4,8 @@ import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.exceptions.SeasonNotFoundException;
 import com.streamarr.server.services.SeriesService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
@@ -19,5 +21,14 @@ public class EpisodeFieldResolver {
   public List<MediaFile> files(DataFetchingEnvironment dfe) {
     Episode episode = dfe.getSource();
     return seriesService.findMediaFiles(episode.getId());
+  }
+
+  @DgsData(parentType = "Episode", field = "season")
+  public Season season(DataFetchingEnvironment dfe) {
+    Episode episode = dfe.getSource();
+    var seasonId = episode.getSeason().getId();
+    return seriesService
+        .findSeasonById(seasonId)
+        .orElseThrow(() -> new SeasonNotFoundException(seasonId));
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolver.java
@@ -29,6 +29,6 @@ public class EpisodeFieldResolver {
     var seasonId = episode.getSeason().getId();
     return seriesService
         .findSeasonById(seasonId)
-        .orElseThrow(() -> new SeasonNotFoundException(seasonId));
+        .orElseThrow(() -> new SeasonNotFoundException(seasonId, episode.getId()));
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
@@ -29,6 +29,6 @@ public class SeasonFieldResolver {
     var seriesId = season.getSeries().getId();
     return seriesService
         .findById(seriesId)
-        .orElseThrow(() -> new SeriesNotFoundException(seriesId));
+        .orElseThrow(() -> new SeriesNotFoundException(seriesId, season.getId()));
   }
 }

--- a/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolver.java
@@ -4,6 +4,8 @@ import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.exceptions.SeriesNotFoundException;
 import com.streamarr.server.services.SeriesService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
@@ -19,5 +21,14 @@ public class SeasonFieldResolver {
   public List<Episode> episodes(DataFetchingEnvironment dfe) {
     Season season = dfe.getSource();
     return seriesService.findEpisodes(season.getId());
+  }
+
+  @DgsData(parentType = "Season", field = "series")
+  public Series series(DataFetchingEnvironment dfe) {
+    Season season = dfe.getSource();
+    var seriesId = season.getSeries().getId();
+    return seriesService
+        .findById(seriesId)
+        .orElseThrow(() -> new SeriesNotFoundException(seriesId));
   }
 }

--- a/src/main/java/com/streamarr/server/repositories/media/EpisodeRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/media/EpisodeRepository.java
@@ -6,12 +6,21 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EpisodeRepository extends JpaRepository<Episode, UUID>, EpisodeRepositoryCustom {
 
-  List<Episode> findBySeasonId(UUID seasonId);
+  @Query(
+      """
+      select episode
+      from Episode episode
+      where episode.season.id = :seasonId
+      order by episode.episodeNumber
+      """)
+  List<Episode> findBySeasonId(@Param("seasonId") UUID seasonId);
 
   List<Episode> findBySeasonIdIn(Collection<UUID> seasonIds);
 

--- a/src/main/java/com/streamarr/server/repositories/media/EpisodeRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/media/EpisodeRepository.java
@@ -6,21 +6,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EpisodeRepository extends JpaRepository<Episode, UUID>, EpisodeRepositoryCustom {
 
-  @Query(
-      """
-      select episode
-      from Episode episode
-      where episode.season.id = :seasonId
-      order by episode.episodeNumber
-      """)
-  List<Episode> findBySeasonId(@Param("seasonId") UUID seasonId);
+  List<Episode> findBySeasonIdOrderByEpisodeNumber(UUID seasonId);
 
   List<Episode> findBySeasonIdIn(Collection<UUID> seasonIds);
 

--- a/src/main/java/com/streamarr/server/repositories/media/EpisodeRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/media/EpisodeRepository.java
@@ -1,7 +1,6 @@
 package com.streamarr.server.repositories.media;
 
 import com.streamarr.server.domain.media.Episode;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -12,8 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface EpisodeRepository extends JpaRepository<Episode, UUID>, EpisodeRepositoryCustom {
 
   List<Episode> findBySeasonIdOrderByEpisodeNumber(UUID seasonId);
-
-  List<Episode> findBySeasonIdIn(Collection<UUID> seasonIds);
 
   Optional<Episode> findBySeasonIdAndEpisodeNumber(UUID seasonId, int episodeNumber);
 }

--- a/src/main/java/com/streamarr/server/repositories/media/SeasonRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeasonRepository.java
@@ -1,7 +1,6 @@
 package com.streamarr.server.repositories.media;
 
 import com.streamarr.server.domain.media.Season;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,6 +13,4 @@ public interface SeasonRepository extends JpaRepository<Season, UUID>, SeasonRep
   Optional<Season> findBySeriesIdAndSeasonNumber(UUID seriesId, int seasonNumber);
 
   List<Season> findBySeriesIdOrderBySeasonNumber(UUID seriesId);
-
-  List<Season> findBySeriesIdIn(Collection<UUID> seriesIds);
 }

--- a/src/main/java/com/streamarr/server/repositories/media/SeasonRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeasonRepository.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,14 +13,7 @@ public interface SeasonRepository extends JpaRepository<Season, UUID>, SeasonRep
 
   Optional<Season> findBySeriesIdAndSeasonNumber(UUID seriesId, int seasonNumber);
 
-  @Query(
-      """
-      select season
-      from Season season
-      where season.series.id = :seriesId
-      order by season.seasonNumber
-      """)
-  List<Season> findBySeriesId(@Param("seriesId") UUID seriesId);
+  List<Season> findBySeriesIdOrderBySeasonNumber(UUID seriesId);
 
   List<Season> findBySeriesIdIn(Collection<UUID> seriesIds);
 }

--- a/src/main/java/com/streamarr/server/repositories/media/SeasonRepository.java
+++ b/src/main/java/com/streamarr/server/repositories/media/SeasonRepository.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,7 +15,14 @@ public interface SeasonRepository extends JpaRepository<Season, UUID>, SeasonRep
 
   Optional<Season> findBySeriesIdAndSeasonNumber(UUID seriesId, int seasonNumber);
 
-  List<Season> findBySeriesId(UUID seriesId);
+  @Query(
+      """
+      select season
+      from Season season
+      where season.series.id = :seriesId
+      order by season.seasonNumber
+      """)
+  List<Season> findBySeriesId(@Param("seriesId") UUID seriesId);
 
   List<Season> findBySeriesIdIn(Collection<UUID> seriesIds);
 }

--- a/src/main/java/com/streamarr/server/services/SeriesService.java
+++ b/src/main/java/com/streamarr/server/services/SeriesService.java
@@ -262,7 +262,7 @@ public class SeriesService {
 
   @Transactional(readOnly = true)
   public List<Season> findSeasons(UUID seriesId) {
-    return seasonRepository.findBySeriesId(seriesId);
+    return seasonRepository.findBySeriesIdOrderBySeasonNumber(seriesId);
   }
 
   @Transactional(readOnly = true)
@@ -277,7 +277,7 @@ public class SeriesService {
 
   @Transactional(readOnly = true)
   public List<Episode> findEpisodes(UUID seasonId) {
-    return episodeRepository.findBySeasonId(seasonId);
+    return episodeRepository.findBySeasonIdOrderByEpisodeNumber(seasonId);
   }
 
   @Transactional(readOnly = true)

--- a/src/test/java/com/streamarr/server/controllers/StreamControllerIT.java
+++ b/src/test/java/com/streamarr/server/controllers/StreamControllerIT.java
@@ -106,6 +106,30 @@ class StreamControllerIT extends AbstractIntegrationTest {
         .andExpect(status().isNotFound());
   }
 
+  @Test
+  @DisplayName("Should return 400 when segment name contains parent directory traversal")
+  void shouldReturn400WhenSegmentNameContainsParentDirectoryTraversal() throws Exception {
+    mockMvc
+        .perform(get("/api/stream/{id}/{segment}", UUID.randomUUID(), "..secret.ts"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("Should return 400 when segment name contains backslash")
+  void shouldReturn400WhenSegmentNameContainsBackslash() throws Exception {
+    mockMvc
+        .perform(get("/api/stream/{id}/{segment}", UUID.randomUUID(), "evil\\name.ts"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("Should return 400 when variant label contains parent directory traversal")
+  void shouldReturn400WhenVariantLabelContainsParentDirectoryTraversal() throws Exception {
+    mockMvc
+        .perform(get("/api/stream/{id}/{variant}/stream.m3u8", UUID.randomUUID(), ".."))
+        .andExpect(status().isBadRequest());
+  }
+
   private static class StubStreamingService implements StreamingService {
 
     private final ConcurrentHashMap<UUID, StreamSession> sessions = new ConcurrentHashMap<>();

--- a/src/test/java/com/streamarr/server/domain/media/MediaFileTest.java
+++ b/src/test/java/com/streamarr/server/domain/media/MediaFileTest.java
@@ -1,0 +1,40 @@
+package com.streamarr.server.domain.media;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Media File Entity Tests")
+class MediaFileTest {
+
+  @Test
+  @DisplayName("Should be equal when both have the same filepath URI")
+  void shouldBeEqualWhenBothHaveSameFilepathUri() {
+    var a = MediaFile.builder().filepathUri("file:///media/movie.mkv").filename("a.mkv").build();
+    var b = MediaFile.builder().filepathUri("file:///media/movie.mkv").filename("b.mkv").build();
+
+    assertThat(a).isEqualTo(b);
+    assertThat(a).hasSameHashCodeAs(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when filepath URIs differ")
+  void shouldNotBeEqualWhenFilepathUrisDiffer() {
+    var a = MediaFile.builder().filepathUri("file:///media/movie.mkv").build();
+    var b = MediaFile.builder().filepathUri("file:///media/other.mkv").build();
+
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when filepath URI is null on either side")
+  void shouldNotBeEqualWhenFilepathUriIsNull() {
+    var a = MediaFile.builder().filename("orphan.mkv").build();
+    var b = MediaFile.builder().filename("orphan.mkv").build();
+
+    assertThat(a).isNotEqualTo(b);
+  }
+}

--- a/src/test/java/com/streamarr/server/domain/media/MediaFileTest.java
+++ b/src/test/java/com/streamarr/server/domain/media/MediaFileTest.java
@@ -16,8 +16,7 @@ class MediaFileTest {
     var a = MediaFile.builder().filepathUri("file:///media/movie.mkv").filename("a.mkv").build();
     var b = MediaFile.builder().filepathUri("file:///media/movie.mkv").filename("b.mkv").build();
 
-    assertThat(a).isEqualTo(b);
-    assertThat(a).hasSameHashCodeAs(b);
+    assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/domain/media/MediaFileTest.java
+++ b/src/test/java/com/streamarr/server/domain/media/MediaFileTest.java
@@ -2,6 +2,7 @@ package com.streamarr.server.domain.media;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.streamarr.server.domain.metadata.Genre;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,17 @@ class MediaFileTest {
   void shouldNotBeEqualWhenFilepathUriIsNull() {
     var a = MediaFile.builder().filename("orphan.mkv").build();
     var b = MediaFile.builder().filename("orphan.mkv").build();
+    var withUri = MediaFile.builder().filepathUri("file:///media/movie.mkv").build();
 
-    assertThat(a).isNotEqualTo(b);
+    assertThat(a).isNotEqualTo(b).isNotEqualTo(withUri);
+    assertThat(withUri).isNotEqualTo(a);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when compared against different type")
+  void shouldNotBeEqualWhenComparedAgainstDifferentType() {
+    var mediaFile = MediaFile.builder().filepathUri("file:///media/movie.mkv").build();
+
+    assertThat(mediaFile).isNotEqualTo(Genre.builder().name("Drama").sourceId("18").build());
   }
 }

--- a/src/test/java/com/streamarr/server/domain/metadata/GenreTest.java
+++ b/src/test/java/com/streamarr/server/domain/metadata/GenreTest.java
@@ -1,0 +1,40 @@
+package com.streamarr.server.domain.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Genre Entity Tests")
+class GenreTest {
+
+  @Test
+  @DisplayName("Should be equal when both have the same sourceId")
+  void shouldBeEqualWhenBothHaveSameSourceId() {
+    var a = Genre.builder().sourceId("878").name("Science Fiction").build();
+    var b = Genre.builder().sourceId("878").name("Sci-Fi").build();
+
+    assertThat(a).isEqualTo(b);
+    assertThat(a).hasSameHashCodeAs(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when sourceIds differ")
+  void shouldNotBeEqualWhenSourceIdsDiffer() {
+    var a = Genre.builder().sourceId("878").name("Science Fiction").build();
+    var b = Genre.builder().sourceId("18").name("Drama").build();
+
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when sourceId is null on either side")
+  void shouldNotBeEqualWhenSourceIdIsNull() {
+    var a = Genre.builder().name("Unknown").build();
+    var b = Genre.builder().name("Unknown").build();
+
+    assertThat(a).isNotEqualTo(b);
+  }
+}

--- a/src/test/java/com/streamarr/server/domain/metadata/GenreTest.java
+++ b/src/test/java/com/streamarr/server/domain/metadata/GenreTest.java
@@ -16,8 +16,7 @@ class GenreTest {
     var a = Genre.builder().sourceId("878").name("Science Fiction").build();
     var b = Genre.builder().sourceId("878").name("Sci-Fi").build();
 
-    assertThat(a).isEqualTo(b);
-    assertThat(a).hasSameHashCodeAs(b);
+    assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/domain/metadata/GenreTest.java
+++ b/src/test/java/com/streamarr/server/domain/metadata/GenreTest.java
@@ -33,7 +33,17 @@ class GenreTest {
   void shouldNotBeEqualWhenSourceIdIsNull() {
     var a = Genre.builder().name("Unknown").build();
     var b = Genre.builder().name("Unknown").build();
+    var withSourceId = Genre.builder().sourceId("878").name("Science Fiction").build();
 
-    assertThat(a).isNotEqualTo(b);
+    assertThat(a).isNotEqualTo(b).isNotEqualTo(withSourceId);
+    assertThat(withSourceId).isNotEqualTo(a);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when compared against different type")
+  void shouldNotBeEqualWhenComparedAgainstDifferentType() {
+    var genre = Genre.builder().sourceId("878").name("Science Fiction").build();
+
+    assertThat(genre).isNotEqualTo(Person.builder().sourceId("878").name("Same Key").build());
   }
 }

--- a/src/test/java/com/streamarr/server/domain/metadata/PersonTest.java
+++ b/src/test/java/com/streamarr/server/domain/metadata/PersonTest.java
@@ -16,8 +16,7 @@ class PersonTest {
     var a = Person.builder().sourceId("6193").name("Leonardo DiCaprio").build();
     var b = Person.builder().sourceId("6193").name("Leo DiCaprio").build();
 
-    assertThat(a).isEqualTo(b);
-    assertThat(a).hasSameHashCodeAs(b);
+    assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/domain/metadata/PersonTest.java
+++ b/src/test/java/com/streamarr/server/domain/metadata/PersonTest.java
@@ -1,0 +1,48 @@
+package com.streamarr.server.domain.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Person Entity Tests")
+class PersonTest {
+
+  @Test
+  @DisplayName("Should be equal when both have the same sourceId")
+  void shouldBeEqualWhenBothHaveSameSourceId() {
+    var a = Person.builder().sourceId("6193").name("Leonardo DiCaprio").build();
+    var b = Person.builder().sourceId("6193").name("Leo DiCaprio").build();
+
+    assertThat(a).isEqualTo(b);
+    assertThat(a).hasSameHashCodeAs(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when sourceIds differ")
+  void shouldNotBeEqualWhenSourceIdsDiffer() {
+    var a = Person.builder().sourceId("6193").name("Leonardo DiCaprio").build();
+    var b = Person.builder().sourceId("525").name("Christopher Nolan").build();
+
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when sourceId is null on either side")
+  void shouldNotBeEqualWhenSourceIdIsNull() {
+    var a = Person.builder().name("Unknown").build();
+    var b = Person.builder().name("Unknown").build();
+
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  @Test
+  @DisplayName("Should not be equal when compared against different type")
+  void shouldNotBeEqualWhenComparedAgainstDifferentType() {
+    var person = Person.builder().sourceId("6193").name("Leonardo DiCaprio").build();
+
+    assertThat(person).isNotEqualTo(Genre.builder().sourceId("6193").name("Drama").build());
+  }
+}

--- a/src/test/java/com/streamarr/server/domain/metadata/PersonTest.java
+++ b/src/test/java/com/streamarr/server/domain/metadata/PersonTest.java
@@ -33,8 +33,10 @@ class PersonTest {
   void shouldNotBeEqualWhenSourceIdIsNull() {
     var a = Person.builder().name("Unknown").build();
     var b = Person.builder().name("Unknown").build();
+    var withSourceId = Person.builder().sourceId("6193").name("Leonardo DiCaprio").build();
 
-    assertThat(a).isNotEqualTo(b);
+    assertThat(a).isNotEqualTo(b).isNotEqualTo(withSourceId);
+    assertThat(withSourceId).isNotEqualTo(a);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/fakes/FakeEpisodeRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeEpisodeRepository.java
@@ -1,5 +1,7 @@
 package com.streamarr.server.fakes;
 
+import static java.util.Comparator.comparingInt;
+
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.repositories.media.EpisodeRepository;
 import java.util.Collection;
@@ -17,7 +19,9 @@ public class FakeEpisodeRepository extends FakeJpaRepository<Episode> implements
 
   @Override
   public List<Episode> findBySeasonId(UUID seasonId) {
-    return findBySeasonIdIn(List.of(seasonId));
+    return findBySeasonIdIn(List.of(seasonId)).stream()
+        .sorted(comparingInt(Episode::getEpisodeNumber))
+        .toList();
   }
 
   @Override

--- a/src/test/java/com/streamarr/server/fakes/FakeEpisodeRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeEpisodeRepository.java
@@ -19,14 +19,10 @@ public class FakeEpisodeRepository extends FakeJpaRepository<Episode> implements
 
   @Override
   public List<Episode> findBySeasonIdOrderByEpisodeNumber(UUID seasonId) {
-    return findBySeasonIdIn(List.of(seasonId)).stream()
+    return database.values().stream()
+        .filter(episode -> inSeasons(episode, List.of(seasonId)))
         .sorted(comparingInt(Episode::getEpisodeNumber))
         .toList();
-  }
-
-  @Override
-  public List<Episode> findBySeasonIdIn(Collection<UUID> seasonIds) {
-    return database.values().stream().filter(episode -> inSeasons(episode, seasonIds)).toList();
   }
 
   @Override

--- a/src/test/java/com/streamarr/server/fakes/FakeEpisodeRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeEpisodeRepository.java
@@ -18,7 +18,7 @@ public class FakeEpisodeRepository extends FakeJpaRepository<Episode> implements
   }
 
   @Override
-  public List<Episode> findBySeasonId(UUID seasonId) {
+  public List<Episode> findBySeasonIdOrderByEpisodeNumber(UUID seasonId) {
     return findBySeasonIdIn(List.of(seasonId)).stream()
         .sorted(comparingInt(Episode::getEpisodeNumber))
         .toList();

--- a/src/test/java/com/streamarr/server/fakes/FakeSeasonRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeSeasonRepository.java
@@ -42,7 +42,7 @@ public class FakeSeasonRepository extends FakeJpaRepository<Season> implements S
   }
 
   @Override
-  public List<Season> findBySeriesId(UUID seriesId) {
+  public List<Season> findBySeriesIdOrderBySeasonNumber(UUID seriesId) {
     return findBySeriesIdIn(List.of(seriesId)).stream()
         .sorted(comparingInt(Season::getSeasonNumber))
         .toList();

--- a/src/test/java/com/streamarr/server/fakes/FakeSeasonRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeSeasonRepository.java
@@ -1,5 +1,7 @@
 package com.streamarr.server.fakes;
 
+import static java.util.Comparator.comparingInt;
+
 import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.repositories.media.SeasonRepository;
 import java.util.Collection;
@@ -41,6 +43,8 @@ public class FakeSeasonRepository extends FakeJpaRepository<Season> implements S
 
   @Override
   public List<Season> findBySeriesId(UUID seriesId) {
-    return findBySeriesIdIn(List.of(seriesId));
+    return findBySeriesIdIn(List.of(seriesId)).stream()
+        .sorted(comparingInt(Season::getSeasonNumber))
+        .toList();
   }
 }

--- a/src/test/java/com/streamarr/server/fakes/FakeSeasonRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeSeasonRepository.java
@@ -27,11 +27,6 @@ public class FakeSeasonRepository extends FakeJpaRepository<Season> implements S
   }
 
   @Override
-  public List<Season> findBySeriesIdIn(Collection<UUID> seriesIds) {
-    return database.values().stream().filter(season -> inSeries(season, seriesIds)).toList();
-  }
-
-  @Override
   public Map<UUID, List<UUID>> findSeasonIdsBySeriesIds(Collection<UUID> seriesIds) {
     return database.values().stream()
         .filter(season -> inSeries(season, seriesIds))
@@ -43,7 +38,8 @@ public class FakeSeasonRepository extends FakeJpaRepository<Season> implements S
 
   @Override
   public List<Season> findBySeriesIdOrderBySeasonNumber(UUID seriesId) {
-    return findBySeriesIdIn(List.of(seriesId)).stream()
+    return database.values().stream()
+        .filter(season -> inSeries(season, List.of(seriesId)))
         .sorted(comparingInt(Season::getSeasonNumber))
         .toList();
   }

--- a/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverIT.java
@@ -85,9 +85,9 @@ class ContinueWatchingResolverIT extends AbstractIntegrationTest {
     var season = (Map<String, Object>) item.get("season");
     var series = (Map<String, Object>) season.get("series");
 
-    assertThat(item.get("title")).isEqualTo(episode.getTitle());
-    assertThat(season.get("seasonNumber")).isEqualTo(1);
-    assertThat(series.get("title")).isEqualTo("Test Series");
+    assertThat(item).containsEntry("title", episode.getTitle());
+    assertThat(season).containsEntry("seasonNumber", 1);
+    assertThat(series).containsEntry("title", "Test Series");
   }
 
   private Episode createEpisodeWithProgress() {

--- a/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverIT.java
@@ -1,0 +1,138 @@
+package com.streamarr.server.graphql.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.MediaFileStatus;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.streaming.SessionProgress;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.jooq.generated.Tables;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.EpisodeRepository;
+import com.streamarr.server.repositories.media.SeasonRepository;
+import com.streamarr.server.repositories.media.SeriesRepository;
+import com.streamarr.server.repositories.streaming.SessionProgressRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@EnableDgsTest
+@DisplayName("Continue Watching Resolver Integration Tests")
+class ContinueWatchingResolverIT extends AbstractIntegrationTest {
+
+  private static final UUID USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private SeriesRepository seriesRepository;
+  @Autowired private SeasonRepository seasonRepository;
+  @Autowired private EpisodeRepository episodeRepository;
+  @Autowired private SessionProgressRepository sessionProgressRepository;
+  @Autowired private DSLContext dsl;
+
+  @BeforeEach
+  void setUp() {
+    dsl.deleteFrom(Tables.SESSION_PROGRESS)
+        .where(Tables.SESSION_PROGRESS.USER_ID.eq(USER_ID))
+        .execute();
+    dsl.deleteFrom(Tables.WATCH_HISTORY).where(Tables.WATCH_HISTORY.USER_ID.eq(USER_ID)).execute();
+  }
+
+  @Test
+  @DisplayName("Should resolve episode season details when continue watching returns an episode")
+  @SuppressWarnings("unchecked")
+  void shouldResolveEpisodeSeasonDetailsWhenContinueWatchingReturnsAnEpisode() {
+    var episode = createEpisodeWithProgress();
+
+    var result =
+        dgsQueryExecutor.execute(
+            """
+            {
+              continueWatching(first: 1) {
+                ... on Episode {
+                  title
+                  season {
+                    seasonNumber
+                    series {
+                      title
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+    assertThat(result.getErrors()).isEmpty();
+
+    Map<String, Object> data = result.getData();
+    var items = (List<Map<String, Object>>) data.get("continueWatching");
+    var item = items.getFirst();
+    var season = (Map<String, Object>) item.get("season");
+    var series = (Map<String, Object>) season.get("series");
+
+    assertThat(item.get("title")).isEqualTo(episode.getTitle());
+    assertThat(season.get("seasonNumber")).isEqualTo(1);
+    assertThat(series.get("title")).isEqualTo("Test Series");
+  }
+
+  private Episode createEpisodeWithProgress() {
+    var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+    var series = createSeries(library);
+    var season = createSeason(library, series);
+
+    var file =
+        MediaFile.builder()
+            .libraryId(library.getId())
+            .status(MediaFileStatus.MATCHED)
+            .filename("pilot.mkv")
+            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .build();
+
+    var episode =
+        episodeRepository.saveAndFlush(
+            Episode.builder()
+                .episodeNumber(1)
+                .title("Pilot")
+                .season(season)
+                .library(library)
+                .files(Set.of(file))
+                .build());
+
+    sessionProgressRepository.saveAndFlush(
+        SessionProgress.builder()
+            .sessionId(UUID.randomUUID())
+            .userId(USER_ID)
+            .mediaFileId(episode.getFiles().iterator().next().getId())
+            .positionSeconds(900)
+            .percentComplete(25.0)
+            .durationSeconds(3600)
+            .build());
+
+    return episode;
+  }
+
+  private Series createSeries(Library library) {
+    return seriesRepository.saveAndFlush(
+        Series.builder().title("Test Series").titleSort("Test Series").library(library).build());
+  }
+
+  private Season createSeason(Library library, Series series) {
+    return seasonRepository.saveAndFlush(
+        Season.builder().title("Season 1").seasonNumber(1).series(series).library(library).build());
+  }
+}

--- a/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/ContinueWatchingResolverIT.java
@@ -100,7 +100,7 @@ class ContinueWatchingResolverIT extends AbstractIntegrationTest {
             .libraryId(library.getId())
             .status(MediaFileStatus.MATCHED)
             .filename("pilot.mkv")
-            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .filepathUri("file:///media/" + UUID.randomUUID() + ".mkv")
             .build();
 
     var episode =

--- a/src/test/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/EpisodeFieldResolverTest.java
@@ -1,0 +1,62 @@
+package com.streamarr.server.graphql.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.services.SeriesService;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@Tag("UnitTest")
+@EnableDgsTest
+@SpringBootTest(
+    classes = {
+      SeasonFieldResolver.class,
+      EpisodeFieldResolver.class,
+      SeriesFieldResolver.class,
+      SeriesResolver.class
+    })
+@DisplayName("Episode Field Resolver Tests")
+class EpisodeFieldResolverTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+
+  @MockitoBean private SeriesService seriesService;
+
+  @Test
+  @DisplayName("Should return season not found error when episode references missing season")
+  void shouldReturnSeasonNotFoundErrorWhenEpisodeReferencesMissingSeason() {
+    var seasonId = UUID.randomUUID();
+    var season = Season.builder().title("Season 1").seasonNumber(1).build();
+    season.setId(seasonId);
+
+    var episodeId = UUID.randomUUID();
+    var episode = Episode.builder().title("Pilot").episodeNumber(1).season(season).build();
+    episode.setId(episodeId);
+
+    when(seriesService.findEpisodeById(episodeId)).thenReturn(Optional.of(episode));
+    when(seriesService.findSeasonById(seasonId)).thenReturn(Optional.empty());
+
+    var result =
+        dgsQueryExecutor.execute(
+            String.format("{ episode(id: \"%s\") { season { seasonNumber } } }", episodeId));
+
+    assertThat(result.getErrors())
+        .singleElement()
+        .satisfies(
+            error ->
+                assertThat(error.getMessage())
+                    .contains("Season not found: " + seasonId)
+                    .contains(episodeId.toString()));
+  }
+}

--- a/src/test/java/com/streamarr/server/graphql/resolvers/MovieResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/MovieResolverIT.java
@@ -1,0 +1,143 @@
+package com.streamarr.server.graphql.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.MediaFileStatus;
+import com.streamarr.server.domain.media.Movie;
+import com.streamarr.server.domain.metadata.Company;
+import com.streamarr.server.domain.metadata.Genre;
+import com.streamarr.server.domain.metadata.Person;
+import com.streamarr.server.domain.metadata.Rating;
+import com.streamarr.server.domain.metadata.Review;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.CompanyRepository;
+import com.streamarr.server.repositories.GenreRepository;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.PersonRepository;
+import com.streamarr.server.repositories.RatingRepository;
+import com.streamarr.server.repositories.ReviewRepository;
+import com.streamarr.server.repositories.media.MediaFileRepository;
+import com.streamarr.server.repositories.media.MovieRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@EnableDgsTest
+@DisplayName("Movie Resolver Integration Tests")
+class MovieResolverIT extends AbstractIntegrationTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private MovieRepository movieRepository;
+  @Autowired private PersonRepository personRepository;
+  @Autowired private CompanyRepository companyRepository;
+  @Autowired private GenreRepository genreRepository;
+  @Autowired private RatingRepository ratingRepository;
+  @Autowired private ReviewRepository reviewRepository;
+  @Autowired private MediaFileRepository mediaFileRepository;
+
+  @Test
+  @DisplayName("Should resolve all movie relationships from movie query")
+  @SuppressWarnings("unchecked")
+  void shouldResolveAllMovieRelationshipsFromMovieQuery() {
+    var movie = createMovieWithRelationships();
+
+    var result =
+        dgsQueryExecutor.execute(
+            """
+            {
+              movie(id: "%s") {
+                title
+                studios { name }
+                cast { name }
+                directors { name }
+                genres { name }
+                ratings { source value }
+                reviews { author }
+                files { filename }
+              }
+            }
+            """
+                .formatted(movie.getId()));
+
+    assertThat(result.getErrors()).isEmpty();
+
+    Map<String, Object> data = result.getData();
+    var movieData = (Map<String, Object>) data.get("movie");
+
+    assertThat(movieData).containsEntry("title", "Inception");
+    assertThat((List<Map<String, Object>>) movieData.get("studios"))
+        .extracting(studio -> studio.get("name"))
+        .containsExactly("Warner Bros");
+    assertThat((List<Map<String, Object>>) movieData.get("cast"))
+        .extracting(castMember -> castMember.get("name"))
+        .containsExactly("Leonardo DiCaprio");
+    assertThat((List<Map<String, Object>>) movieData.get("directors"))
+        .extracting(director -> director.get("name"))
+        .containsExactly("Christopher Nolan");
+    assertThat((List<Map<String, Object>>) movieData.get("genres"))
+        .extracting(genre -> genre.get("name"))
+        .containsExactly("Sci-Fi");
+    assertThat((List<Map<String, Object>>) movieData.get("ratings"))
+        .extracting(rating -> rating.get("source"), rating -> rating.get("value"))
+        .containsExactly(tuple("IMDb", "8.8"));
+    assertThat((List<Map<String, Object>>) movieData.get("reviews"))
+        .extracting(review -> review.get("author"))
+        .containsExactly("Roger Ebert");
+    assertThat((List<Map<String, Object>>) movieData.get("files")).hasSize(1);
+  }
+
+  private Movie createMovieWithRelationships() {
+    var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
+    var actor =
+        personRepository.save(
+            Person.builder().name("Leonardo DiCaprio").sourceId(uniqueSourceId()).build());
+    var director =
+        personRepository.save(
+            Person.builder().name("Christopher Nolan").sourceId(uniqueSourceId()).build());
+    var studio =
+        companyRepository.save(
+            Company.builder().name("Warner Bros").sourceId(uniqueSourceId()).build());
+    var genre =
+        genreRepository.save(Genre.builder().name("Sci-Fi").sourceId(uniqueSourceId()).build());
+
+    var movie =
+        movieRepository.saveAndFlush(
+            Movie.builder()
+                .title("Inception")
+                .library(library)
+                .studios(Set.of(studio))
+                .cast(List.of(actor))
+                .directors(List.of(director))
+                .genres(Set.of(genre))
+                .build());
+
+    ratingRepository.save(Rating.builder().movie(movie).source("IMDb").value("8.8").build());
+    reviewRepository.save(Review.builder().movie(movie).author("Roger Ebert").build());
+    mediaFileRepository.save(
+        MediaFile.builder()
+            .mediaId(movie.getId())
+            .libraryId(library.getId())
+            .status(MediaFileStatus.MATCHED)
+            .filename("inception.mkv")
+            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .build());
+
+    return movie;
+  }
+
+  private String uniqueSourceId() {
+    return "movie-resolver-it-" + UUID.randomUUID();
+  }
+}

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeasonFieldResolverTest.java
@@ -101,4 +101,31 @@ class SeasonFieldResolverTest {
 
     assertThat(filepathUri).isEqualTo("/media/shows/Breaking Bad/Season 1/breaking.bad.s01e01.mkv");
   }
+
+  @Test
+  @DisplayName("Should return series not found error when season references missing series")
+  void shouldReturnSeriesNotFoundErrorWhenSeasonReferencesMissingSeries() {
+    var seriesId = UUID.randomUUID();
+    var series = Series.builder().title("Breaking Bad").build();
+    series.setId(seriesId);
+
+    var seasonId = UUID.randomUUID();
+    var season = Season.builder().title("Season 1").seasonNumber(1).series(series).build();
+    season.setId(seasonId);
+
+    when(seriesService.findSeasonById(seasonId)).thenReturn(Optional.of(season));
+    when(seriesService.findById(seriesId)).thenReturn(Optional.empty());
+
+    var result =
+        dgsQueryExecutor.execute(
+            String.format("{ season(id: \"%s\") { series { title } } }", seasonId));
+
+    assertThat(result.getErrors())
+        .singleElement()
+        .satisfies(
+            error ->
+                assertThat(error.getMessage())
+                    .contains("Series not found: " + seriesId)
+                    .contains(seasonId.toString()));
+  }
 }

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
@@ -64,6 +64,44 @@ class SeriesResolverIT extends AbstractIntegrationTest {
   }
 
   @Test
+  @DisplayName("Should resolve seasons by season number from series query")
+  @SuppressWarnings("unchecked")
+  void shouldResolveSeasonsBySeasonNumberFromSeriesQuery() {
+    var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+    var series = createSeries(library);
+    seasonRepository.saveAllAndFlush(
+        List.of(
+            createSeason(library, series, 2),
+            createSeason(library, series, 3),
+            createSeason(library, series, 4),
+            createSeason(library, series, 1),
+            createSeason(library, series, 5)));
+
+    var result =
+        dgsQueryExecutor.execute(
+            """
+            {
+              series(id: "%s") {
+                seasons {
+                  seasonNumber
+                }
+              }
+            }
+            """
+                .formatted(series.getId()));
+
+    assertThat(result.getErrors()).isEmpty();
+
+    Map<String, Object> data = result.getData();
+    var seriesData = (Map<String, Object>) data.get("series");
+    var seasons = (List<Map<String, Object>>) seriesData.get("seasons");
+
+    assertThat(seasons)
+        .extracting(season -> season.get("seasonNumber"))
+        .containsExactly(1, 2, 3, 4, 5);
+  }
+
+  @Test
   @DisplayName("Should resolve episodes by episode number from season query")
   @SuppressWarnings("unchecked")
   void shouldResolveEpisodesByEpisodeNumberFromSeasonQuery() {
@@ -102,8 +140,11 @@ class SeriesResolverIT extends AbstractIntegrationTest {
   private Season createSeason() {
     var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
     var series = createSeries(library);
-    return seasonRepository.saveAndFlush(
-        Season.builder().seasonNumber(1).series(series).library(library).build());
+    return seasonRepository.saveAndFlush(createSeason(library, series, 1));
+  }
+
+  private Season createSeason(Library library, Series series, int seasonNumber) {
+    return Season.builder().seasonNumber(seasonNumber).series(series).library(library).build();
   }
 
   private Series createSeries(Library library) {

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
@@ -1,0 +1,127 @@
+package com.streamarr.server.graphql.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.graphql.dgs.DgsQueryExecutor;
+import com.netflix.graphql.dgs.test.EnableDgsTest;
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.EpisodeRepository;
+import com.streamarr.server.repositories.media.SeasonRepository;
+import com.streamarr.server.repositories.media.SeriesRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@EnableDgsTest
+@DisplayName("Series Resolver Integration Tests")
+class SeriesResolverIT extends AbstractIntegrationTest {
+
+  @Autowired private DgsQueryExecutor dgsQueryExecutor;
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private SeriesRepository seriesRepository;
+  @Autowired private SeasonRepository seasonRepository;
+  @Autowired private EpisodeRepository episodeRepository;
+
+  @Test
+  @DisplayName("Should resolve series scalar fields from season query")
+  @SuppressWarnings("unchecked")
+  void shouldResolveSeriesScalarFieldsFromSeasonQuery() {
+    var season = createSeason();
+
+    var result =
+        dgsQueryExecutor.execute(
+            """
+            {
+              season(id: "%s") {
+                series {
+                  title
+                  firstAirDate
+                }
+              }
+            }
+            """
+                .formatted(season.getId()));
+
+    assertThat(result.getErrors()).isEmpty();
+
+    Map<String, Object> data = result.getData();
+    var seasonData = (Map<String, Object>) data.get("season");
+    var seriesData = (Map<String, Object>) seasonData.get("series");
+
+    assertThat(seriesData.get("title")).isEqualTo("The Vampire Diaries");
+    assertThat(seriesData.get("firstAirDate")).isEqualTo("2009-09-10");
+  }
+
+  @Test
+  @DisplayName("Should resolve episodes by episode number from season query")
+  @SuppressWarnings("unchecked")
+  void shouldResolveEpisodesByEpisodeNumberFromSeasonQuery() {
+    var season = createSeason();
+    var library = season.getLibrary();
+    episodeRepository.saveAllAndFlush(
+        List.of(
+            createEpisode(library, season, 1),
+            createEpisode(library, season, 17),
+            createEpisode(library, season, 2)));
+
+    var result =
+        dgsQueryExecutor.execute(
+            """
+            {
+              season(id: "%s") {
+                episodes {
+                  episodeNumber
+                }
+              }
+            }
+            """
+                .formatted(season.getId()));
+
+    assertThat(result.getErrors()).isEmpty();
+
+    Map<String, Object> data = result.getData();
+    var seasonData = (Map<String, Object>) data.get("season");
+    var episodes = (List<Map<String, Object>>) seasonData.get("episodes");
+
+    assertThat(episodes)
+        .extracting(episode -> episode.get("episodeNumber"))
+        .containsExactly(1, 2, 17);
+  }
+
+  private Season createSeason() {
+    var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+    var series = createSeries(library);
+    return seasonRepository.saveAndFlush(
+        Season.builder().seasonNumber(1).series(series).library(library).build());
+  }
+
+  private Series createSeries(Library library) {
+    return seriesRepository.saveAndFlush(
+        Series.builder()
+            .title("The Vampire Diaries")
+            .titleSort("Vampire Diaries, The")
+            .firstAirDate(LocalDate.parse("2009-09-10"))
+            .library(library)
+            .build());
+  }
+
+  private Episode createEpisode(Library library, Season season, int episodeNumber) {
+    return Episode.builder()
+        .episodeNumber(episodeNumber)
+        .title("Episode %d".formatted(episodeNumber))
+        .library(library)
+        .season(season)
+        .build();
+  }
+}

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
@@ -76,9 +76,9 @@ class SeriesResolverIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @DisplayName("Should resolve seasons by season number from series query")
+  @DisplayName("Should return seasons ordered by season number from series query")
   @SuppressWarnings("unchecked")
-  void shouldResolveSeasonsBySeasonNumberFromSeriesQuery() {
+  void shouldReturnSeasonsOrderedBySeasonNumberFromSeriesQuery() {
     var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
     var series = createSeries(library);
     seasonRepository.saveAllAndFlush(
@@ -114,9 +114,9 @@ class SeriesResolverIT extends AbstractIntegrationTest {
   }
 
   @Test
-  @DisplayName("Should resolve episodes by episode number from season query")
+  @DisplayName("Should return episodes ordered by episode number from season query")
   @SuppressWarnings("unchecked")
-  void shouldResolveEpisodesByEpisodeNumberFromSeasonQuery() {
+  void shouldReturnEpisodesOrderedByEpisodeNumberFromSeasonQuery() {
     var season = createSeason();
     var library = season.getLibrary();
     episodeRepository.saveAllAndFlush(

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
@@ -86,6 +86,7 @@ class SeriesResolverIT extends AbstractIntegrationTest {
             createSeason(library, series, 2),
             createSeason(library, series, 3),
             createSeason(library, series, 4),
+            createSeason(library, series, 0),
             createSeason(library, series, 1),
             createSeason(library, series, 5)));
 
@@ -110,7 +111,7 @@ class SeriesResolverIT extends AbstractIntegrationTest {
 
     assertThat(seasons)
         .extracting(season -> season.get("seasonNumber"))
-        .containsExactly(1, 2, 3, 4, 5);
+        .containsExactly(0, 1, 2, 3, 4, 5);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
@@ -59,8 +59,9 @@ class SeriesResolverIT extends AbstractIntegrationTest {
     var seasonData = (Map<String, Object>) data.get("season");
     var seriesData = (Map<String, Object>) seasonData.get("series");
 
-    assertThat(seriesData.get("title")).isEqualTo("The Vampire Diaries");
-    assertThat(seriesData.get("firstAirDate")).isEqualTo("2009-09-10");
+    assertThat(seriesData)
+        .containsEntry("title", "The Vampire Diaries")
+        .containsEntry("firstAirDate", "2009-09-10");
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/SeriesResolverIT.java
@@ -9,14 +9,22 @@ import com.streamarr.server.domain.Library;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.metadata.Company;
+import com.streamarr.server.domain.metadata.Genre;
+import com.streamarr.server.domain.metadata.Person;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.CompanyRepository;
+import com.streamarr.server.repositories.GenreRepository;
 import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.PersonRepository;
 import com.streamarr.server.repositories.media.EpisodeRepository;
 import com.streamarr.server.repositories.media.SeasonRepository;
 import com.streamarr.server.repositories.media.SeriesRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -32,6 +40,9 @@ class SeriesResolverIT extends AbstractIntegrationTest {
   @Autowired private SeriesRepository seriesRepository;
   @Autowired private SeasonRepository seasonRepository;
   @Autowired private EpisodeRepository episodeRepository;
+  @Autowired private PersonRepository personRepository;
+  @Autowired private CompanyRepository companyRepository;
+  @Autowired private GenreRepository genreRepository;
 
   @Test
   @DisplayName("Should resolve series scalar fields from season query")
@@ -136,6 +147,72 @@ class SeriesResolverIT extends AbstractIntegrationTest {
     assertThat(episodes)
         .extracting(episode -> episode.get("episodeNumber"))
         .containsExactly(1, 2, 17);
+  }
+
+  @Test
+  @DisplayName("Should resolve studios cast directors and genres from series query")
+  @SuppressWarnings("unchecked")
+  void shouldResolveStudiosCastDirectorsAndGenresFromSeriesQuery() {
+    var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+    var actor =
+        personRepository.save(
+            Person.builder().name("Nina Dobrev").sourceId(uniqueSourceId()).build());
+    var director =
+        personRepository.save(
+            Person.builder().name("Kevin Williamson").sourceId(uniqueSourceId()).build());
+    var studio =
+        companyRepository.save(
+            Company.builder().name("Warner Bros").sourceId(uniqueSourceId()).build());
+    var genre =
+        genreRepository.save(Genre.builder().name("Fantasy").sourceId(uniqueSourceId()).build());
+
+    var series =
+        seriesRepository.saveAndFlush(
+            Series.builder()
+                .title("The Vampire Diaries")
+                .titleSort("Vampire Diaries, The")
+                .library(library)
+                .studios(Set.of(studio))
+                .cast(List.of(actor))
+                .directors(List.of(director))
+                .genres(Set.of(genre))
+                .build());
+
+    var result =
+        dgsQueryExecutor.execute(
+            """
+            {
+              series(id: "%s") {
+                studios { name }
+                cast { name }
+                directors { name }
+                genres { name }
+              }
+            }
+            """
+                .formatted(series.getId()));
+
+    assertThat(result.getErrors()).isEmpty();
+
+    Map<String, Object> data = result.getData();
+    var seriesData = (Map<String, Object>) data.get("series");
+
+    assertThat((List<Map<String, Object>>) seriesData.get("studios"))
+        .extracting(studioData -> studioData.get("name"))
+        .containsExactly("Warner Bros");
+    assertThat((List<Map<String, Object>>) seriesData.get("cast"))
+        .extracting(castData -> castData.get("name"))
+        .containsExactly("Nina Dobrev");
+    assertThat((List<Map<String, Object>>) seriesData.get("directors"))
+        .extracting(directorData -> directorData.get("name"))
+        .containsExactly("Kevin Williamson");
+    assertThat((List<Map<String, Object>>) seriesData.get("genres"))
+        .extracting(genreData -> genreData.get("name"))
+        .containsExactly("Fantasy");
+  }
+
+  private String uniqueSourceId() {
+    return "series-resolver-it-" + UUID.randomUUID();
   }
 
   private Season createSeason() {

--- a/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/WatchProgressFieldResolverTest.java
@@ -568,6 +568,7 @@ class WatchProgressFieldResolverTest {
       when(seriesService.findById(seriesId)).thenReturn(Optional.of(series));
       when(seriesService.findSeasons(seriesId)).thenReturn(List.of(season));
       when(seriesService.findEpisodes(seasonId)).thenReturn(List.of(episode));
+      when(seriesService.findSeasonById(seasonId)).thenReturn(Optional.of(season));
 
       Integer seasonNumber =
           dgsQueryExecutor.executeAndExtractJsonPath(

--- a/src/test/java/com/streamarr/server/services/SeriesServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/SeriesServiceTest.java
@@ -344,7 +344,7 @@ class SeriesServiceTest {
 
       var season = seriesService.createSeasonWithEpisodes(series, details, library);
 
-      var savedEpisodes = episodeRepository.findBySeasonId(season.getId());
+      var savedEpisodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
       var episodeEvents =
           eventPublisher.getEventsOfType(MetadataEnrichedEvent.class).stream()
               .filter(e -> e.entityType() == ImageEntityType.EPISODE)
@@ -428,7 +428,7 @@ class SeriesServiceTest {
       assertThat(season.getAirDate()).isEqualTo(java.time.LocalDate.of(2008, 1, 20));
       assertThat(season.getSeries().getId()).isEqualTo(series.getId());
 
-      var episodes = episodeRepository.findBySeasonId(season.getId());
+      var episodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
       assertThat(episodes).hasSize(2);
       assertThat(episodes).extracting(Episode::getEpisodeNumber).containsExactlyInAnyOrder(1, 2);
       assertThat(episodes)
@@ -458,7 +458,7 @@ class SeriesServiceTest {
 
       assertThat(season.getTitle()).isEqualTo("Specials");
       assertThat(season.getSeasonNumber()).isZero();
-      assertThat(episodeRepository.findBySeasonId(season.getId())).isEmpty();
+      assertThat(episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId())).isEmpty();
 
       var events = eventPublisher.getEventsOfType(MetadataEnrichedEvent.class);
       assertThat(events)
@@ -503,7 +503,7 @@ class SeriesServiceTest {
 
       var season = seriesService.createSeasonWithEpisodes(series, details, library);
 
-      var savedEpisodes = episodeRepository.findBySeasonId(season.getId());
+      var savedEpisodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
       assertThat(savedEpisodes).hasSize(3);
 
       var episodeEvents =
@@ -691,7 +691,7 @@ class SeriesServiceTest {
       assertThat(result.getTitle()).isEqualTo("Season 1");
       assertThat(result.getOverview()).isEqualTo("Updated overview");
       assertThat(result.getAirDate()).isEqualTo(LocalDate.of(2008, 1, 20));
-      assertThat(seasonRepository.findBySeriesId(series.getId())).hasSize(1);
+      assertThat(seasonRepository.findBySeriesIdOrderBySeasonNumber(series.getId())).hasSize(1);
     }
 
     @Test
@@ -758,7 +758,7 @@ class SeriesServiceTest {
 
       seriesService.refreshSeasonWithEpisodes(series, details, library);
 
-      var episodes = episodeRepository.findBySeasonId(season.getId());
+      var episodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
       assertThat(episodes).hasSize(1);
       assertThat(episodes.getFirst().getId()).isEqualTo(existingEpisode.getId());
       assertThat(episodes.getFirst().getTitle()).isEqualTo("Pilot");
@@ -808,7 +808,7 @@ class SeriesServiceTest {
 
       seriesService.refreshSeasonWithEpisodes(series, details, library);
 
-      var episodes = episodeRepository.findBySeasonId(season.getId());
+      var episodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
       assertThat(episodes).hasSize(2);
       assertThat(episodes)
           .extracting(Episode::getTitle)

--- a/src/test/java/com/streamarr/server/services/SeriesServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/SeriesServiceTest.java
@@ -123,6 +123,30 @@ class SeriesServiceTest {
 
       assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("Should return seasons ordered by season number when saved out of order")
+    void shouldReturnSeasonsOrderedBySeasonNumberWhenSavedOutOfOrder() {
+      var series = seriesRepository.save(Series.builder().title("Breaking Bad").build());
+      seasonRepository.save(Season.builder().seasonNumber(2).series(series).build());
+      seasonRepository.save(Season.builder().seasonNumber(1).series(series).build());
+
+      var result = seriesService.findSeasons(series.getId());
+
+      assertThat(result).extracting(Season::getSeasonNumber).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("Should return episodes ordered by episode number when saved out of order")
+    void shouldReturnEpisodesOrderedByEpisodeNumberWhenSavedOutOfOrder() {
+      var season = seasonRepository.save(Season.builder().seasonNumber(1).build());
+      episodeRepository.save(Episode.builder().episodeNumber(2).season(season).build());
+      episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
+
+      var result = seriesService.findEpisodes(season.getId());
+
+      assertThat(result).extracting(Episode::getEpisodeNumber).containsExactly(1, 2);
+    }
   }
 
   @Nested

--- a/src/test/java/com/streamarr/server/services/library/LibraryRefreshServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/library/LibraryRefreshServiceTest.java
@@ -251,11 +251,11 @@ class LibraryRefreshServiceTest {
 
     refreshService.refreshLibrary(library);
 
-    var seasons = seasonRepository.findBySeriesId(series.getId());
+    var seasons = seasonRepository.findBySeriesIdOrderBySeasonNumber(series.getId());
     assertThat(seasons).hasSize(1);
     assertThat(seasons.getFirst().getTitle()).isEqualTo("Season 1");
 
-    var episodes = episodeRepository.findBySeasonId(seasons.getFirst().getId());
+    var episodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(seasons.getFirst().getId());
     assertThat(episodes).hasSize(1);
     assertThat(episodes.getFirst().getTitle()).isEqualTo("Pilot");
   }
@@ -330,7 +330,7 @@ class LibraryRefreshServiceTest {
 
     refreshService.refreshLibrary(library);
 
-    var seasons = seasonRepository.findBySeriesId(series.getId());
+    var seasons = seasonRepository.findBySeriesIdOrderBySeasonNumber(series.getId());
     assertThat(seasons).hasSize(1);
     assertThat(seasons.getFirst().getTitle()).isEqualTo("Season 2");
   }
@@ -416,7 +416,7 @@ class LibraryRefreshServiceTest {
 
     refreshService.refreshLibrary(library);
 
-    assertThat(seasonRepository.findBySeriesId(series.getId())).isEmpty();
+    assertThat(seasonRepository.findBySeriesIdOrderBySeasonNumber(series.getId())).isEmpty();
   }
 
   private Library buildSeriesLibrary() {

--- a/src/test/java/com/streamarr/server/services/library/MovieFileProcessorTest.java
+++ b/src/test/java/com/streamarr/server/services/library/MovieFileProcessorTest.java
@@ -155,4 +155,47 @@ class MovieFileProcessorTest {
     assertThat(fakeMediaFileRepository.findById(mediaFile.getId()).orElseThrow().getStatus())
         .isEqualTo(MediaFileStatus.UNMATCHED);
   }
+
+  @Test
+  @DisplayName("Should mark metadata parsing failed when filename is blank")
+  void shouldMarkMetadataParsingFailedWhenFilenameIsBlank() {
+    var library = LibraryFixtureCreator.buildFakeLibrary();
+
+    var mediaFile =
+        fakeMediaFileRepository.save(
+            MediaFile.builder()
+                .libraryId(library.getId())
+                .filepathUri("file:///library/unknown/")
+                .filename("")
+                .status(MediaFileStatus.UNMATCHED)
+                .build());
+
+    movieFileProcessor.process(library, mediaFile);
+
+    assertThat(fakeMediaFileRepository.findById(mediaFile.getId()).orElseThrow().getStatus())
+        .isEqualTo(MediaFileStatus.METADATA_PARSING_FAILED);
+  }
+
+  @Test
+  @DisplayName("Should mark metadata search failed when provider finds no match")
+  void shouldMarkMetadataSearchFailedWhenProviderFindsNoMatch() {
+    var library = LibraryFixtureCreator.buildFakeLibrary();
+
+    var mediaFile =
+        fakeMediaFileRepository.save(
+            MediaFile.builder()
+                .libraryId(library.getId())
+                .filepathUri("file:///library/Obscure%20Film%20(1999)/Obscure.Film.1999.mkv")
+                .filename("Obscure.Film.1999.mkv")
+                .status(MediaFileStatus.UNMATCHED)
+                .build());
+
+    when(tmdbMovieProvider.getAgentStrategy()).thenReturn(ExternalAgentStrategy.TMDB);
+    when(tmdbMovieProvider.search(any(VideoFileParserResult.class))).thenReturn(Optional.empty());
+
+    movieFileProcessor.process(library, mediaFile);
+
+    assertThat(fakeMediaFileRepository.findById(mediaFile.getId()).orElseThrow().getStatus())
+        .isEqualTo(MediaFileStatus.METADATA_SEARCH_FAILED);
+  }
 }

--- a/src/test/java/com/streamarr/server/services/library/SeriesFileProcessorTest.java
+++ b/src/test/java/com/streamarr/server/services/library/SeriesFileProcessorTest.java
@@ -223,4 +223,48 @@ class SeriesFileProcessorTest {
     assertThat(fakeMediaFileRepository.findById(mediaFile.getId()).orElseThrow().getStatus())
         .isEqualTo(MediaFileStatus.ENRICHMENT_FAILED);
   }
+
+  @Test
+  @DisplayName("Should mark metadata parsing failed when path has no episode info")
+  void shouldMarkMetadataParsingFailedWhenPathHasNoEpisodeInfo() {
+    var library = LibraryFixtureCreator.buildFakeSeriesLibrary();
+
+    var mediaFile =
+        fakeMediaFileRepository.save(
+            MediaFile.builder()
+                .libraryId(library.getId())
+                .filepathUri("file:///library/Nature%20Documentary/beach.mkv")
+                .filename("beach.mkv")
+                .status(MediaFileStatus.UNMATCHED)
+                .build());
+
+    seriesFileProcessor.process(library, mediaFile);
+
+    assertThat(fakeMediaFileRepository.findById(mediaFile.getId()).orElseThrow().getStatus())
+        .isEqualTo(MediaFileStatus.METADATA_PARSING_FAILED);
+  }
+
+  @Test
+  @DisplayName("Should mark metadata search failed when provider finds no match")
+  void shouldMarkMetadataSearchFailedWhenProviderFindsNoMatch() {
+    var library = LibraryFixtureCreator.buildFakeSeriesLibrary();
+
+    var mediaFile =
+        fakeMediaFileRepository.save(
+            MediaFile.builder()
+                .libraryId(library.getId())
+                .filepathUri("file:///library/Unknown%20Show/Season%2001/Unknown.Show.S01E01.mkv")
+                .filename("Unknown.Show.S01E01.mkv")
+                .status(MediaFileStatus.UNMATCHED)
+                .build());
+
+    when(seriesMetadataProvider.getAgentStrategy()).thenReturn(ExternalAgentStrategy.TMDB);
+    when(seriesMetadataProvider.search(any(VideoFileParserResult.class)))
+        .thenReturn(Optional.empty());
+
+    seriesFileProcessor.process(library, mediaFile);
+
+    assertThat(fakeMediaFileRepository.findById(mediaFile.getId()).orElseThrow().getStatus())
+        .isEqualTo(MediaFileStatus.METADATA_SEARCH_FAILED);
+  }
 }

--- a/src/test/java/com/streamarr/server/services/library/SeriesScanningIT.java
+++ b/src/test/java/com/streamarr/server/services/library/SeriesScanningIT.java
@@ -98,7 +98,7 @@ class SeriesScanningIT extends AbstractWireMockIntegrationTest {
     assertThat(season.getSeasonNumber()).isEqualTo(1);
     assertThat(season.getTitle()).isEqualTo("Season 1");
 
-    var episodes = episodeRepository.findBySeasonId(season.getId());
+    var episodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
     assertThat(episodes).hasSize(7);
     assertThat(episodes).extracting("episodeNumber").containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6, 7);
 
@@ -130,7 +130,7 @@ class SeriesScanningIT extends AbstractWireMockIntegrationTest {
     assertThat(seasonRepository.findAll()).hasSize(1);
 
     var season = seasonRepository.findAll().getFirst();
-    assertThat(episodeRepository.findBySeasonId(season.getId())).hasSize(7);
+    assertThat(episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId())).hasSize(7);
 
     var mediaFiles = mediaFileRepository.findByLibraryId(library.getId());
     assertThat(mediaFiles).hasSize(2).allMatch(mf -> mf.getStatus() == MediaFileStatus.MATCHED);
@@ -162,8 +162,8 @@ class SeriesScanningIT extends AbstractWireMockIntegrationTest {
 
     var season1 = seasons.stream().filter(s -> s.getSeasonNumber() == 1).findFirst().orElseThrow();
     var season2 = seasons.stream().filter(s -> s.getSeasonNumber() == 2).findFirst().orElseThrow();
-    assertThat(episodeRepository.findBySeasonId(season1.getId())).hasSize(7);
-    assertThat(episodeRepository.findBySeasonId(season2.getId())).hasSize(2);
+    assertThat(episodeRepository.findBySeasonIdOrderByEpisodeNumber(season1.getId())).hasSize(7);
+    assertThat(episodeRepository.findBySeasonIdOrderByEpisodeNumber(season2.getId())).hasSize(2);
   }
 
   @Test
@@ -287,7 +287,7 @@ class SeriesScanningIT extends AbstractWireMockIntegrationTest {
     libraryManagementService.processDiscoveredFile(library.getId(), file);
 
     var season = seasonRepository.findAll().getFirst();
-    var episodes = episodeRepository.findBySeasonId(season.getId());
+    var episodes = episodeRepository.findBySeasonIdOrderByEpisodeNumber(season.getId());
     assertThat(episodes).hasSize(8);
 
     var ep99 = episodeRepository.findBySeasonIdAndEpisodeNumber(season.getId(), 99);

--- a/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalFfprobeServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalFfprobeServiceTest.java
@@ -623,6 +623,79 @@ class LocalFfprobeServiceTest {
         .hasMessage(TranscodeException.GENERIC_MESSAGE);
   }
 
+  @Test
+  @DisplayName("Should ignore explicit null metadata when stream fields are null")
+  void shouldIgnoreExplicitNullMetadataWhenStreamFieldsAreNull() {
+    var json =
+        """
+        {
+          "streams": [
+            {
+              "index": null,
+              "codec_type": "video",
+              "codec_name": "h264",
+              "width": 1920,
+              "height": 1080,
+              "r_frame_rate": "24/1",
+              "tags": null,
+              "disposition": null
+            },
+            {
+              "codec_type": "audio",
+              "codec_name": "aac",
+              "channels": null,
+              "bit_rate": null,
+              "tags": { "language": null },
+              "disposition": { "default": null, "forced": 1 }
+            }
+          ],
+          "format": {
+            "duration": "60.0",
+            "bit_rate": "5000000"
+          }
+        }
+        """;
+
+    var service = new LocalFfprobeService(objectMapper, path -> createFakeProcess(json, 0));
+
+    var probe = service.probe(Path.of("/test/movie.mkv"));
+
+    var video = probe.streams().getFirst();
+    assertThat(video.index()).isZero();
+    assertThat(video.language()).isEmpty();
+    assertThat(video.isDefault()).isFalse();
+
+    var audio = probe.streams().get(1);
+    assertThat(audio.index()).isEqualTo(1);
+    assertThat(audio.language()).isEmpty();
+    assertThat(audio.channels()).isEmpty();
+    assertThat(audio.bitrate()).isEmpty();
+    assertThat(audio.isDefault()).isFalse();
+    assertThat(audio.isForced()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should throw with generic message when streams key is missing")
+  void shouldThrowWithGenericMessageWhenStreamsKeyIsMissing() {
+    var json =
+        """
+        {
+          "format": {
+            "duration": "60.0",
+            "bit_rate": "5000000"
+          }
+        }
+        """;
+
+    var service = new LocalFfprobeService(objectMapper, path -> createFakeProcess(json, 0));
+
+    var filePath = Path.of("/test/movie.mkv");
+
+    assertThatThrownBy(() -> service.probe(filePath))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessage(TranscodeException.GENERIC_MESSAGE);
+  }
+
   private Process createFakeProcess(String stdout, int exitCode) {
     return new FakeProcess(stdout, exitCode);
   }

--- a/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceIT.java
@@ -105,6 +105,10 @@ class WatchStatusServiceIT extends AbstractIntegrationTest {
 
     watchStatusService.markUnwatched(userId, series.getId());
 
+    assertThat(
+            watchHistoryRepository.findByUserIdAndCollectableIdIn(userId, List.of(episode.getId())))
+        .isNotEmpty()
+        .allSatisfy(entry -> assertThat(entry.getDismissedAt()).isNotNull());
     assertThat(watchStatusService.getWatchStatusForSeries(userId, List.of(series.getId())))
         .containsEntry(series.getId(), WatchStatus.UNWATCHED);
     assertThat(sessionProgressRepository.findByUserIdAndMediaFileIdIn(userId, Set.of(mediaFileId)))

--- a/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceIT.java
@@ -1,0 +1,145 @@
+package com.streamarr.server.services.watchprogress;
+
+import static com.streamarr.server.fixtures.SessionProgressFixture.progressBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.Episode;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.domain.media.MediaFileStatus;
+import com.streamarr.server.domain.media.Season;
+import com.streamarr.server.domain.media.Series;
+import com.streamarr.server.domain.streaming.CollectableScope;
+import com.streamarr.server.domain.streaming.WatchHistory;
+import com.streamarr.server.domain.streaming.WatchStatus;
+import com.streamarr.server.fixtures.LibraryFixtureCreator;
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.EpisodeRepository;
+import com.streamarr.server.repositories.media.SeasonRepository;
+import com.streamarr.server.repositories.media.SeriesRepository;
+import com.streamarr.server.repositories.streaming.SessionProgressRepository;
+import com.streamarr.server.repositories.streaming.WatchHistoryRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Watch Status Service Integration Tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WatchStatusServiceIT extends AbstractIntegrationTest {
+
+  @Autowired private LibraryRepository libraryRepository;
+  @Autowired private SeriesRepository seriesRepository;
+  @Autowired private SeasonRepository seasonRepository;
+  @Autowired private EpisodeRepository episodeRepository;
+  @Autowired private WatchHistoryRepository watchHistoryRepository;
+  @Autowired private SessionProgressRepository sessionProgressRepository;
+  @Autowired private WatchStatusService watchStatusService;
+
+  private Library library;
+
+  @BeforeAll
+  void setup() {
+    library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeSeriesLibrary());
+  }
+
+  @Test
+  @DisplayName("Should write history for every episode when marking series watched by id")
+  void shouldWriteHistoryForEveryEpisodeWhenMarkingSeriesWatchedById() {
+    var userId = UUID.randomUUID();
+    var series = createSeries("Fully Watched Series");
+    var seasonOne = createSeason(series, 1);
+    var seasonTwo = createSeason(series, 2);
+    var episodeIds =
+        List.of(
+            createEpisode(seasonOne, 1).getId(),
+            createEpisode(seasonOne, 2).getId(),
+            createEpisode(seasonTwo, 1).getId(),
+            createEpisode(seasonTwo, 2).getId());
+
+    watchStatusService.markWatched(userId, series.getId());
+
+    var history = watchHistoryRepository.findByUserIdAndCollectableIdIn(userId, episodeIds);
+    assertThat(history)
+        .extracting(WatchHistory::getCollectableId)
+        .containsExactlyInAnyOrderElementsOf(episodeIds);
+    assertThat(watchStatusService.getWatchStatusForSeries(userId, List.of(series.getId())))
+        .containsEntry(series.getId(), WatchStatus.WATCHED);
+  }
+
+  @Test
+  @DisplayName("Should insert history once when marking series watched twice at same instant")
+  void shouldInsertHistoryOnceWhenMarkingSeriesWatchedTwiceAtSameInstant() {
+    var userId = UUID.randomUUID();
+    var series = createSeries("Idempotent Series");
+    var season = createSeason(series, 1);
+    var episodeIds = List.of(createEpisode(season, 1).getId(), createEpisode(season, 2).getId());
+    var watchedAt = Instant.parse("2026-07-07T12:00:00Z");
+
+    watchStatusService.markWatched(userId, series.getId(), CollectableScope.SERIES, watchedAt, 0);
+    watchStatusService.markWatched(userId, series.getId(), CollectableScope.SERIES, watchedAt, 0);
+
+    assertThat(watchHistoryRepository.findByUserIdAndCollectableIdIn(userId, episodeIds))
+        .hasSize(2);
+  }
+
+  @Test
+  @DisplayName("Should dismiss history and delete progress when marking series unwatched")
+  void shouldDismissHistoryAndDeleteProgressWhenMarkingSeriesUnwatched() {
+    var userId = UUID.randomUUID();
+    var series = createSeries("Reset Series");
+    var season = createSeason(series, 1);
+    var episode = createEpisodeWithFile(season, 1);
+    var mediaFileId = episode.getFiles().iterator().next().getId();
+    sessionProgressRepository.saveAndFlush(
+        progressBuilder(userId, mediaFileId).positionSeconds(900).build());
+    watchStatusService.markWatched(userId, series.getId());
+
+    watchStatusService.markUnwatched(userId, series.getId());
+
+    assertThat(watchStatusService.getWatchStatusForSeries(userId, List.of(series.getId())))
+        .containsEntry(series.getId(), WatchStatus.UNWATCHED);
+    assertThat(sessionProgressRepository.findByUserIdAndMediaFileIdIn(userId, Set.of(mediaFileId)))
+        .isEmpty();
+  }
+
+  private Series createSeries(String title) {
+    return seriesRepository.saveAndFlush(
+        Series.builder().title(title).titleSort(title).library(library).build());
+  }
+
+  private Season createSeason(Series series, int seasonNumber) {
+    return seasonRepository.saveAndFlush(
+        Season.builder().seasonNumber(seasonNumber).series(series).library(library).build());
+  }
+
+  private Episode createEpisode(Season season, int episodeNumber) {
+    return episodeRepository.saveAndFlush(
+        Episode.builder().episodeNumber(episodeNumber).season(season).library(library).build());
+  }
+
+  private Episode createEpisodeWithFile(Season season, int episodeNumber) {
+    var file =
+        MediaFile.builder()
+            .libraryId(library.getId())
+            .status(MediaFileStatus.MATCHED)
+            .filename("episode.mkv")
+            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .build();
+    return episodeRepository.saveAndFlush(
+        Episode.builder()
+            .episodeNumber(episodeNumber)
+            .season(season)
+            .library(library)
+            .files(Set.of(file))
+            .build());
+  }
+}

--- a/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceIT.java
@@ -132,7 +132,7 @@ class WatchStatusServiceIT extends AbstractIntegrationTest {
             .libraryId(library.getId())
             .status(MediaFileStatus.MATCHED)
             .filename("episode.mkv")
-            .filepathUri("/media/" + UUID.randomUUID() + ".mkv")
+            .filepathUri("file:///media/" + UUID.randomUUID() + ".mkv")
             .build();
     return episodeRepository.saveAndFlush(
         Episode.builder()

--- a/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceTest.java
@@ -353,8 +353,8 @@ class WatchStatusServiceTest {
     }
 
     @Test
-    @DisplayName("Should return unwatched when series seasons have no episodes")
-    void shouldReturnUnwatchedWhenSeriesSeasonsHaveNoEpisodes() {
+    @DisplayName("Should return unwatched when series has no episodes or no watch history")
+    void shouldReturnUnwatchedWhenSeriesHasNoEpisodesOrNoHistory() {
       var populated = buildSeries();
       var populatedSeason =
           seasonRepository.save(Season.builder().seasonNumber(1).series(populated).build());

--- a/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceTest.java
@@ -6,6 +6,7 @@ import static com.streamarr.server.fixtures.MediaEntityFixture.buildSeries;
 import static com.streamarr.server.fixtures.SessionProgressFixture.progressBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.streamarr.server.domain.AuditFieldSetter;
 import com.streamarr.server.domain.media.Episode;
 import com.streamarr.server.domain.media.Season;
 import com.streamarr.server.domain.streaming.CollectableScope;
@@ -282,6 +283,126 @@ class WatchStatusServiceTest {
       assertThat(result)
           .containsEntry(s1.getId(), WatchStatus.IN_PROGRESS)
           .containsEntry(s2.getId(), WatchStatus.UNWATCHED);
+    }
+  }
+
+  @Nested
+  @DisplayName("Scope Resolution")
+  class ScopeResolution {
+
+    @Test
+    @DisplayName("Should resolve season scope when marking season watched by id")
+    void shouldResolveSeasonScopeWhenMarkingSeasonWatchedById() {
+      var season = seasonRepository.save(Season.builder().seasonNumber(1).build());
+      episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
+      episodeRepository.save(Episode.builder().episodeNumber(2).season(season).build());
+
+      service.markWatched(USER_ID, season.getId());
+
+      assertThat(watchHistoryRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Should dismiss all episode history when marking season unwatched explicitly")
+    void shouldDismissAllEpisodeHistoryWhenMarkingSeasonUnwatchedExplicitly() {
+      var season = seasonRepository.save(Season.builder().seasonNumber(1).build());
+      episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
+      episodeRepository.save(Episode.builder().episodeNumber(2).season(season).build());
+      service.markWatched(USER_ID, season.getId(), CollectableScope.SEASON, Instant.now(), 3600);
+
+      service.markUnwatched(USER_ID, season.getId(), CollectableScope.SEASON);
+
+      var result = service.getWatchStatusForSeasons(USER_ID, List.of(season.getId()));
+      assertThat(result).containsEntry(season.getId(), WatchStatus.UNWATCHED);
+    }
+  }
+
+  @Nested
+  @DisplayName("Aggregate History Derivation")
+  class AggregateHistoryDerivation {
+
+    @Test
+    @DisplayName("Should return watched when every episode across seasons has history")
+    void shouldReturnWatchedWhenEveryEpisodeAcrossSeasonsHasHistory() {
+      var series = buildSeries();
+      var s1 = seasonRepository.save(Season.builder().seasonNumber(1).series(series).build());
+      var s2 = seasonRepository.save(Season.builder().seasonNumber(2).series(series).build());
+      episodeRepository.save(Episode.builder().episodeNumber(1).season(s1).build());
+      episodeRepository.save(Episode.builder().episodeNumber(1).season(s2).build());
+
+      service.markWatched(USER_ID, series.getId(), CollectableScope.SERIES, Instant.now(), 3600);
+
+      var result = service.getWatchStatusForSeries(USER_ID, List.of(series.getId()));
+      assertThat(result).containsEntry(series.getId(), WatchStatus.WATCHED);
+    }
+
+    @Test
+    @DisplayName("Should return in progress when only some episodes have history")
+    void shouldReturnInProgressWhenOnlySomeEpisodesHaveHistory() {
+      var series = buildSeries();
+      var season = seasonRepository.save(Season.builder().seasonNumber(1).series(series).build());
+      var watched =
+          episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
+      episodeRepository.save(Episode.builder().episodeNumber(2).season(season).build());
+
+      service.markWatched(
+          USER_ID, watched.getId(), CollectableScope.DIRECT_MEDIA, Instant.now(), 3600);
+
+      var result = service.getWatchStatusForSeries(USER_ID, List.of(series.getId()));
+      assertThat(result).containsEntry(series.getId(), WatchStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("Should return unwatched when series seasons have no episodes")
+    void shouldReturnUnwatchedWhenSeriesSeasonsHaveNoEpisodes() {
+      var populated = buildSeries();
+      var populatedSeason =
+          seasonRepository.save(Season.builder().seasonNumber(1).series(populated).build());
+      episodeRepository.save(Episode.builder().episodeNumber(1).season(populatedSeason).build());
+
+      var empty = buildSeries();
+      seasonRepository.save(Season.builder().seasonNumber(1).series(empty).build());
+
+      var result =
+          service.getWatchStatusForSeries(USER_ID, List.of(populated.getId(), empty.getId()));
+
+      assertThat(result)
+          .containsEntry(populated.getId(), WatchStatus.UNWATCHED)
+          .containsEntry(empty.getId(), WatchStatus.UNWATCHED);
+    }
+
+    @Test
+    @DisplayName("Should return unwatched when session progress position is zero")
+    void shouldReturnUnwatchedWhenSessionProgressPositionIsZero() {
+      var season = seasonRepository.save(Season.builder().seasonNumber(1).build());
+      var episode =
+          episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
+      var file = mediaFileRepository.save(buildMatchedMediaFile(episode.getId()));
+
+      sessionProgressRepository.save(
+          progressBuilder(USER_ID, file.getId()).positionSeconds(0).build());
+
+      var result = service.getWatchStatusForSeasons(USER_ID, List.of(season.getId()));
+      assertThat(result).containsEntry(season.getId(), WatchStatus.UNWATCHED);
+    }
+
+    @Test
+    @DisplayName("Should prefer most recent session when duplicate progress rows share media file")
+    void shouldPreferMostRecentSessionWhenDuplicateProgressRowsShareMediaFile() {
+      var movie = buildMovie();
+      var file = mediaFileRepository.save(buildMatchedMediaFile(movie.getId()));
+
+      var stale =
+          sessionProgressRepository.save(
+              progressBuilder(USER_ID, file.getId()).positionSeconds(900).build());
+      AuditFieldSetter.setLastModifiedOn(stale, Instant.parse("2026-01-01T00:00:00Z"));
+      var latest =
+          sessionProgressRepository.save(
+              progressBuilder(USER_ID, file.getId()).positionSeconds(0).build());
+      AuditFieldSetter.setLastModifiedOn(latest, Instant.parse("2026-02-01T00:00:00Z"));
+
+      var result = service.getWatchStatusForDirectMedia(USER_ID, List.of(movie.getId()));
+      assertThat(result).containsEntry(movie.getId(), WatchStatus.UNWATCHED);
     }
   }
 

--- a/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/WatchStatusServiceTest.java
@@ -306,14 +306,21 @@ class WatchStatusServiceTest {
     @DisplayName("Should dismiss all episode history when marking season unwatched explicitly")
     void shouldDismissAllEpisodeHistoryWhenMarkingSeasonUnwatchedExplicitly() {
       var season = seasonRepository.save(Season.builder().seasonNumber(1).build());
-      episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
-      episodeRepository.save(Episode.builder().episodeNumber(2).season(season).build());
+      var first = episodeRepository.save(Episode.builder().episodeNumber(1).season(season).build());
+      var second =
+          episodeRepository.save(Episode.builder().episodeNumber(2).season(season).build());
       service.markWatched(USER_ID, season.getId(), CollectableScope.SEASON, Instant.now(), 3600);
 
       service.markUnwatched(USER_ID, season.getId(), CollectableScope.SEASON);
 
-      var result = service.getWatchStatusForSeasons(USER_ID, List.of(season.getId()));
-      assertThat(result).containsEntry(season.getId(), WatchStatus.UNWATCHED);
+      var history =
+          watchHistoryRepository.findByUserIdAndCollectableIdIn(
+              USER_ID, List.of(first.getId(), second.getId()));
+      assertThat(history)
+          .hasSize(2)
+          .allSatisfy(entry -> assertThat(entry.getDismissedAt()).isNotNull());
+      assertThat(service.getWatchStatusForSeasons(USER_ID, List.of(season.getId())))
+          .containsEntry(season.getId(), WatchStatus.UNWATCHED);
     }
   }
 


### PR DESCRIPTION
Summary: fixes lazy season/series field traversal for GraphQL season and continue-watching paths, orders Series.seasons by seasonNumber, and orders Season.episodes by episodeNumber at the repository boundary. Tests: ./mvnw test passed with 1,255 tests; SeriesResolverIT captures both season and episode ordering regressions red then green.

Review follow-up: removed the unused unordered batch finders (findBySeriesIdIn/findBySeasonIdIn), pinned the ordering contract at the service layer with out-of-order fixtures (including season 0 specials), covered the resolver not-found error paths with narrowed resolver tests, carried the referencing child id in the not-found messages for post-cascade debuggability, asserted markUnwatched dismisses history rows (dismissedAt set) rather than deleting them, and covered the asymmetric-null and cross-type branches of the business-key equals contracts. Pre-existing findings tracked in #194, #195, #196; batching of the new to-one resolvers tracked in #191.

Closes #192