### PR TITLE
Enforce stream-session ownership on seek, destroy, and timeline

### DIFF
--- a/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
@@ -37,6 +37,10 @@ public class StreamSession {
   private final AtomicReference<PlaybackSnapshot> playbackSnapshot =
       new AtomicReference<>(new PlaybackSnapshot(0, PlaybackState.STOPPED, Instant.now(), 0));
 
+  public boolean isOwnedBy(UUID candidateProfileId) {
+    return profileId != null && profileId.equals(candidateProfileId);
+  }
+
   public void updatePlaybackState(int positionSeconds, PlaybackState state) {
     playbackSnapshot.updateAndGet(
         current ->

--- a/src/main/java/com/streamarr/server/graphql/resolvers/StreamingResolver.java
+++ b/src/main/java/com/streamarr/server/graphql/resolvers/StreamingResolver.java
@@ -45,14 +45,16 @@ public class StreamingResolver {
   @DgsMutation
   public StreamSessionDto seekStreamSession(
       @InputArgument String sessionId, @InputArgument int positionSeconds) {
-    var session = streamingService.seekSession(parseUuid(sessionId), positionSeconds);
+    var session =
+        streamingService.seekSession(
+            parseUuid(sessionId), authorizationService.requireProfile(), positionSeconds);
 
     return toDto(session);
   }
 
   @DgsMutation
   public boolean destroyStreamSession(@InputArgument String sessionId) {
-    streamingService.destroySession(parseUuid(sessionId));
+    streamingService.destroySession(parseUuid(sessionId), authorizationService.requireProfile());
 
     return true;
   }

--- a/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -94,10 +94,12 @@ public class HlsStreamingService implements StreamingService {
   }
 
   @Override
-  public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+  public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
+    // Unowned reads as missing — a foreign profile must not learn the session exists.
     var session =
         sessionRepository
             .findById(sessionId)
+            .filter(s -> s.isOwnedBy(profileId))
             .orElseThrow(() -> new SessionNotFoundException(sessionId));
 
     transcodeExecutor.stop(sessionId);
@@ -108,6 +110,15 @@ public class HlsStreamingService implements StreamingService {
 
     log.info("Seek-ed session {} to position {}s", sessionId, positionSeconds);
     return session;
+  }
+
+  @Override
+  public void destroySession(UUID sessionId, UUID profileId) {
+    // No-op for unowned sessions, matching the idempotent no-op for missing ones.
+    sessionRepository
+        .findById(sessionId)
+        .filter(session -> session.isOwnedBy(profileId))
+        .ifPresent(session -> destroySession(sessionId));
   }
 
   @Override

--- a/src/main/java/com/streamarr/server/services/streaming/StreamingService.java
+++ b/src/main/java/com/streamarr/server/services/streaming/StreamingService.java
@@ -14,7 +14,9 @@ public interface StreamingService {
 
   void destroySession(UUID sessionId);
 
-  StreamSession seekSession(UUID sessionId, int positionSeconds);
+  void destroySession(UUID sessionId, UUID profileId);
+
+  StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds);
 
   Collection<StreamSession> getAllSessions();
 

--- a/src/main/java/com/streamarr/server/services/watchprogress/SessionProgressService.java
+++ b/src/main/java/com/streamarr/server/services/watchprogress/SessionProgressService.java
@@ -45,9 +45,11 @@ public class SessionProgressService {
       return;
     }
 
+    // Unowned reads as missing — a foreign profile must not learn the session exists.
     var session =
         sessionRepository
             .findById(sessionId)
+            .filter(s -> s.isOwnedBy(profileId))
             .orElseThrow(() -> new SessionNotFoundException(sessionId));
 
     session.updatePlaybackState(positionSeconds, state);

--- a/src/test/java/com/streamarr/server/controllers/StreamControllerIT.java
+++ b/src/test/java/com/streamarr/server/controllers/StreamControllerIT.java
@@ -218,13 +218,18 @@ class StreamControllerIT extends AbstractIntegrationTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+    public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
       throw new UnsupportedOperationException();
     }
 
     @Override
     public void destroySession(UUID sessionId) {
       sessions.remove(sessionId);
+    }
+
+    @Override
+    public void destroySession(UUID sessionId, UUID profileId) {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/com/streamarr/server/controllers/StreamControllerTest.java
+++ b/src/test/java/com/streamarr/server/controllers/StreamControllerTest.java
@@ -465,13 +465,18 @@ class StreamControllerTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+    public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
       throw new UnsupportedOperationException();
     }
 
     @Override
     public void destroySession(UUID sessionId) {
       // no-op for test fake
+    }
+
+    @Override
+    public void destroySession(UUID sessionId, UUID profileId) {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/com/streamarr/server/fixtures/StreamSessionFixture.java
+++ b/src/test/java/com/streamarr/server/fixtures/StreamSessionFixture.java
@@ -87,8 +87,7 @@ public final class StreamSessionFixture {
     return sessionWithDurationBuilder(durationSeconds).build();
   }
 
-  public static StreamSession.StreamSessionBuilder sessionWithDurationBuilder(
-      int durationSeconds) {
+  public static StreamSession.StreamSessionBuilder sessionWithDurationBuilder(int durationSeconds) {
     return defaultSessionBuilder()
         .mediaProbe(defaultProbeBuilder().duration(Duration.ofSeconds(durationSeconds)).build());
   }

--- a/src/test/java/com/streamarr/server/fixtures/StreamSessionFixture.java
+++ b/src/test/java/com/streamarr/server/fixtures/StreamSessionFixture.java
@@ -84,9 +84,13 @@ public final class StreamSessionFixture {
   }
 
   public static StreamSession buildSessionWithDuration(int durationSeconds) {
+    return sessionWithDurationBuilder(durationSeconds).build();
+  }
+
+  public static StreamSession.StreamSessionBuilder sessionWithDurationBuilder(
+      int durationSeconds) {
     return defaultSessionBuilder()
-        .mediaProbe(defaultProbeBuilder().duration(Duration.ofSeconds(durationSeconds)).build())
-        .build();
+        .mediaProbe(defaultProbeBuilder().duration(Duration.ofSeconds(durationSeconds)).build());
   }
 
   public static StreamSession buildSessionForMediaFile(UUID mediaFileId) {
@@ -94,6 +98,10 @@ public final class StreamSessionFixture {
   }
 
   public static StreamSession buildZeroDurationSession() {
+    return zeroDurationSessionBuilder().build();
+  }
+
+  public static StreamSession.StreamSessionBuilder zeroDurationSessionBuilder() {
     return defaultSessionBuilder()
         .sourcePath(Path.of("/media/corrupt.mkv"))
         .mediaProbe(
@@ -103,7 +111,6 @@ public final class StreamSessionFixture {
                 .width(0)
                 .height(0)
                 .bitrate(0)
-                .build())
-        .build();
+                .build());
   }
 }

--- a/src/test/java/com/streamarr/server/graphql/resolvers/StreamingResolverTest.java
+++ b/src/test/java/com/streamarr/server/graphql/resolvers/StreamingResolverTest.java
@@ -17,6 +17,7 @@ import com.streamarr.server.services.authorization.SecurityContextAuthorizationS
 import com.streamarr.server.services.streaming.StreamingService;
 import com.streamarr.server.services.watchprogress.SessionProgressService;
 import com.streamarr.server.services.watchprogress.WatchStatusService;
+import com.streamarr.server.support.security.TestIdentityConstants;
 import com.streamarr.server.support.security.WithProfileContext;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -258,6 +259,39 @@ class StreamingResolverTest {
   }
 
   @Test
+  @DisplayName("Should pass authenticated profile to service when seeking session")
+  void shouldPassAuthenticatedProfileToServiceWhenSeekingSession() {
+    var sessionId = UUID.randomUUID();
+    STUB_SERVICE.setNextResult(buildSession(sessionId));
+
+    var mutation =
+        String.format(
+            """
+            mutation {
+              seekStreamSession(sessionId: "%s", positionSeconds: 300) {
+                id
+              }
+            }
+            """,
+            sessionId);
+
+    dgsQueryExecutor.executeAndExtractJsonPath(mutation, "data.seekStreamSession.id");
+
+    assertThat(STUB_SERVICE.getLastSeekProfileId()).isEqualTo(TestIdentityConstants.PROFILE_ID);
+  }
+
+  @Test
+  @DisplayName("Should pass authenticated profile to service when destroying session")
+  void shouldPassAuthenticatedProfileToServiceWhenDestroyingSession() {
+    var mutation =
+        String.format("mutation { destroyStreamSession(sessionId: \"%s\") }", UUID.randomUUID());
+
+    dgsQueryExecutor.executeAndExtractJsonPath(mutation, "data.destroyStreamSession");
+
+    assertThat(STUB_SERVICE.getLastDestroyProfileId()).isEqualTo(TestIdentityConstants.PROFILE_ID);
+  }
+
+  @Test
   @DisplayName("Should return error when seek session ID is invalid")
   void shouldReturnErrorWhenSeekSessionIdIsInvalid() {
     var result =
@@ -320,6 +354,8 @@ class StreamingResolverTest {
 
     private StreamSession nextResult;
     private StreamingOptions lastReceivedOptions;
+    private UUID lastSeekProfileId;
+    private UUID lastDestroyProfileId;
 
     void setNextResult(StreamSession session) {
       this.nextResult = session;
@@ -327,6 +363,14 @@ class StreamingResolverTest {
 
     StreamingOptions getLastReceivedOptions() {
       return lastReceivedOptions;
+    }
+
+    UUID getLastSeekProfileId() {
+      return lastSeekProfileId;
+    }
+
+    UUID getLastDestroyProfileId() {
+      return lastDestroyProfileId;
     }
 
     @Override
@@ -341,13 +385,19 @@ class StreamingResolverTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+    public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
+      this.lastSeekProfileId = profileId;
       return nextResult;
     }
 
     @Override
     public void destroySession(UUID sessionId) {
       // no-op for test fake
+    }
+
+    @Override
+    public void destroySession(UUID sessionId, UUID profileId) {
+      this.lastDestroyProfileId = profileId;
     }
 
     @Override

--- a/src/test/java/com/streamarr/server/services/library/StreamingSessionCleanupListenerTest.java
+++ b/src/test/java/com/streamarr/server/services/library/StreamingSessionCleanupListenerTest.java
@@ -94,7 +94,12 @@ class StreamingSessionCleanupListenerTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+    public void destroySession(UUID sessionId, UUID profileId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceIT.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceIT.java
@@ -131,10 +131,11 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should update seek position when seeking session")
   void shouldUpdateSeekPositionWhenSeekingSession() {
+    var profileId = UUID.randomUUID();
     var session =
-        streamingService.createSession(savedMediaFile.getId(), UUID.randomUUID(), defaultOptions());
+        streamingService.createSession(savedMediaFile.getId(), profileId, defaultOptions());
 
-    var seeked = streamingService.seekSession(session.getSessionId(), 300);
+    var seeked = streamingService.seekSession(session.getSessionId(), profileId, 300);
 
     assertThat(seeked.getPlaybackSnapshot().positionSeconds()).isEqualTo(300);
     assertThat(seeked.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
@@ -145,7 +146,7 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
   void shouldThrowWhenSeekingNonexistentSession() {
     var nonExistentId = UUID.randomUUID();
 
-    assertThatThrownBy(() -> streamingService.seekSession(nonExistentId, 300))
+    assertThatThrownBy(() -> streamingService.seekSession(nonExistentId, UUID.randomUUID(), 300))
         .isInstanceOf(SessionNotFoundException.class);
   }
 

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -328,10 +328,11 @@ class HlsStreamingServiceTest {
   @DisplayName("Should update seek position when seeking session")
   void shouldUpdateSeekPositionWhenSeekingSession() {
     var file = seedMediaFile();
-    var session = service.createSession(file.getId(), UUID.randomUUID(), defaultOptions());
+    var profileId = UUID.randomUUID();
+    var session = service.createSession(file.getId(), profileId, defaultOptions());
     var originalSessionId = session.getSessionId();
 
-    var seeked = service.seekSession(originalSessionId, 300);
+    var seeked = service.seekSession(originalSessionId, profileId, 300);
 
     assertThat(seeked.getSessionId()).isEqualTo(originalSessionId);
     assertThat(seeked.getPlaybackSnapshot().positionSeconds()).isEqualTo(300);
@@ -341,9 +342,10 @@ class HlsStreamingServiceTest {
   @DisplayName("Should restart transcode when seeking")
   void shouldRestartTranscodeWhenSeeking() {
     var file = seedMediaFile();
-    var session = service.createSession(file.getId(), UUID.randomUUID(), defaultOptions());
+    var profileId = UUID.randomUUID();
+    var session = service.createSession(file.getId(), profileId, defaultOptions());
 
-    var seeked = service.seekSession(session.getSessionId(), 300);
+    var seeked = service.seekSession(session.getSessionId(), profileId, 300);
 
     assertThat(seeked.getHandle()).isNotNull();
     assertThat(transcodeExecutor.isRunning(session.getSessionId())).isTrue();
@@ -353,9 +355,10 @@ class HlsStreamingServiceTest {
   @DisplayName("Should stop old transcode when seeking to new position")
   void shouldStopOldTranscodeWhenSeekingToNewPosition() {
     var file = seedMediaFile();
-    var session = service.createSession(file.getId(), UUID.randomUUID(), defaultOptions());
+    var profileId = UUID.randomUUID();
+    var session = service.createSession(file.getId(), profileId, defaultOptions());
 
-    service.seekSession(session.getSessionId(), 300);
+    service.seekSession(session.getSessionId(), profileId, 300);
 
     assertThat(transcodeExecutor.getStopped()).contains(session.getSessionId());
   }
@@ -365,8 +368,47 @@ class HlsStreamingServiceTest {
   void shouldThrowWhenSeekingNonexistentSession() {
     var invalidId = UUID.randomUUID();
 
-    assertThatThrownBy(() -> service.seekSession(invalidId, 300))
+    assertThatThrownBy(() -> service.seekSession(invalidId, UUID.randomUUID(), 300))
         .isInstanceOf(SessionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("Should throw when seeking session owned by another profile")
+  void shouldThrowWhenSeekingSessionOwnedByAnotherProfile() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), UUID.randomUUID(), defaultOptions());
+    var sessionId = session.getSessionId();
+    var otherProfileId = UUID.randomUUID();
+
+    assertThatThrownBy(() -> service.seekSession(sessionId, otherProfileId, 300))
+        .isInstanceOf(SessionNotFoundException.class);
+    assertThat(transcodeExecutor.getStopped()).doesNotContain(sessionId);
+    assertThat(transcodeExecutor.isRunning(sessionId)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should not destroy session when destruction requested by another profile")
+  void shouldNotDestroySessionWhenDestructionRequestedByAnotherProfile() {
+    var file = seedMediaFile();
+    var session = service.createSession(file.getId(), UUID.randomUUID(), defaultOptions());
+
+    service.destroySession(session.getSessionId(), UUID.randomUUID());
+
+    assertThat(service.accessSession(session.getSessionId())).isPresent();
+    assertThat(transcodeExecutor.isRunning(session.getSessionId())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should destroy session when destruction requested by owning profile")
+  void shouldDestroySessionWhenDestructionRequestedByOwningProfile() {
+    var file = seedMediaFile();
+    var profileId = UUID.randomUUID();
+    var session = service.createSession(file.getId(), profileId, defaultOptions());
+
+    service.destroySession(session.getSessionId(), profileId);
+
+    assertThat(service.accessSession(session.getSessionId())).isEmpty();
+    assertThat(transcodeExecutor.isRunning(session.getSessionId())).isFalse();
   }
 
   @Test
@@ -824,9 +866,10 @@ class HlsStreamingServiceTest {
       "Should compute resume position from seek origin and segment index when resuming after seek")
   void shouldComputeResumePositionFromSeekOriginAndSegmentIndexWhenResumingAfterSeek() {
     var file = seedMediaFile();
-    var session = service.createSession(file.getId(), UUID.randomUUID(), defaultOptions());
+    var profileId = UUID.randomUUID();
+    var session = service.createSession(file.getId(), profileId, defaultOptions());
 
-    service.seekSession(session.getSessionId(), 60);
+    service.seekSession(session.getSessionId(), profileId, 60);
 
     session.updatePlaybackState(120, PlaybackState.PLAYING);
     assertThat(session.getSeekOrigin()).isEqualTo(60);

--- a/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
@@ -281,13 +281,18 @@ class SessionReaperTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+    public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
       throw new UnsupportedOperationException();
     }
 
     @Override
     public void destroySession(UUID sessionId) {
       sessions.remove(sessionId);
+    }
+
+    @Override
+    public void destroySession(UUID sessionId, UUID profileId) {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/com/streamarr/server/services/streaming/StreamingShutdownHookTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/StreamingShutdownHookTest.java
@@ -72,7 +72,7 @@ class StreamingShutdownHookTest {
     }
 
     @Override
-    public StreamSession seekSession(UUID sessionId, int positionSeconds) {
+    public StreamSession seekSession(UUID sessionId, UUID profileId, int positionSeconds) {
       throw new UnsupportedOperationException();
     }
 
@@ -80,6 +80,11 @@ class StreamingShutdownHookTest {
     public void destroySession(UUID sessionId) {
       sessions.remove(sessionId);
       destroyedIds.add(sessionId);
+    }
+
+    @Override
+    public void destroySession(UUID sessionId, UUID profileId) {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/test/java/com/streamarr/server/services/watchprogress/SessionProgressServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/SessionProgressServiceTest.java
@@ -81,7 +81,7 @@ class SessionProgressServiceTest {
   }
 
   private StreamSession addSession() {
-    var session = StreamSessionFixture.buildMpegtsSession();
+    var session = StreamSessionFixture.defaultSessionBuilder().profileId(PROFILE_ID).build();
     sessionRepository.save(session);
     saveMediaFileForSession(session);
     return session;
@@ -198,7 +198,7 @@ class SessionProgressServiceTest {
     @Test
     @DisplayName("Should return early when duration is zero")
     void shouldReturnEarlyWhenDurationIsZero() {
-      var session = StreamSessionFixture.buildZeroDurationSession();
+      var session = StreamSessionFixture.zeroDurationSessionBuilder().profileId(PROFILE_ID).build();
       sessionRepository.save(session);
 
       service.reportStreamSessionTimeline(
@@ -217,6 +217,22 @@ class SessionProgressServiceTest {
                   service.reportStreamSessionTimeline(
                       PROFILE_ID, unknownId, 300, PlaybackState.PLAYING))
           .isInstanceOf(SessionNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("Should throw when reporting timeline for session owned by another profile")
+    void shouldThrowWhenReportingTimelineForSessionOwnedByAnotherProfile() {
+      var session = addSession();
+      var sessionId = session.getSessionId();
+      var otherProfileId = UUID.randomUUID();
+
+      assertThatThrownBy(
+              () ->
+                  service.reportStreamSessionTimeline(
+                      otherProfileId, sessionId, 300, PlaybackState.PLAYING))
+          .isInstanceOf(SessionNotFoundException.class);
+      assertThat(session.getPlaybackSnapshot().positionSeconds()).isZero();
+      assertThat(sessionProgressRepository.count()).isZero();
     }
 
     @Test
@@ -298,7 +314,10 @@ class SessionProgressServiceTest {
     @DisplayName("Should delete session progress when stopped and watched threshold is met")
     void shouldDeleteSessionProgressWhenWatchedThresholdMet(
         String description, int durationSeconds, int positionSeconds) {
-      var session = StreamSessionFixture.buildSessionWithDuration(durationSeconds);
+      var session =
+          StreamSessionFixture.sessionWithDurationBuilder(durationSeconds)
+              .profileId(PROFILE_ID)
+              .build();
       sessionRepository.save(session);
       saveMediaFileForSession(session);
 
@@ -336,7 +355,10 @@ class SessionProgressServiceTest {
         "Should not mark short content as watched via remaining seconds threshold when duration is below max remaining")
     void
         shouldNotMarkShortContentAsWatchedViaRemainingSecondsThresholdWhenDurationIsBelowMaxRemaining() {
-      var shortSession = StreamSessionFixture.buildSessionWithDuration(120); // 2 min trailer
+      var shortSession =
+          StreamSessionFixture.sessionWithDurationBuilder(120) // 2 min trailer
+              .profileId(PROFILE_ID)
+              .build();
       sessionRepository.save(shortSession);
       saveMediaFileForSession(shortSession);
 
@@ -635,7 +657,11 @@ class SessionProgressServiceTest {
   }
 
   private StreamSession addSessionForMediaFile(UUID mediaFileId) {
-    var session = StreamSessionFixture.buildSessionForMediaFile(mediaFileId);
+    var session =
+        StreamSessionFixture.defaultSessionBuilder()
+            .profileId(PROFILE_ID)
+            .mediaFileId(mediaFileId)
+            .build();
     sessionRepository.save(session);
     return session;
   }


### PR DESCRIPTION
## Scope

Stacked on #205. Closes the loop on the review finding there: `seekStreamSession`, `destroyStreamSession`, and `reportStreamSessionTimeline` resolved sessions by id alone, so any authenticated profile that learned a session UUID could seek another profile's stream (and, once #205 lands, mint a playable `?t=` URL for it), destroy it, or mutate its playback state. Pre-existing since the original HLS implementation (#38) — enforcement only became possible once sessions were stamped with an owning profile in the auth stack.

- **`StreamSession.isOwnedBy`** defines ownership once, on the domain object.
- **Owner-scoped service operations**: `seekSession(sessionId, profileId, positionSeconds)` and a `destroySession(sessionId, profileId)` overload; the resolver threads `requireProfile()` into both. The profile-less `destroySession` remains for system callers (session reaper, shutdown hook, orphaned-file cleanup listener).
- **No existence oracle**: unowned seek and timeline report throw `SessionNotFoundException` — indistinguishable from a missing session; unowned destroy no-ops, matching the idempotent no-op for missing sessions. The ownership check runs before any side effect (transcode stop, segment deletion).

Red-first: unowned seek/destroy/timeline tests at the service layer (`HlsStreamingServiceTest`, `SessionProgressServiceTest`); resolver delegation of the authenticated profile in `StreamingResolverTest`.