### PR TITLE
Serve full-duration HLS playlists on an absolute timeline

### DIFF
--- a/src/main/java/com/streamarr/server/domain/streaming/PlaybackSnapshot.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/PlaybackSnapshot.java
@@ -4,5 +4,4 @@ import java.time.Instant;
 import lombok.Builder;
 
 @Builder
-public record PlaybackSnapshot(
-    int positionSeconds, PlaybackState state, Instant accessedAt, int seekOrigin) {}
+public record PlaybackSnapshot(int positionSeconds, PlaybackState state, Instant accessedAt) {}

--- a/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
@@ -33,12 +33,11 @@ public class StreamSession {
   @Getter(lombok.AccessLevel.NONE)
   @Builder.Default
   private final AtomicReference<PlaybackSnapshot> playbackSnapshot =
-      new AtomicReference<>(new PlaybackSnapshot(0, PlaybackState.STOPPED, Instant.now(), 0));
+      new AtomicReference<>(new PlaybackSnapshot(0, PlaybackState.STOPPED, Instant.now()));
 
   public void updatePlaybackState(int positionSeconds, PlaybackState state) {
     playbackSnapshot.updateAndGet(
-        current ->
-            new PlaybackSnapshot(positionSeconds, state, Instant.now(), current.seekOrigin()));
+        current -> new PlaybackSnapshot(positionSeconds, state, Instant.now()));
   }
 
   public PlaybackSnapshot getPlaybackSnapshot() {
@@ -47,12 +46,7 @@ public class StreamSession {
 
   public void seek(int positionSeconds) {
     playbackSnapshot.updateAndGet(
-        current ->
-            new PlaybackSnapshot(positionSeconds, current.state(), Instant.now(), positionSeconds));
-  }
-
-  public int getSeekOrigin() {
-    return playbackSnapshot.get().seekOrigin();
+        current -> new PlaybackSnapshot(positionSeconds, current.state(), Instant.now()));
   }
 
   public Instant getLastAccessedAt() {
@@ -61,9 +55,7 @@ public class StreamSession {
 
   public void setLastAccessedAt(Instant accessedAt) {
     playbackSnapshot.updateAndGet(
-        current ->
-            new PlaybackSnapshot(
-                current.positionSeconds(), current.state(), accessedAt, current.seekOrigin()));
+        current -> new PlaybackSnapshot(current.positionSeconds(), current.state(), accessedAt));
   }
 
   public TranscodeHandle getHandle() {

--- a/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
@@ -44,11 +44,6 @@ public class StreamSession {
     return playbackSnapshot.get();
   }
 
-  public void seek(int positionSeconds) {
-    playbackSnapshot.updateAndGet(
-        current -> new PlaybackSnapshot(positionSeconds, current.state(), Instant.now()));
-  }
-
   public Instant getLastAccessedAt() {
     return playbackSnapshot.get().accessedAt();
   }

--- a/src/main/java/com/streamarr/server/domain/streaming/TranscodeHandle.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/TranscodeHandle.java
@@ -1,3 +1,8 @@
 package com.streamarr.server.domain.streaming;
 
-public record TranscodeHandle(long processId, TranscodeStatus status) {}
+public record TranscodeHandle(long processId, TranscodeStatus status, int startNumber) {
+
+  public TranscodeHandle(long processId, TranscodeStatus status) {
+    this(processId, status, 0);
+  }
+}

--- a/src/main/java/com/streamarr/server/graphql/dto/StreamSessionDto.java
+++ b/src/main/java/com/streamarr/server/graphql/dto/StreamSessionDto.java
@@ -3,4 +3,5 @@ package com.streamarr.server.graphql.dto;
 import lombok.Builder;
 
 @Builder
-public record StreamSessionDto(String id, String streamUrl, String transcodeMode) {}
+public record StreamSessionDto(
+    String id, String streamUrl, String transcodeMode, String timeline) {}

--- a/src/main/java/com/streamarr/server/graphql/dto/StreamSessionDto.java
+++ b/src/main/java/com/streamarr/server/graphql/dto/StreamSessionDto.java
@@ -3,5 +3,4 @@ package com.streamarr.server.graphql.dto;
 import lombok.Builder;
 
 @Builder
-public record StreamSessionDto(
-    String id, String streamUrl, String transcodeMode, String timeline) {}
+public record StreamSessionDto(String id, String streamUrl, String transcodeMode) {}

--- a/src/main/java/com/streamarr/server/graphql/resolvers/StreamingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/StreamingResolver.java
@@ -22,8 +22,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StreamingResolver {
 
-  private static final String ABSOLUTE_TIMELINE = "ABSOLUTE";
-
   private final StreamingService streamingService;
   private final SessionProgressService sessionProgressService;
   private final WatchStatusService watchStatusService;
@@ -33,14 +31,6 @@ public class StreamingResolver {
       @InputArgument String mediaFileId, @InputArgument StreamingOptionsInput options) {
     var opts = mapOptions(options);
     var session = streamingService.createSession(parseUuid(mediaFileId), opts);
-
-    return toDto(session);
-  }
-
-  @DgsMutation
-  public StreamSessionDto seekStreamSession(
-      @InputArgument String sessionId, @InputArgument int positionSeconds) {
-    var session = streamingService.seekSession(parseUuid(sessionId), positionSeconds);
 
     return toDto(session);
   }
@@ -121,7 +111,6 @@ public class StreamingResolver {
         .id(session.getSessionId().toString())
         .streamUrl("/api/stream/" + session.getSessionId() + "/master.m3u8")
         .transcodeMode(session.getTranscodeDecision().transcodeMode().name())
-        .timeline(ABSOLUTE_TIMELINE)
         .build();
   }
 

--- a/src/main/java/com/streamarr/server/graphql/resolvers/StreamingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/StreamingResolver.java
@@ -22,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StreamingResolver {
 
+  private static final String ABSOLUTE_TIMELINE = "ABSOLUTE";
+
   private final StreamingService streamingService;
   private final SessionProgressService sessionProgressService;
   private final WatchStatusService watchStatusService;
@@ -119,6 +121,7 @@ public class StreamingResolver {
         .id(session.getSessionId().toString())
         .streamUrl("/api/stream/" + session.getSessionId() + "/master.m3u8")
         .transcodeMode(session.getTranscodeDecision().transcodeMode().name())
+        .timeline(ABSOLUTE_TIMELINE)
         .build();
   }
 

--- a/src/main/java/com/streamarr/server/services/streaming/HlsPlaylistService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/HlsPlaylistService.java
@@ -77,16 +77,19 @@ public class HlsPlaylistService {
     sb.append("\n");
   }
 
+  /**
+   * The playlist always covers the full media duration on an absolute timeline: segment {@code i}
+   * is media time {@code [i * segmentDuration, (i + 1) * segmentDuration)} regardless of any
+   * server-side seek, so player position and duration match real media time.
+   */
   public String generateMediaPlaylist(StreamSession session) {
     var decision = session.getTranscodeDecision();
     var container = decision.containerFormat();
     var probe = session.getMediaProbe();
     var segmentDuration = (int) properties.segmentDuration().toSeconds();
     var totalDurationMs = probe.duration().toMillis();
-    var seekOffsetMs = session.getSeekOrigin() * 1000L;
-    var remainingDurationMs = Math.max(0, totalDurationMs - seekOffsetMs);
     var segmentDurationMs = segmentDuration * 1000L;
-    var segmentCount = (int) Math.ceil((double) remainingDurationMs / segmentDurationMs);
+    var segmentCount = (int) Math.ceil((double) totalDurationMs / segmentDurationMs);
     var extension = container.segmentExtension();
 
     var sb = new StringBuilder();
@@ -101,7 +104,7 @@ public class HlsPlaylistService {
     }
 
     for (int i = 0; i < segmentCount; i++) {
-      var remainingMs = remainingDurationMs - (i * segmentDurationMs);
+      var remainingMs = totalDurationMs - (i * segmentDurationMs);
       var durationMs = Math.min(segmentDurationMs, remainingMs);
       sb.append("#EXTINF:").append(String.format("%.6f", durationMs / 1000.0)).append(",\n");
       sb.append("segment").append(i).append(extension).append("\n");

--- a/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -100,9 +100,14 @@ public class HlsStreamingService implements StreamingService {
             .orElseThrow(() -> new SessionNotFoundException(sessionId));
 
     transcodeExecutor.stop(sessionId);
-    segmentStore.deleteSession(sessionId);
     session.seek(positionSeconds);
-    startTranscodes(session, positionSeconds, 0);
+
+    // Relocate the encoder on the absolute timeline: snap to the segment
+    // boundary so produced segments align with the full-duration playlist.
+    // Previously transcoded segments stay valid and are kept.
+    var segmentDurationSeconds = (int) properties.segmentDuration().toSeconds();
+    var startSegment = positionSeconds / segmentDurationSeconds;
+    startTranscodes(session, startSegment * segmentDurationSeconds, startSegment);
     sessionRepository.save(session);
 
     log.info("Seek-ed session {} to position {}s", sessionId, positionSeconds);
@@ -163,8 +168,7 @@ public class HlsStreamingService implements StreamingService {
     }
 
     var segmentIndex = parseSegmentIndex(segmentName);
-    var resumeSeek =
-        session.getSeekOrigin() + (segmentIndex * (int) properties.segmentDuration().toSeconds());
+    var resumeSeek = segmentIndex * (int) properties.segmentDuration().toSeconds();
 
     startTranscodes(session, resumeSeek, segmentIndex);
     session.setLastAccessedAt(Instant.now());

--- a/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -12,7 +12,6 @@ import com.streamarr.server.domain.streaming.TranscodeRequest;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.exceptions.MaxConcurrentTranscodesException;
 import com.streamarr.server.exceptions.MediaFileNotFoundException;
-import com.streamarr.server.exceptions.SessionNotFoundException;
 import com.streamarr.server.repositories.media.MediaFileRepository;
 import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.library.FilepathCodec;
@@ -94,28 +93,6 @@ public class HlsStreamingService implements StreamingService {
           s.setLastAccessedAt(Instant.now());
           sessionRepository.save(s);
         });
-    return session;
-  }
-
-  @Override
-  public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-    var session =
-        sessionRepository
-            .findById(sessionId)
-            .orElseThrow(() -> new SessionNotFoundException(sessionId));
-
-    transcodeExecutor.stop(sessionId);
-    session.seek(positionSeconds);
-
-    // Relocate the encoder on the absolute timeline: snap to the segment
-    // boundary so produced segments align with the full-duration playlist.
-    // Previously transcoded segments stay valid and are kept.
-    var segmentDurationSeconds = (int) properties.segmentDuration().toSeconds();
-    var startSegment = positionSeconds / segmentDurationSeconds;
-    startTranscodes(session, startSegment * segmentDurationSeconds, startSegment);
-    sessionRepository.save(session);
-
-    log.info("Seek-ed session {} to position {}s", sessionId, positionSeconds);
     return session;
   }
 

--- a/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -6,6 +6,7 @@ import com.streamarr.server.domain.streaming.QualityVariant;
 import com.streamarr.server.domain.streaming.StreamSession;
 import com.streamarr.server.domain.streaming.StreamingOptions;
 import com.streamarr.server.domain.streaming.TranscodeDecision;
+import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.TranscodeMode;
 import com.streamarr.server.domain.streaming.TranscodeRequest;
 import com.streamarr.server.domain.streaming.VideoQuality;
@@ -15,6 +16,7 @@ import com.streamarr.server.exceptions.SessionNotFoundException;
 import com.streamarr.server.repositories.media.MediaFileRepository;
 import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.library.FilepathCodec;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,6 +32,9 @@ import lombok.extern.slf4j.Slf4j;
 public class HlsStreamingService implements StreamingService {
 
   private static final Pattern SEGMENT_INDEX_PATTERN = Pattern.compile("segment(\\d+)");
+
+  /** Beyond this lead, restarting the encoder beats waiting for it to catch up. */
+  private static final Duration FORWARD_RELOCATION_GAP = Duration.ofSeconds(24);
 
   private final MediaFileRepository mediaFileRepository;
   private final TranscodeExecutor transcodeExecutor;
@@ -139,7 +144,7 @@ public class HlsStreamingService implements StreamingService {
   @Override
   public void resumeSessionIfNeeded(UUID sessionId, String segmentName) {
     var session = sessionRepository.findById(sessionId).orElse(null);
-    if (session == null || !session.isSuspended()) {
+    if (session == null) {
       return;
     }
 
@@ -147,7 +152,16 @@ public class HlsStreamingService implements StreamingService {
       return;
     }
 
-    resumeWithLock(sessionId, segmentName);
+    if (session.isSuspended()) {
+      resumeWithLock(sessionId, segmentName);
+      return;
+    }
+
+    if (!requiresRelocation(session, segmentName)) {
+      return;
+    }
+
+    relocateWithLock(sessionId, segmentName);
   }
 
   private void resumeWithLock(UUID sessionId, String segmentName) {
@@ -159,6 +173,77 @@ public class HlsStreamingService implements StreamingService {
     } finally {
       lock.unlock();
     }
+  }
+
+  /**
+   * A running encoder produces segments sequentially from its start segment. A requested segment
+   * needs the encoder relocated when it lies behind that start (it will never be produced) or so
+   * far ahead of produced output that waiting would stall the player longer than restarting.
+   */
+  private boolean requiresRelocation(StreamSession session, String segmentName) {
+    var requestedIndex = parseSegmentIndex(segmentName);
+    var startNumber = activeStartNumber(session);
+    if (requestedIndex < startNumber) {
+      return true;
+    }
+
+    var probeIndex = requestedIndex - forwardGapSegments();
+    if (probeIndex < startNumber) {
+      return false;
+    }
+
+    return !segmentStore.segmentExists(
+        session.getSessionId(), siblingSegmentName(segmentName, probeIndex));
+  }
+
+  private void relocateWithLock(UUID sessionId, String segmentName) {
+    var lock = resumeMutex.getMutex(sessionId);
+    lock.lock();
+
+    try {
+      doRelocate(sessionId, segmentName);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void doRelocate(UUID sessionId, String segmentName) {
+    var session = sessionRepository.findById(sessionId).orElse(null);
+    if (session == null || !requiresRelocation(session, segmentName)) {
+      return;
+    }
+
+    if (segmentStore.segmentExists(sessionId, segmentName)) {
+      return;
+    }
+
+    var segmentIndex = parseSegmentIndex(segmentName);
+    transcodeExecutor.stop(sessionId);
+    startTranscodes(session, segmentIndex * segmentDurationSeconds(), segmentIndex);
+    session.setLastAccessedAt(Instant.now());
+    sessionRepository.save(session);
+
+    log.info("Relocated transcode for session {} to segment {}", sessionId, segmentIndex);
+  }
+
+  private int activeStartNumber(StreamSession session) {
+    return session.getVariantHandles().values().stream()
+        .mapToInt(TranscodeHandle::startNumber)
+        .max()
+        .orElse(0);
+  }
+
+  private int forwardGapSegments() {
+    var gapSegments = FORWARD_RELOCATION_GAP.toSeconds() / properties.segmentDuration().toSeconds();
+    return Math.max(1, (int) gapSegments);
+  }
+
+  private int segmentDurationSeconds() {
+    return (int) properties.segmentDuration().toSeconds();
+  }
+
+  private static String siblingSegmentName(String segmentName, int index) {
+    return SEGMENT_INDEX_PATTERN.matcher(segmentName).replaceFirst("segment" + index);
   }
 
   private void doResume(UUID sessionId, String segmentName) {

--- a/src/main/java/com/streamarr/server/services/streaming/SessionReaper.java
+++ b/src/main/java/com/streamarr/server/services/streaming/SessionReaper.java
@@ -63,7 +63,8 @@ public class SessionReaper {
       }
 
       session.setVariantHandle(
-          entry.getKey(), new TranscodeHandle(handle.processId(), TranscodeStatus.SUSPENDED));
+          entry.getKey(),
+          new TranscodeHandle(handle.processId(), TranscodeStatus.SUSPENDED, handle.startNumber()));
     }
     sessionRepository.save(session);
   }
@@ -83,7 +84,8 @@ public class SessionReaper {
 
       log.warn("FFmpeg process died for session {} variant {}", session.getSessionId(), label);
       session.setVariantHandle(
-          label, new TranscodeHandle(handle.processId(), TranscodeStatus.FAILED));
+          label,
+          new TranscodeHandle(handle.processId(), TranscodeStatus.FAILED, handle.startNumber()));
       sessionRepository.save(session);
     }
   }

--- a/src/main/java/com/streamarr/server/services/streaming/StreamingService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/StreamingService.java
@@ -14,8 +14,6 @@ public interface StreamingService {
 
   void destroySession(UUID sessionId);
 
-  StreamSession seekSession(UUID sessionId, int positionSeconds);
-
   Collection<StreamSession> getAllSessions();
 
   int getActiveSessionCount();

--- a/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
+++ b/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
@@ -40,7 +40,7 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
         job.videoEncoder(),
         process.pid());
 
-    return new TranscodeHandle(process.pid(), TranscodeStatus.ACTIVE);
+    return new TranscodeHandle(process.pid(), TranscodeStatus.ACTIVE, request.startNumber());
   }
 
   @Override

--- a/src/main/resources/schema/root-mutation.graphqls
+++ b/src/main/resources/schema/root-mutation.graphqls
@@ -6,7 +6,6 @@ type Mutation {
     refreshLibrary(id: ID!): Boolean!
     createStreamSession(mediaFileId: ID!, options: StreamingOptionsInput): StreamSession!
     destroyStreamSession(sessionId: ID!): Boolean!
-    seekStreamSession(sessionId: ID!, positionSeconds: Int!): StreamSession! @deprecated(reason: "The stream timeline is absolute; seek the player locally and the server relocates the encoder from segment requests.")
     reportStreamSessionTimeline(sessionId: ID!, positionSeconds: Int!, state: PlaybackState!): Boolean!
     markWatched(id: ID!): Boolean!
     markUnwatched(id: ID!): Boolean!

--- a/src/main/resources/schema/root-mutation.graphqls
+++ b/src/main/resources/schema/root-mutation.graphqls
@@ -6,7 +6,7 @@ type Mutation {
     refreshLibrary(id: ID!): Boolean!
     createStreamSession(mediaFileId: ID!, options: StreamingOptionsInput): StreamSession!
     destroyStreamSession(sessionId: ID!): Boolean!
-    seekStreamSession(sessionId: ID!, positionSeconds: Int!): StreamSession!
+    seekStreamSession(sessionId: ID!, positionSeconds: Int!): StreamSession! @deprecated(reason: "The stream timeline is absolute; seek the player locally and the server relocates the encoder from segment requests.")
     reportStreamSessionTimeline(sessionId: ID!, positionSeconds: Int!, state: PlaybackState!): Boolean!
     markWatched(id: ID!): Boolean!
     markUnwatched(id: ID!): Boolean!

--- a/src/main/resources/schema/streaming.graphqls
+++ b/src/main/resources/schema/streaming.graphqls
@@ -2,19 +2,6 @@ type StreamSession {
     id: ID!
     streamUrl: String!
     transcodeMode: TranscodeMode!
-    "Timeline addressing for the session's playlist and reported positions."
-    timeline: StreamTimeline!
-}
-
-"""
-How stream positions map to media time. ABSOLUTE means the playlist covers
-the full media duration and player positions equal real media positions, so
-clients seek locally and report positions without any seek-offset
-compensation. Servers without this field trim the playlist at the seek
-point instead.
-"""
-enum StreamTimeline {
-    ABSOLUTE
 }
 
 enum TranscodeMode {

--- a/src/main/resources/schema/streaming.graphqls
+++ b/src/main/resources/schema/streaming.graphqls
@@ -2,6 +2,19 @@ type StreamSession {
     id: ID!
     streamUrl: String!
     transcodeMode: TranscodeMode!
+    "Timeline addressing for the session's playlist and reported positions."
+    timeline: StreamTimeline!
+}
+
+"""
+How stream positions map to media time. ABSOLUTE means the playlist covers
+the full media duration and player positions equal real media positions, so
+clients seek locally and report positions without any seek-offset
+compensation. Servers without this field trim the playlist at the seek
+point instead.
+"""
+enum StreamTimeline {
+    ABSOLUTE
 }
 
 enum TranscodeMode {

--- a/src/test/java/com/streamarr/server/controllers/StreamControllerIT.java
+++ b/src/test/java/com/streamarr/server/controllers/StreamControllerIT.java
@@ -125,11 +125,6 @@ class StreamControllerIT extends AbstractIntegrationTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void destroySession(UUID sessionId) {
       sessions.remove(sessionId);
     }

--- a/src/test/java/com/streamarr/server/controllers/StreamControllerTest.java
+++ b/src/test/java/com/streamarr/server/controllers/StreamControllerTest.java
@@ -389,11 +389,6 @@ class StreamControllerTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void destroySession(UUID sessionId) {
       // no-op for test fake
     }

--- a/src/test/java/com/streamarr/server/fakes/FakeTranscodeExecutor.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeTranscodeExecutor.java
@@ -26,7 +26,7 @@ public class FakeTranscodeExecutor implements TranscodeExecutor {
     var key = new ProcessKey(request.sessionId(), request.variantLabel());
     running.add(key);
     started.add(key);
-    return new TranscodeHandle(1L, TranscodeStatus.ACTIVE);
+    return new TranscodeHandle(1L, TranscodeStatus.ACTIVE, request.startNumber());
   }
 
   @Override

--- a/src/test/java/com/streamarr/server/graphql/resolvers/StreamingResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/StreamingResolverTest.java
@@ -117,6 +117,31 @@ class StreamingResolverTest {
   }
 
   @Test
+  @DisplayName("Should expose an absolute timeline capability on the session")
+  void shouldExposeAnAbsoluteTimelineCapabilityOnTheSession() {
+    var sessionId = UUID.randomUUID();
+    var session = buildSession(sessionId);
+    STUB_SERVICE.setNextResult(session);
+
+    var mutation =
+        String.format(
+            """
+            mutation {
+              createStreamSession(mediaFileId: "%s") {
+                id
+                timeline
+              }
+            }
+            """,
+            UUID.randomUUID());
+
+    var context = dgsQueryExecutor.executeAndGetDocumentContext(mutation);
+    String timeline = context.read("data.createStreamSession.timeline");
+
+    assertThat(timeline).isEqualTo("ABSOLUTE");
+  }
+
+  @Test
   @DisplayName("Should map GraphQL options input to streaming options when options provided")
   void shouldMapGraphqlOptionsInputToStreamingOptionsWhenOptionsProvided() {
     var sessionId = UUID.randomUUID();

--- a/src/test/java/com/streamarr/server/graphql/resolvers/StreamingResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/StreamingResolverTest.java
@@ -117,31 +117,6 @@ class StreamingResolverTest {
   }
 
   @Test
-  @DisplayName("Should expose an absolute timeline capability on the session")
-  void shouldExposeAnAbsoluteTimelineCapabilityOnTheSession() {
-    var sessionId = UUID.randomUUID();
-    var session = buildSession(sessionId);
-    STUB_SERVICE.setNextResult(session);
-
-    var mutation =
-        String.format(
-            """
-            mutation {
-              createStreamSession(mediaFileId: "%s") {
-                id
-                timeline
-              }
-            }
-            """,
-            UUID.randomUUID());
-
-    var context = dgsQueryExecutor.executeAndGetDocumentContext(mutation);
-    String timeline = context.read("data.createStreamSession.timeline");
-
-    assertThat(timeline).isEqualTo("ABSOLUTE");
-  }
-
-  @Test
   @DisplayName("Should map GraphQL options input to streaming options when options provided")
   void shouldMapGraphqlOptionsInputToStreamingOptionsWhenOptionsProvided() {
     var sessionId = UUID.randomUUID();
@@ -223,47 +198,6 @@ class StreamingResolverTest {
     assertThat(result.getErrors().getFirst().getMessage()).contains("Invalid ID format");
   }
 
-  @Test
-  @DisplayName("Should return session DTO when seeking session")
-  void shouldReturnSessionDtoWhenSeekingSession() {
-    var sessionId = UUID.randomUUID();
-    var session = buildSession(sessionId);
-    STUB_SERVICE.setNextResult(session);
-
-    var mutation =
-        String.format(
-            """
-            mutation {
-              seekStreamSession(sessionId: "%s", positionSeconds: 300) {
-                id
-                streamUrl
-              }
-            }
-            """,
-            sessionId);
-
-    var id = dgsQueryExecutor.executeAndExtractJsonPath(mutation, "data.seekStreamSession.id");
-
-    assertThat(id).isEqualTo(sessionId.toString());
-  }
-
-  @Test
-  @DisplayName("Should return error when seek session ID is invalid")
-  void shouldReturnErrorWhenSeekSessionIdIsInvalid() {
-    var result =
-        dgsQueryExecutor.execute(
-            """
-            mutation {
-              seekStreamSession(sessionId: "bad-id", positionSeconds: 300) {
-                id
-              }
-            }
-            """);
-
-    assertThat(result.getErrors()).isNotEmpty();
-    assertThat(result.getErrors().getFirst().getMessage()).contains("Invalid ID format");
-  }
-
   @ParameterizedTest(name = "{0}")
   @MethodSource("booleanMutations")
   @DisplayName("Should return true when executing boolean mutation")
@@ -328,11 +262,6 @@ class StreamingResolverTest {
     @Override
     public Optional<StreamSession> accessSession(UUID sessionId) {
       return Optional.ofNullable(nextResult);
-    }
-
-    @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-      return nextResult;
     }
 
     @Override

--- a/src/test/java/com/streamarr/server/services/library/StreamingSessionCleanupListenerTest.java
+++ b/src/test/java/com/streamarr/server/services/library/StreamingSessionCleanupListenerTest.java
@@ -94,11 +94,6 @@ class StreamingSessionCleanupListenerTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Collection<StreamSession> getAllSessions() {
       return sessions.values();
     }

--- a/src/test/java/com/streamarr/server/services/streaming/HlsPlaylistServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsPlaylistServiceTest.java
@@ -422,24 +422,10 @@ class HlsPlaylistServiceTest {
   }
 
   @Test
-  @DisplayName("Should keep the full segment count when the session has been seeked")
-  void shouldKeepTheFullSegmentCountWhenTheSessionHasBeenSeeked() {
-    // The playlist timeline is absolute: 120s / 6s = 20 segments regardless of seeking.
+  @DisplayName("Should keep the full segment count when playback advances")
+  void shouldKeepTheFullSegmentCountWhenPlaybackAdvances() {
+    // The playlist timeline is absolute: 120s / 6s = 20 segments, always.
     var session = createSession(ContainerFormat.MPEGTS, TranscodeMode.FULL_TRANSCODE, 120);
-    session.seek(60);
-
-    var playlist = service.generateMediaPlaylist(session);
-
-    var segmentLines =
-        playlist.lines().filter(l -> l.startsWith("segment") && l.endsWith(".ts")).toList();
-    assertThat(segmentLines).hasSize(20);
-  }
-
-  @Test
-  @DisplayName("Should keep the full segment count when playback advances after a seek")
-  void shouldKeepTheFullSegmentCountWhenPlaybackAdvancesAfterASeek() {
-    var session = createSession(ContainerFormat.MPEGTS, TranscodeMode.FULL_TRANSCODE, 120);
-    session.seek(60);
     session.updatePlaybackState(90, PlaybackState.PLAYING);
 
     var playlist = service.generateMediaPlaylist(session);

--- a/src/test/java/com/streamarr/server/services/streaming/HlsPlaylistServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsPlaylistServiceTest.java
@@ -422,9 +422,9 @@ class HlsPlaylistServiceTest {
   }
 
   @Test
-  @DisplayName("Should reduce segment count when seek origin is non-zero")
-  void shouldReduceSegmentCountWhenSeekOriginIsNonZero() {
-    // 120s total / 6s segments = 20; seek(60) leaves 60s / 6s = 10 segments
+  @DisplayName("Should keep the full segment count when the session has been seeked")
+  void shouldKeepTheFullSegmentCountWhenTheSessionHasBeenSeeked() {
+    // The playlist timeline is absolute: 120s / 6s = 20 segments regardless of seeking.
     var session = createSession(ContainerFormat.MPEGTS, TranscodeMode.FULL_TRANSCODE, 120);
     session.seek(60);
 
@@ -432,24 +432,21 @@ class HlsPlaylistServiceTest {
 
     var segmentLines =
         playlist.lines().filter(l -> l.startsWith("segment") && l.endsWith(".ts")).toList();
-    assertThat(segmentLines).hasSize(10);
+    assertThat(segmentLines).hasSize(20);
   }
 
   @Test
-  @DisplayName("Should not change segment count when playback position advances beyond seek origin")
-  void shouldNotChangeSegmentCountWhenPlaybackPositionAdvancesBeyondSeekOrigin() {
-    // seekOrigin stays 60 (updatePlaybackState does not update it), so segments = (120-60)/6 = 10
+  @DisplayName("Should keep the full segment count when playback advances after a seek")
+  void shouldKeepTheFullSegmentCountWhenPlaybackAdvancesAfterASeek() {
     var session = createSession(ContainerFormat.MPEGTS, TranscodeMode.FULL_TRANSCODE, 120);
     session.seek(60);
     session.updatePlaybackState(90, PlaybackState.PLAYING);
 
-    assertThat(session.getSeekOrigin()).isEqualTo(60);
-
     var playlist = service.generateMediaPlaylist(session);
 
     var segmentLines =
         playlist.lines().filter(l -> l.startsWith("segment") && l.endsWith(".ts")).toList();
-    assertThat(segmentLines).hasSize(10);
+    assertThat(segmentLines).hasSize(20);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceIT.java
@@ -11,7 +11,6 @@ import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.exceptions.MediaFileNotFoundException;
-import com.streamarr.server.exceptions.SessionNotFoundException;
 import com.streamarr.server.fakes.FakeFfprobeService;
 import com.streamarr.server.fakes.FakeSegmentStore;
 import com.streamarr.server.fakes.FakeTranscodeExecutor;
@@ -121,26 +120,6 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
 
     assertThatThrownBy(() -> streamingService.createSession(nonExistentId, options))
         .isInstanceOf(MediaFileNotFoundException.class);
-  }
-
-  @Test
-  @DisplayName("Should update seek position when seeking session")
-  void shouldUpdateSeekPositionWhenSeekingSession() {
-    var session = streamingService.createSession(savedMediaFile.getId(), defaultOptions());
-
-    var seeked = streamingService.seekSession(session.getSessionId(), 300);
-
-    assertThat(seeked.getPlaybackSnapshot().positionSeconds()).isEqualTo(300);
-    assertThat(seeked.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-  }
-
-  @Test
-  @DisplayName("Should throw when seeking nonexistent session")
-  void shouldThrowWhenSeekingNonexistentSession() {
-    var nonExistentId = UUID.randomUUID();
-
-    assertThatThrownBy(() -> streamingService.seekSession(nonExistentId, 300))
-        .isInstanceOf(SessionNotFoundException.class);
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -8,7 +8,6 @@ import com.streamarr.server.config.StreamingProperties;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.MediaFileStatus;
 import com.streamarr.server.domain.streaming.MediaProbe;
-import com.streamarr.server.domain.streaming.PlaybackState;
 import com.streamarr.server.domain.streaming.StreamSession;
 import com.streamarr.server.domain.streaming.StreamingOptions;
 import com.streamarr.server.domain.streaming.TranscodeHandle;
@@ -18,7 +17,6 @@ import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.exceptions.MaxConcurrentTranscodesException;
 import com.streamarr.server.exceptions.MediaFileNotFoundException;
-import com.streamarr.server.exceptions.SessionNotFoundException;
 import com.streamarr.server.fakes.FakeFfprobeService;
 import com.streamarr.server.fakes.FakeMediaFileRepository;
 import com.streamarr.server.fakes.FakeSegmentStore;
@@ -325,89 +323,16 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName("Should update seek position when seeking session")
-  void shouldUpdateSeekPositionWhenSeekingSession() {
-    var file = seedMediaFile();
-    var session = service.createSession(file.getId(), defaultOptions());
-    var originalSessionId = session.getSessionId();
-
-    var seeked = service.seekSession(originalSessionId, 300);
-
-    assertThat(seeked.getSessionId()).isEqualTo(originalSessionId);
-    assertThat(seeked.getPlaybackSnapshot().positionSeconds()).isEqualTo(300);
-  }
-
-  @Test
-  @DisplayName("Should restart transcode when seeking")
-  void shouldRestartTranscodeWhenSeeking() {
-    var file = seedMediaFile();
-    var session = service.createSession(file.getId(), defaultOptions());
-
-    var seeked = service.seekSession(session.getSessionId(), 300);
-
-    assertThat(seeked.getHandle()).isNotNull();
-    assertThat(transcodeExecutor.isRunning(session.getSessionId())).isTrue();
-  }
-
-  @Test
-  @DisplayName("Should stop old transcode when seeking to new position")
-  void shouldStopOldTranscodeWhenSeekingToNewPosition() {
-    var file = seedMediaFile();
-    var session = service.createSession(file.getId(), defaultOptions());
-
-    service.seekSession(session.getSessionId(), 300);
-
-    assertThat(transcodeExecutor.getStopped()).contains(session.getSessionId());
-  }
-
-  @Test
-  @DisplayName("Should restart the transcode at the absolute segment when seeking")
-  void shouldRestartTheTranscodeAtTheAbsoluteSegmentWhenSeeking() {
-    var file = seedMediaFile();
-    var session = service.createSession(file.getId(), defaultOptions());
-
-    service.seekSession(session.getSessionId(), 300);
-
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.seekPosition()).isEqualTo(300);
-    assertThat(lastRequest.startNumber()).isEqualTo(50);
-  }
-
-  @Test
-  @DisplayName("Should snap a mid-segment seek to the segment boundary")
-  void shouldSnapAMidSegmentSeekToTheSegmentBoundary() {
-    var file = seedMediaFile();
-    var session = service.createSession(file.getId(), defaultOptions());
-
-    service.seekSession(session.getSessionId(), 303);
-
-    // segment50 covers [300s, 306s); ffmpeg must start on the boundary so the
-    // produced segments align with the absolute playlist timeline.
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.seekPosition()).isEqualTo(300);
-    assertThat(lastRequest.startNumber()).isEqualTo(50);
-  }
-
-  @Test
-  @DisplayName("Should keep previously transcoded segments when seeking")
-  void shouldKeepPreviouslyTranscodedSegmentsWhenSeeking() {
+  @DisplayName("Should keep previously transcoded segments when relocating")
+  void shouldKeepPreviouslyTranscodedSegmentsWhenRelocating() {
     var file = seedMediaFile();
     var session = service.createSession(file.getId(), defaultOptions());
     segmentStore.addSegment(session.getSessionId(), "segment0.ts", new byte[] {1});
 
-    service.seekSession(session.getSessionId(), 300);
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
 
     // Segments are addressed on the absolute timeline, so earlier segments stay valid.
     assertThat(segmentStore.segmentExists(session.getSessionId(), "segment0.ts")).isTrue();
-  }
-
-  @Test
-  @DisplayName("Should throw when seeking nonexistent session")
-  void shouldThrowWhenSeekingNonexistentSession() {
-    var invalidId = UUID.randomUUID();
-
-    assertThatThrownBy(() -> service.seekSession(invalidId, 300))
-        .isInstanceOf(SessionNotFoundException.class);
   }
 
   @Test
@@ -866,7 +791,8 @@ class HlsStreamingServiceTest {
   void shouldRelocateTheTranscodeWhenTheRequestedSegmentIsBehindTheEncoderStart() {
     var file = seedMediaFile();
     var session = service.createSession(file.getId(), defaultOptions());
-    service.seekSession(session.getSessionId(), 300);
+    // Move the encoder forward first: segment50 is far ahead of fresh output.
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment50.ts");
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment10.ts");
 
@@ -922,7 +848,6 @@ class HlsStreamingServiceTest {
   void shouldNotRelocateWhenTheRequestedSegmentAlreadyExists() {
     var file = seedMediaFile();
     var session = service.createSession(file.getId(), defaultOptions());
-    service.seekSession(session.getSessionId(), 300);
     segmentStore.addSegment(session.getSessionId(), "segment10.ts", new byte[] {1});
     var requestsBefore = transcodeExecutor.getStartedRequests().size();
 
@@ -932,22 +857,17 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName("Should resume at the absolute segment position when resuming after seek")
-  void shouldResumeAtTheAbsoluteSegmentPositionWhenResumingAfterSeek() {
+  @DisplayName("Should resume at the absolute segment position when resuming")
+  void shouldResumeAtTheAbsoluteSegmentPositionWhenResuming() {
     var file = seedMediaFile();
     var session = service.createSession(file.getId(), defaultOptions());
-
-    service.seekSession(session.getSessionId(), 60);
-
-    session.updatePlaybackState(120, PlaybackState.PLAYING);
 
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
     transcodeExecutor.markDead(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
 
-    // The timeline is absolute: segment5 always covers [30s, 36s), regardless of
-    // any earlier seek.
+    // The timeline is absolute: segment5 always covers [30s, 36s).
     var lastRequest = transcodeExecutor.getStartedRequests().getLast();
     assertThat(lastRequest.seekPosition()).isEqualTo(30);
     assertThat(lastRequest.startNumber()).isEqualTo(5);

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -361,6 +361,47 @@ class HlsStreamingServiceTest {
   }
 
   @Test
+  @DisplayName("Should restart the transcode at the absolute segment when seeking")
+  void shouldRestartTheTranscodeAtTheAbsoluteSegmentWhenSeeking() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+
+    service.seekSession(session.getSessionId(), 300);
+
+    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
+    assertThat(lastRequest.seekPosition()).isEqualTo(300);
+    assertThat(lastRequest.startNumber()).isEqualTo(50);
+  }
+
+  @Test
+  @DisplayName("Should snap a mid-segment seek to the segment boundary")
+  void shouldSnapAMidSegmentSeekToTheSegmentBoundary() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+
+    service.seekSession(session.getSessionId(), 303);
+
+    // segment50 covers [300s, 306s); ffmpeg must start on the boundary so the
+    // produced segments align with the absolute playlist timeline.
+    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
+    assertThat(lastRequest.seekPosition()).isEqualTo(300);
+    assertThat(lastRequest.startNumber()).isEqualTo(50);
+  }
+
+  @Test
+  @DisplayName("Should keep previously transcoded segments when seeking")
+  void shouldKeepPreviouslyTranscodedSegmentsWhenSeeking() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+    segmentStore.addSegment(session.getSessionId(), "segment0.ts", new byte[] {1});
+
+    service.seekSession(session.getSessionId(), 300);
+
+    // Segments are addressed on the absolute timeline, so earlier segments stay valid.
+    assertThat(segmentStore.segmentExists(session.getSessionId(), "segment0.ts")).isTrue();
+  }
+
+  @Test
   @DisplayName("Should throw when seeking nonexistent session")
   void shouldThrowWhenSeekingNonexistentSession() {
     var invalidId = UUID.randomUUID();
@@ -820,24 +861,24 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName(
-      "Should compute resume position from seek origin and segment index when resuming after seek")
-  void shouldComputeResumePositionFromSeekOriginAndSegmentIndexWhenResumingAfterSeek() {
+  @DisplayName("Should resume at the absolute segment position when resuming after seek")
+  void shouldResumeAtTheAbsoluteSegmentPositionWhenResumingAfterSeek() {
     var file = seedMediaFile();
     var session = service.createSession(file.getId(), defaultOptions());
 
     service.seekSession(session.getSessionId(), 60);
 
     session.updatePlaybackState(120, PlaybackState.PLAYING);
-    assertThat(session.getSeekOrigin()).isEqualTo(60);
 
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
     transcodeExecutor.markDead(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
 
-    // resumeSeek = seekOrigin(60) + segmentIndex(5) * segmentDuration(6) = 60 + 30 = 90
+    // The timeline is absolute: segment5 always covers [30s, 36s), regardless of
+    // any earlier seek.
     var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.seekPosition()).isEqualTo(90);
+    assertThat(lastRequest.seekPosition()).isEqualTo(30);
+    assertThat(lastRequest.startNumber()).isEqualTo(5);
   }
 }

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -861,6 +861,77 @@ class HlsStreamingServiceTest {
   }
 
   @Test
+  @DisplayName(
+      "Should relocate the transcode when the requested segment is behind the encoder start")
+  void shouldRelocateTheTranscodeWhenTheRequestedSegmentIsBehindTheEncoderStart() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+    service.seekSession(session.getSessionId(), 300);
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment10.ts");
+
+    // The encoder started at segment50 and will never produce segment10.
+    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
+    assertThat(lastRequest.seekPosition()).isEqualTo(60);
+    assertThat(lastRequest.startNumber()).isEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("Should relocate the transcode when the requested segment is far ahead of progress")
+  void shouldRelocateTheTranscodeWhenTheRequestedSegmentIsFarAheadOfProgress() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
+
+    // Nothing near segment100 has been produced; waiting would stall the player.
+    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
+    assertThat(lastRequest.seekPosition()).isEqualTo(600);
+    assertThat(lastRequest.startNumber()).isEqualTo(100);
+  }
+
+  @Test
+  @DisplayName("Should wait when the requested segment is near the encoder start")
+  void shouldWaitWhenTheRequestedSegmentIsNearTheEncoderStart() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment2.ts");
+
+    // The encoder started at segment0 and will reach segment2 shortly.
+    assertThat(transcodeExecutor.getStartedRequests()).hasSize(requestsBefore);
+  }
+
+  @Test
+  @DisplayName("Should wait when the encoder is within the forward gap of the request")
+  void shouldWaitWhenTheEncoderIsWithinTheForwardGapOfTheRequest() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+    segmentStore.addSegment(session.getSessionId(), "segment96.ts", new byte[] {1});
+    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
+
+    // segment96 exists, so the encoder is close behind the request.
+    assertThat(transcodeExecutor.getStartedRequests()).hasSize(requestsBefore);
+  }
+
+  @Test
+  @DisplayName("Should not relocate when the requested segment already exists")
+  void shouldNotRelocateWhenTheRequestedSegmentAlreadyExists() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), defaultOptions());
+    service.seekSession(session.getSessionId(), 300);
+    segmentStore.addSegment(session.getSessionId(), "segment10.ts", new byte[] {1});
+    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment10.ts");
+
+    assertThat(transcodeExecutor.getStartedRequests()).hasSize(requestsBefore);
+  }
+
+  @Test
   @DisplayName("Should resume at the absolute segment position when resuming after seek")
   void shouldResumeAtTheAbsoluteSegmentPositionWhenResumingAfterSeek() {
     var file = seedMediaFile();

--- a/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
@@ -281,11 +281,6 @@ class SessionReaperTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void destroySession(UUID sessionId) {
       sessions.remove(sessionId);
     }

--- a/src/test/java/com/streamarr/server/services/streaming/StreamingShutdownHookTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/StreamingShutdownHookTest.java
@@ -72,11 +72,6 @@ class StreamingShutdownHookTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void destroySession(UUID sessionId) {
       sessions.remove(sessionId);
       destroyedIds.add(sessionId);

--- a/src/test/java/com/streamarr/server/services/streaming/local/InMemoryStreamSessionRepositoryTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/local/InMemoryStreamSessionRepositoryTest.java
@@ -2,6 +2,7 @@ package com.streamarr.server.services.streaming.local;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.streamarr.server.domain.streaming.PlaybackState;
 import com.streamarr.server.fixtures.StreamSessionFixture;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +96,7 @@ class InMemoryStreamSessionRepositoryTest {
     var session = StreamSessionFixture.buildMpegtsSession();
     repository.save(session);
 
-    session.seek(300);
+    session.updatePlaybackState(300, PlaybackState.PLAYING);
     repository.save(session);
 
     assertThat(repository.count()).isEqualTo(1);


### PR DESCRIPTION
Implements #199.

## Summary
- Serve one full-duration media playlist per session: segment `i` always covers media time `[i*segDur, (i+1)*segDur)`, `#EXT-X-MEDIA-SEQUENCE:0`, regardless of seeking — player position and duration now equal real media time
- Generalize segment-request-driven transcoding beyond suspended sessions: a request for a missing segment that is behind the encoder start, or more than 24s ahead of produced output (predecessor-segment probe), stops and restarts ffmpeg at that segment under the existing resume mutex; near-future requests keep waiting on the 10s segment wait
- `TranscodeHandle` carries the transcode's start segment so the service knows what a running encoder will produce
- Remove `seekStreamSession` outright (schema, resolver, service) - clients seek locally and the encoder relocates from segment requests; with no production deployments there is nothing to migrate
- Remove the now write-only `seekOrigin` from `PlaybackSnapshot`/`StreamSession`

## Why

Verified against a live server: seeking a 6100s movie to 600s trimmed the playlist from 1017 to 917 segments with the timeline restarting at zero, positions reported on the seeked session were stored uncompensated, and an AVPlayer probe showed `currentTime` from 0 with `duration` 5500s. Every client had to carry a compensating seek-offset (streamarr/streamarr-apple#35) and native transport bars were wrong on resumed sessions. Jellyfin and Seanime both use the full-playlist / segment-request-driven architecture this PR adopts; the ffmpeg foundation (input-side `-ss`, `-copyts`, `-start_number`) was already in place.

## Test plan
- [x] `./mvnw verify` — 1254 unit + 289 integration tests, 0 failures; Checkstyle + Spotless clean
- [x] TDD: trimmed-playlist tests rewritten to the absolute contract (RED first); relocation behind-start / far-ahead / near-encoder / segment-exists cases covered; seeking now driven entirely through segment requests
- [x] Deploy preview: playlist byte-identical across seeks (1017 segments), AVPlayer local seek to 600s played at `duration` 6100s with zero stalls, positions round-trip absolutely (see PR comment for transcripts)

## Client note

streamarr-apple drops `seekStreamSession` and `timelineBaseSeconds` in a paired branch: resume becomes a local player seek and reported positions are the player's own (absolute) positions. The two changes ship together; there are no production deployments to stage across.
