### PR TITLE
Adopt fenced distributed transcoding architecture

### DIFF
--- a/docs/adr/0016-authentication-mechanisms-and-session-security.adoc
+++ b/docs/adr/0016-authentication-mechanisms-and-session-security.adoc
@@ -8,7 +8,7 @@ Accepted
 
 * Issue #213's version counters are retired. Access and playback tokens no longer carry `sv`, `mv`, or `pv`; the validation/cache/listener pipeline and its database columns are removed.
 * The persisted playback-enforcement lifecycle in link:0017-playback-enforcement-lifecycle.adoc[ADR 0017] and atomic authorization-session revocation are implemented. Its joint stream-session/authorization-session authority is playback's sole revocation channel.
-* Distributed transcoding topology A (issue #76) is the recommended direction, not ratified; a future ADR 0018 decides the transport.
+* link:0018-direct-fenced-worker-control.adoc[ADR 0018] accepts topology A and direct mTLS gRPC for optional distributed transcoding; the remote path is not implemented or enabled yet.
 
 == Context
 
@@ -77,7 +77,7 @@ Playback tokens are not exempt from mandatory expiry: they carry a concrete `exp
 
 Signing keys are configuration: rotation starts issuing with a new key while old keys remain verification-only until every token they signed has expired, which short access-token TTLs keep brief.
 Tokens are signed asymmetrically (ES256, P-256), each carrying its key's RFC 7638 thumbprint as `kid`: only the media server holds the private key, and verifiers need public keys only.
-This is defense-in-depth and optionality rather than a present operational requirement: the recommended segment-serving topology for the transcode split (issue #76, topology A) proxies segments through the API server, so transcode workers never verify a playback token — but keeping the minting key private to the media server preserves worker-as-verifier and edge-verifier topologies without ever placing a signing secret beside FFmpeg and untrusted media.
+This is defense-in-depth and optionality rather than a present operational requirement: link:0018-direct-fenced-worker-control.adoc[ADR 0018]'s accepted topology A proxies segments through the API server, so transcode workers never verify a playback token — but keeping the minting key private to the media server preserves worker-as-verifier and edge-verifier topologies without ever placing a signing secret beside FFmpeg and untrusted media.
 Symmetric HMAC signing would be simpler and equivalent in a single process; it was set aside to keep those topologies open.
 A public key is never sufficient authorization, though: signature-plus-expiry checking alone cannot see revocation — for playback that authority is the stream-session row and authorization session together (link:0017-playback-enforcement-lifecycle.adoc[ADR 0017]), so any future external verifier must check that joint authority or be handed short-lived signed URLs that encode the check.
 The public verification keys are served at `/.well-known/jwks.json` (revisiting an earlier deferral: shipping ES256 without its discovery surface left the design incomplete, and the endpoint is pure public data).
@@ -198,6 +198,7 @@ Explicitly deferred from v1:
 
 * link:0015-authorization-profiles-and-content-controls.adoc[ADR 0015: Authorization, Profiles, and Content Controls]
 * link:0017-playback-enforcement-lifecycle.adoc[ADR 0017: Persisted Playback-Enforcement Lifecycle]
+* link:0018-direct-fenced-worker-control.adoc[ADR 0018: Direct, Fenced Worker Control]
 * https://github.com/streamarr/streamarr-server/issues/41[Issue #41: Authentication & User Management]
 * https://github.com/streamarr/streamarr-server/issues/163[Issue #163: Replace placeholder user ID with authenticated user from Spring Security]
 * https://github.com/streamarr/streamarr-server/issues/211[Issue #211: Persist stream sessions in PostgreSQL]

--- a/docs/adr/0017-playback-enforcement-lifecycle.adoc
+++ b/docs/adr/0017-playback-enforcement-lifecycle.adoc
@@ -8,7 +8,7 @@ Accepted
 
 * Persisted admission and locked activation, the per-request gate, runtime terminal fencing, first-wins terminalization, leased compensation, durable cleanup retry, media-parent deletion choreography, timeline integration, retention reaping, and restart reconciliation are implemented.
 * Atomic authorization-session revocation is integrated and issue #213's version counters are retired. The joint stream-session/authorization-session authority is the sole playback revocation channel.
-* The single-streaming-instance boundary holds until the distributed control plane (issue #76); `PROVISIONING` here is a local admission state, not #76's distributed capacity reservation.
+* The single-streaming-instance boundary holds until link:0018-direct-fenced-worker-control.adoc[ADR 0018]'s accepted distributed control plane is implemented; `PROVISIONING` here is local admission, not a projected or physical worker-capacity claim.
 * Media-deletion choreography and its restrictive foreign key are one invariant: authoritative parent deletion cannot bypass terminal cleanup.
 
 == Context
@@ -106,7 +106,7 @@ Graceful runtime shutdown drops only process-local directory registrations; it p
 * Every lifecycle transition is a conditional statement; read-check-write sequences in Java are structurally excluded.
 * Cleanup is durable: crash windows between terminalization, teardown, and deletion are covered by the retained `TERMINATING` row and periodic retry.
 * Parent deletion becomes choreography rather than cascade — future account/profile/grant management must route through it.
-* The single-instance boundary is explicit; the distributed control plane extends this machine (owner, generation, leases) rather than replacing it.
+* The single-instance boundary is explicit; ADR 0018 extends this machine with an exact owner, generation, durable command intent, and desired-versus-observed reconciliation rather than replacing it.
 
 == Rejected Alternatives
 
@@ -115,12 +115,13 @@ Graceful runtime shutdown drops only process-local directory registrations; it p
 * Admission serialized against revocation with `SELECT … FOR SHARE` on the auth session before the grant check — manually reproduced as a PostgreSQL deadlock (`40P01`) with concurrent grant deletion; `FOR UPDATE` strengthens the same lock inversion. Admission is a conditional checkpoint; activation is the linearization point.
 * A generic durable save/upsert for the stream row — runtime saves after suspend/resume/relocate could resurrect revoked or deleted rows; only explicit conditional lifecycle operations exist.
 * `DELETE … RETURNING` with best-effort cleanup — deletion removes the only retry marker; the terminal state is retained until external teardown succeeds.
-* Distributed `RESERVED` semantics for local admission — #76's reservation is an atomic worker-capacity claim; local `PROVISIONING` claims no capacity, so the states are named differently on purpose.
+* Distributed physical-admission semantics for local admission — ADR 0018 splits projected control-plane capacity from atomic worker `StartJob` admission; local `PROVISIONING` claims neither.
 
 == References
 
 * link:0016-authentication-mechanisms-and-session-security.adoc[ADR 0016: Authentication Mechanisms and Session Security]
 * link:0013-stream-decision-architecture.adoc[ADR 0013: Stream Decision Architecture]
+* link:0018-direct-fenced-worker-control.adoc[ADR 0018: Direct, Fenced Worker Control]
 * https://github.com/streamarr/streamarr-server/issues/211[Issue #211: Persist stream sessions in PostgreSQL]
 * https://github.com/streamarr/streamarr-server/issues/213[Issue #213: Retire token version counters]
 * https://github.com/streamarr/streamarr-server/issues/76[Issue #76: Distributed transcoding control plane]

--- a/docs/adr/0018-direct-fenced-worker-control.adoc
+++ b/docs/adr/0018-direct-fenced-worker-control.adoc
@@ -1,0 +1,385 @@
+= ADR 0018: Direct, Fenced Worker Control for Optional Distributed Transcoding
+
+== Status
+
+Accepted
+
+=== Implementation status
+
+* Streamarr still executes every transcode in the media-server process.
+* No remote worker, worker listener, certificate authority, registration path, or distributed playback route is enabled yet.
+* The implementation phases described here introduce the local application boundary before they introduce a remote transport.
+* Distributed playback remains disabled until the durable command lifecycle and topology-A segment gate are complete.
+
+== Context
+
+link:0004-processbuilder-over-jni.adoc[ADR 0004] keeps FFmpeg behind a process boundary, link:0013-stream-decision-architecture.adoc[ADR 0013] defines typed stream decisions, and link:0017-playback-enforcement-lifecycle.adoc[ADR 0017] makes the persisted stream row part of playback authority.
+The current `TranscodeExecutor` is still a process-shaped local interface: it starts one rendition at a time, carries host-local paths, exposes process health, and relies on caller-managed ordering.
+Those assumptions cannot safely express one complete adaptive ladder, an exact remote owner, an unknown RPC outcome, or a stale command arriving after relocation.
+
+Distributed transcoding is optional for a minority of self-hosted installations.
+Its default must therefore cost an ordinary installation no extra service, port, certificate, configuration, background thread, discovery work, or failure mode.
+Installations that enable it need a design that remains correct across control-plane replicas, worker restarts, lost responses, and partial network failure without giving workers Streamarr database or token-signing access.
+
+The evidence and rejected alternatives are recorded in:
+
+* link:../spikes/0018-artifact-and-runtime-footprint.adoc[Artifact and runtime footprint]
+* link:../spikes/0018-control-trust-and-capacity.adoc[Control trust and capacity]
+* link:../spikes/0018-segment-and-source-data-planes.adoc[Segment and source data planes]
+
+== Decision
+
+=== Local default and enablement gates
+
+Local execution remains the default adapter.
+When distributed configuration is absent, Streamarr creates no gRPC channel or server, starts no worker discovery or heartbeat task, opens no worker port, reads no worker certificate, and requires no broker or additional process.
+The server artifact may carry the gRPC/protobuf dependency overhead once the remote client lands, capped at a measured 15 MiB increase over the frozen baseline.
+Operational simplicity wins over publishing separate local and distributed media-server images.
+
+Enablement is staged:
+
+. Convert to the conventional reactor in a behavior-neutral, move-only Sonar preflight.
+. Extract a behavior-preserving local complete-ladder boundary and engine without remote execution.
+. Add the protobuf contract and compatibility checks without wiring a network path.
+. Add worker identity, registration, heartbeat, and observation without accepting mutating remote jobs.
+. Add the durable, fenced command lifecycle while distributed playback remains disabled.
+. Add the measured segment plane and topology-A playback gate, then enable remote assignment only after restart and failure-injection coverage passes.
+. Add deployment adapters and mixed-version hardening.
+
+=== Artifact and dependency boundary
+
+Use one repository and one conventional Maven reactor so the engine, schema, server adapters, and worker change atomically.
+Maven requires an aggregator to use `pom` packaging, so the root becomes the build parent and the existing application moves structurally into `streamarr-server/`.
+The first reactor shape is:
+
+----
+streamarr-transcode-engine
+  JDK-oriented execution model, FFmpeg planning/process lifecycle, local segments
+
+streamarr-transcode-contract
+  streamarr.transcode.v1 protobuf schema and generated gRPC transport types
+
+streamarr-server
+  application-owned TranscodeWorkerPort, local adapter, control plane, optional remote client
+
+streamarr-transcode-worker
+  narrow Spring Boot executable, engine adapter, gRPC server
+
+streamarr-coverage
+  build-only aggregate JaCoCo report
+----
+
+The server depends on the engine.
+It does not depend on the contract until a remote client adapter exists.
+The worker depends on the engine and contract, never the server.
+The engine never depends on Spring, JPA, Flyway, jOOQ, GraphQL, authentication, protobuf, or gRPC.
+The contract depends only on protobuf/gRPC schema runtimes.
+Build rules and architecture tests enforce those directions.
+
+Application records and ports remain outside generated protobuf code.
+The application-owned complete-ladder port lives in the server because it expresses the playback use case.
+Execution value types shared by the local server adapter and worker live in the engine.
+Server and worker transport adapters map those values to and from protobuf; the local adapter never serializes through protobuf.
+No separate application-API module is introduced until a second non-server application demonstrates that it removes rather than moves coupling.
+
+The worker is a narrow Spring Boot application using Boot 4.1's official gRPC server starter and shaded Netty.
+It uses environment-backed configuration, SSL bundles, deterministic lifecycle ownership, gRPC health, observability, and graceful shutdown.
+The measured worker-only cost is accepted because only distributed installations launch it and FFmpeg dominates their runtime load; reimplementing certificate, health, drain, and telemetry lifecycle by hand would create greater security and operations risk.
+The worker still excludes GraphQL, JPA, Flyway, jOOQ, authentication repositories, and the media-server application context.
+
+The structural move lands before behavior in its own draft pull request.
+If Sonar does not preserve moved-file lineage and reports the existing application as new code, stop that slice and resolve the structural-analysis policy explicitly; never hide the move with exclusions or adopt a permanently exceptional reactor merely to evade the tool.
+
+=== Complete-ladder worker boundary
+
+Introduce an application-owned `TranscodeWorkerPort` instead of extending the process-shaped
+`TranscodeExecutor` across a network boundary.
+One `StartJob` owns the complete requested variant ladder or publishes none of it.
+Every generation writes to worker-local staging that the segment gateway cannot resolve.
+Startup readiness requires every rendition process to remain alive and produce its required initialization/playlist artifacts plus the first playable segment.
+Only after every rendition reaches that point does the worker atomically publish the generation; a start failure compensates every process and discards staging.
+If one rendition later dies, the complete job fails and stops rather than silently serving a partial ladder; recovery chooses a new generation and may deliberately choose a different complete ladder.
+The local adapter preserves the same staging, readiness, publication, and compensation rule.
+One playback lifecycle fence surrounds the complete ladder, not one fence per FFmpeg process.
+
+The port accepts a typed `StartJobCommand` envelope containing:
+
+* `command_id` and the exact target `worker_id` and `boot_id` recorded with durable command intent;
+* a `TranscodeJobSpec` with `session_id`, `job_id`, monotonically increasing generation, one
+  portable `MediaSourceRef`, the complete typed rendition ladder and stream decisions, and bounded
+  execution and segment-output parameters.
+
+The command envelope owns delivery and fencing identity; the job specification owns execution
+intent and never contains transport retry state. `StopJobCommand` uses the same envelope identity
+with the exact job and generation. Read-only inspection names its target but has no command id.
+
+It returns typed admission and observation results.
+Inspection reports per-rendition state so the controller can still detect one dead member of a ladder.
+Every mutation carries target worker, target boot, `job_id`, and generation; a delayed old-boot start or stop is rejected and cannot affect a replacement.
+PID and `java.lang.Process` remain engine-local diagnostics.
+`forceStopAll` remains an engine/runtime shutdown operation and is never a remote method.
+
+=== Protobuf contract and compatibility
+
+Remote control uses protobuf package `streamarr.transcode.v1` over gRPC.
+The schema carries typed values, never `google.protobuf.Any`, embedded JSON, raw FFmpeg arguments, API-local `Path`, or process PID.
+Generated sources stay under Maven `target` directories and are not committed.
+Maven downloads pinned platform-specific `protoc` and grpc-java generators; developer-installed generators are not required.
+
+Evolution is additive within `v1`.
+Removed field names and numbers are reserved, unknown enum values are rejected at adapter boundaries, and compatibility ranges are advertised during registration.
+Buf format, lint, and breaking checks compare the proposed schema against the pull request's actual base revision.
+Generated sources are excluded from Sonar issue, duplication, and coverage analysis while the hand-written mappers remain covered.
+The protobuf service defines a typed `ReadSegment` request and bounded `SegmentChunk` stream after the byte-plane spike selected gRPC; media bytes remain data-plane payload while `MediaSourceRef` and every semantic command use the same versioned schema discipline.
+
+=== Service ownership and PostgreSQL
+
+The media-server control plane alone owns PostgreSQL.
+It stores desired job state, selected worker and generation, projected capacity, durable command intent and attempts, observations, and cleanup state.
+Workers receive no database credential and PostgreSQL is not their service API or message bus.
+
+Every mutation follows:
+
+----
+commit desired state + command intent
+  → dispatch after commit to the exact worker
+  → worker idempotently applies the exact generation
+  → record the observation
+  → reconcile desired versus observed state
+----
+
+The command row is the recovery record, not a promise of delivery.
+The dispatcher scans pending work after startup and on a bounded cadence.
+PostgreSQL `LISTEN/NOTIFY` may reduce wake-up latency inside the control plane, but notification loss cannot lose work and no worker consumes it.
+`SKIP LOCKED` coordinates dispatcher replicas only.
+
+Distributed job, command, and cleanup records are lifecycle authority, not cascade-owned children of a stream session, authorization session, media row, or worker registration.
+Parent or source deletion first terminalizes the exact job and writes its cleanup intent in the same transaction; restrictive deletion choreography preserves the identifiers needed to stop or quarantine the worker generation.
+Cleanup remains independently durable until the exact generation is acknowledged absent or authoritative boot cleanup proves it absent.
+A missing source never prevents stop or cleanup.
+Pending, unknown-outcome, and cleanup-bearing commands are never compacted.
+After acknowledged terminal cleanup and a bounded retry/reconciliation retention window, a command may compact to the smallest tombstone that still binds its command id, canonical digest, and result; compaction must not make a delayed duplicate executable again.
+
+=== Identity, connection direction, and discovery
+
+Direct mutual-TLS gRPC is the initial transport.
+Each worker runs one application-owned gRPC endpoint for job control and bounded segment streaming.
+The worker initiates registration and periodic heartbeat RPCs to the control plane and advertises that endpoint.
+The control plane validates the registration, dials the advertised endpoint, and accepts it only when the peer certificate names the same worker.
+The control plane then creates or reuses a channel for that exact worker; DNS or round-robin load balancing never chooses job ownership.
+
+Worker identity is stable across process restarts; `boot_id` is a new random UUID for every worker process.
+The installation UUID is the SPIFFE trust domain and the identity URI is:
+
+----
+spiffe://<installation-uuid>/streamarr/control/<control-node-id>
+spiffe://<installation-uuid>/streamarr/worker/<worker-id>
+----
+
+`boot_id` is process incarnation only and never enters the certificate identity.
+The URI SAN, registered `worker_id`, heartbeat identity, and advertised endpoint must agree.
+TLS validation always checks the installation chain, validity, EKU, revocation, and exact expected URI identity; using SPIFFE identity instead of DNS naming never disables certificate verification.
+An endpoint becomes ready only after the control plane dials it and a nonce proof returns the registered worker identity, `boot_id`, and certificate.
+The controller persists a binding epoch over worker, boot, endpoint, and certificate.
+A new `boot_id`, endpoint replacement, certificate replacement, revocation, or incompatible protocol advertisement advances that epoch and invalidates the old channel and observations.
+Reuse of the endpoint by another identity is rejected.
+
+The initial topology requires the media server to reach each worker's advertised endpoint.
+Workers behind outbound-only NAT, intermittently connected workers, and remote leaf sites are explicitly unsupported until the NATS escalation path is justified.
+Kubernetes discovery supplies candidate endpoints through an adapter, but never replaces application identity or exact-worker selection.
+
+=== Certificate bootstrap, rotation, and recovery
+
+Distributed mode provides a built-in private root and online issuing intermediate because administrator-provisioned PKI would dominate the operational cost for the intended home-server deployment.
+Administrator-provided certificates are a deferred adapter, not a second bootstrap path in the initial release.
+The worker and control-plane certificates use separate key pairs from access-token signing.
+
+The first bootstrap node creates one installation-scoped CA secret at a dedicated persistent path and records the installation id, public chain, and root fingerprint in PostgreSQL.
+Every control-plane replica mounts that same secret, verifies it against the recorded fingerprint, and refuses distributed startup on a missing or mismatched root; replicas never generate independent authorities.
+The private CA key is never stored in PostgreSQL, logged, exported through the API, reused for JWT signing, or copied to a worker.
+Backups of distributed configuration must include this secret; losing it requires explicitly re-enrolling workers under a new trust domain.
+Certificate issuance and issuer/root rotation use a PostgreSQL-backed singleton leadership lease so only one replica performs signing transitions at a time.
+
+An administrator mints a worker-specific 256-bit, single-use enrollment token whose digest and roughly ten-minute expiry are stored in PostgreSQL.
+The enrollment bundle contains the control endpoint, trust-bundle fingerprint, and token.
+The worker generates its private key locally, pins the supplied fingerprint before revealing the token, and submits a CSR containing its requested worker identity.
+The issuer ignores requested SAN authority and writes the worker identity bound to the grant.
+Issuance first durably claims the request and fixes its worker, public-key digest, serial, validity, and extensions; the leader signs without holding a database transaction, then atomically stores the certificate DER/chain and consumes the grant before returning any certificate.
+A retry after a lost response returns that stored certificate for the same request and key, while another key or worker is rejected; an expired in-progress claim may be safely re-signed from its fixed parameters because no certificate is delivered before the storing transaction commits.
+
+Worker certificates initially live seven days and rotate near half-life with jitter through an RPC authenticated by the current certificate; lifetime remains configurable after outage/recovery testing.
+Rotation permits a bounded overlap while the control plane replaces channels.
+Revocation marks the worker in authoritative control-plane state, rejects future registration/rotation, invalidates channels, and denies the certificate serial even before its natural expiry.
+Workers receive a signed revocation update so a revoked control certificate is denied per RPC without worker database access, including on an already-open channel.
+CA rotation and trust-domain replacement use explicit overlap and worker re-enrollment; they are never silent in-place key replacement.
+grpc-java credential-manager reload APIs are experimental, so live leaf reload, peer-identity verification, channel drain, and revocation are executable P5-B gates before remote mutation is enabled.
+
+=== Desired state, fencing, and idempotency
+
+`session_id` names Streamarr playback authority.
+`job_id` names one distributed execution for that session.
+Generation orders replacements of that job.
+`command_id` identifies one durable mutation attempt and is the idempotency key.
+`target_boot_id` binds that intent to one worker process and is checked before idempotency lookup or any side effect.
+
+Within one `boot_id`, the worker retains enough local job metadata to survive control-channel reconnects.
+For each job it atomically records the highest accepted generation and the result associated with each retained command id until control acknowledgement or terminal cleanup.
+Any command whose target worker or boot differs from the current process is rejected, even when the command id is unknown after restart.
+A lower generation is rejected.
+A duplicate command returns its prior result.
+The canonical mutation digest covers every envelope and specification field except `command_id`;
+reusing a command id with a different digest is rejected.
+The same job, generation, and spec under a new command id returns the existing allocation, while conflicting content is rejected rather than reinterpreted.
+A higher generation fences and cleans the prior generation before it can publish observable output.
+
+Idempotency state is boot-scoped rather than silently trusted across a process restart.
+Before allocation, the worker durably journals the boot, job, generation, unique staging/output directory, and `ADMITTING` state; after spawn it adds process-group/PID and process-start identity and retains the record through acknowledged cleanup.
+Supported deployment adapters also own the worker process tree through a container/cgroup or operating-system job boundary so worker exit terminates descendants.
+Before a new boot advertises ready, it scans the journal and managed output root, kills or quarantines every prior-boot process and segment directory, and fails readiness when it cannot prove cleanup; an `ADMITTING` record covers a crash between intent and complete process registration.
+The controller observes the new `boot_id` and creates fresh intent, normally at a higher generation; it never retargets an old-boot command.
+
+Start is all-or-nothing for the complete ladder.
+Stop is idempotent and succeeds when the exact generation is already absent.
+Terminal control-plane authority never transitions back to running from a late observation.
+Stale workers cannot publish observations, serve segments, or acknowledge cleanup for a replacement generation.
+
+=== Capacity has two authorities
+
+The control plane owns a transactionally consistent projected capacity claim across its replicas.
+The worker owns physical CPU/GPU admission.
+Neither authority claims what only the other can know.
+
+The control plane transaction creates a provisional desired assignment, projected claim keyed to worker and boot, and start-command intent carrying that same target.
+`StartJob` first rejects a mismatched target boot, then performs one atomic physical admission for the complete ladder and either accepts all required slots or starts nothing.
+There is no separate `ReserveJob` RPC in `v1`; the spike found no useful work that must occur between physical reservation and start, and an extra lease would add expiry and unknown-outcome states without increasing safety.
+
+On acceptance the controller records observed running state only after revalidating current authority.
+On rejection it releases the projected claim and may select another eligible worker.
+On timeout or connection loss, the result is unknown: the controller retries the same idempotent command against the same worker or inspects it before any reassignment.
+It never guesses that a timed-out start failed and starts the same generation elsewhere.
+
+=== RPC deadlines, retries, and reconciliation
+
+Every RPC has an explicit deadline.
+`StartJob` and `StopJob` are retryable only with the same command id, job id, worker id, target boot, and generation.
+Automatic retry is limited to transport failures that cannot change those fields; an exhausted call becomes unknown and enters reconciliation.
+Inspection, health, and list operations are read-only and may retry.
+Heartbeat is replaced by the next heartbeat rather than replayed.
+Enrollment retries only the same enrollment request id and public key so an unknown issuance outcome returns the same identity; another key requires a new grant.
+
+The worker reports supported protocol range, capabilities, drain state, `boot_id`, jobs, and per-rendition observations.
+The controller rejects incompatible ranges and does not assign new work to a draining worker.
+Control-plane restart reconstructs dispatch and reconciliation from PostgreSQL.
+Worker restart presents a new `boot_id`, finishes prior-boot quarantine before readiness, and cannot make an old or unrecognized job authoritative.
+
+grpc-java Netty owns HTTP/2 transport event loops.
+Application handlers run as blocking work on a dedicated virtual-thread-per-task executor and never block a Netty event loop.
+No reactive or actor domain model is introduced.
+
+=== Portable source data
+
+The first source adapter is a read-only shared mount.
+`MediaSourceRef` contains a logical library/mount id and a normalized relative key, never an absolute server path or URI.
+The media server derives it from the authoritative library root and media file.
+The worker maps the logical id to its configured local root.
+
+Both sides reject absolute keys, `..` traversal, normalization escape, and symbolic-link escape after resolving real paths.
+The worker opens the source read-only and FFmpeg never receives control-plane credentials.
+A ranged internal source endpoint and short-lived signed source URL are additive future adapters behind the same reference.
+Scan-time cached probe metadata remains the preferred way to remove API-side source probing from playback startup, but that storage change is outside this ADR's first implementation.
+
+=== Worker-local segments and topology A
+
+Segments stay worker-local.
+Clients continue to request every manifest, playlist, initialization segment, and media segment through Streamarr's existing playback gate:
+
+----
+client → Streamarr authoritative playback gate → selected worker → Streamarr → client
+----
+
+Workers receive neither playback JWTs, JWKS material, raw account credentials, nor signing keys.
+The server authorizes the request against link:0017-playback-enforcement-lifecycle.adoc[ADR 0017], resolves the current worker and generation, then retrieves bytes over the authenticated worker channel.
+A request admitted before revocation may finish; the first gate after committed revocation denies.
+
+The measured initial byte transport is gRPC server streaming on the worker's existing mTLS channel.
+A typed `ReadSegment` request names target worker/boot, job, generation, rendition, and segment; each `SegmentChunk` carries at most 64 KiB.
+Mutual TLS authenticates the exact control and worker identities, and the worker rejects stale or unknown ownership before opening the file.
+Rendition and segment identifiers must belong to that job's published manifest and are never treated as unchecked filesystem paths.
+HTTP/2 flow control, bounded reads, and response readiness limit queued data, cancellation stops disk reads promptly, and neither endpoint buffers the whole segment.
+The current `SegmentStore.readSegment()` `byte[]` boundary must become a streaming source before remote routing is enabled.
+Mid-stream retry is not transparent after bytes reach the client; Streamarr aborts that response and lets the HLS client request the segment again.
+
+Both spike candidates exceeded a 1 GbE payload ceiling, so throughput beyond that deployment budget does not decide the protocol.
+gRPC allocated less, stopped server read-ahead sooner after cancellation, had much tighter high-concurrency first-byte tails, completed every fork, and avoids a second listener, authentication surface, and deployment port.
+P5-D must repeat the benchmark through the actual two-JVM, two-hop proxy before enablement; if gRPC cannot satisfy bounded-memory, cancellation, and link-throughput gates there, amend this ADR and reconsider authenticated raw HTTP rather than weakening those gates.
+Public worker redirects and shared mutable output are not part of topology A.
+
+=== Kubernetes and broker escalation
+
+Kubernetes is a deployment adapter for warm worker processes, endpoint observation, drain, and vendor device-plugin resources.
+Pod, node, label, taint, and device-plugin types never enter the scheduling domain model.
+The control plane still selects an exact application worker identity and the worker still performs physical admission.
+No privileged worker is used where a vendor device plugin supplies the device.
+
+No broker is mandatory.
+NATS with JetStream is the first escalation only when a measured requirement appears: outbound-only workers, intermittently connected workers with waiting work, remote leaf sites, durable backlog/redelivery/DLQ, or independent lifecycle consumers.
+Protobuf remains the payload, PostgreSQL remains durable command intent, the control plane still selects the worker, and commands use worker-specific subjects rather than queue-group roulette.
+Kafka and Redpanda are rejected for this home-server control workload because their operational and resource cost buys throughput and log-retention characteristics Streamarr does not need.
+
+=== Explicitly deferred
+
+* NATS/JetStream transport and outbound-only workers.
+* Object-storage topology and direct-to-worker client redirects.
+* Ranged or signed source delivery beyond the shared-mount adapter.
+* Scan-time persistence of complete probe metadata.
+* Kubernetes Dynamic Resource Allocation until driver maturity and measured benefit justify it.
+* Offline re-encoding orchestration; it may reuse engine and worker plumbing but not the playback control-plane interface.
+
+== Consequences
+
+* Ordinary local installations retain one process and their existing behavior.
+* The conventional reactor requires one large source-tree move; a move-only pull request isolates Git/Sonar lineage risk before engine behavior changes.
+* The eventual server transport may add at most 15 MiB to the packaged baseline and must allocate no remote sockets or threads while disabled.
+* Distributed installations add application-owned mTLS endpoints, a private CA secret, worker enrollment, and worker mount mappings; those costs appear only when the feature is enabled.
+* The control plane can recover from crashes and lost RPC responses because desired state and command intent survive in PostgreSQL while workers apply idempotent generations.
+* PostgreSQL remains load-bearing for control-plane correctness but is not coupled to worker deployment or used as inter-service delivery.
+* A worker compromise exposes its readable media mounts, active segment data, and its own workload credential, but not Streamarr's database, account credentials, refresh tokens, playback JWTs, or signing keys.
+* Topology A spends one extra internal byte hop and media-server bandwidth to keep authorization, public TLS, and client routing in one place.
+* Direct worker endpoints are simple and lightweight but exclude outbound-only/NAT-isolated workers until the broker escalation.
+* One complete-ladder owner removes partial adaptive sets and makes capacity rejection explicit.
+* Protobuf makes compatibility a tested contract, but generated types and transport adapters add build machinery that must remain outside domain services.
+
+== Rejected Alternatives
+
+* PostgreSQL tables or notifications as the worker message bus — workers would need database credentials and schema coupling, while notifications still would not provide delivery.
+* A mandatory broker — it adds an always-on service for a feature most installations will not use; durable intent plus idempotent direct RPC is sufficient for the initial connected topology.
+* Kafka or Redpanda — their log throughput and partition model do not justify their home-server footprint here.
+* Round-robin gRPC, DNS scheduling, or a required service mesh — capability and physical capacity belong to exact workers, not interchangeable endpoints.
+* A separate `ReserveJob` lease — `StartJob` can atomically admit and start the complete ladder without another unknown-outcome and expiry protocol.
+* REST/JSON control messages — protobuf supplies typed evolution and generated clients without raw transport objects entering the application model.
+* Raw FFmpeg arguments, SSH, rffmpeg, or runtime-downloaded binaries — they export command construction and host trust instead of a bounded job contract, and repeat failure modes visible in older distributed-transcode projects.
+* Worker database access or playback-token verification — it widens the most exposed tier and duplicates the authoritative playback gate.
+* One common worker certificate — a compromised worker could impersonate every worker and endpoint binding would be meaningless.
+* Unauthenticated worker APIs — a LAN is not a trust boundary.
+* Per-rendition scheduling or soft capacity — partial ladders and silent truncation violate the playback contract.
+* Shared mutable segment output — stale owners could overwrite or serve a replacement generation.
+* Public worker redirects initially — they move TLS, reachability, authorization derivatives, and cache exposure to every worker before bandwidth pressure exists.
+* A second raw-HTTPS segment listener initially — its ordinary-concurrency throughput was higher, but both candidates exceeded the link budget while gRPC had safer cancellation/tail behavior, no stall, and one less port and authentication surface.
+* A root server JAR that also aggregates modules — Maven 3.9.16 rejects non-`pom` aggregators.
+* A nested reactor outside the root server project — it builds, but makes ordinary Maven, Paketo, IDE, jOOQ, coverage, Sonar, and release commands exceptional forever.
+* A hand-written plain-Java worker launcher — it saved measured startup and memory, but would reimplement TLS reload, health, configuration, drain, and observability already supplied by the official Boot gRPC stack.
+* A separate repository — independent release cadence would make schema compatibility and whole-stack changes harder before the boundary stabilizes.
+
+== References
+
+* link:0004-processbuilder-over-jni.adoc[ADR 0004: ProcessBuilder over JNI]
+* link:0008-server-generated-hls-playlists.adoc[ADR 0008: Server-Generated HLS Playlists]
+* link:0013-stream-decision-architecture.adoc[ADR 0013: Stream Decision Architecture]
+* link:0016-authentication-mechanisms-and-session-security.adoc[ADR 0016: Authentication Mechanisms and Session Security]
+* link:0017-playback-enforcement-lifecycle.adoc[ADR 0017: Persisted Playback-Enforcement Lifecycle]
+* https://github.com/streamarr/streamarr-server/issues/76[Issue #76: Distributed transcoding]
+* https://grpc.io/docs/guides/[gRPC reliability and transport guides]
+* https://spiffe.io/docs/latest/spiffe-specs/spiffe-id/[SPIFFE identity specification]
+* https://docs.nats.io/nats-concepts/jetstream[NATS JetStream delivery model]
+* https://github.com/UnicornTranscoder/UnicornTranscoder[UnicornTranscoder]
+* https://github.com/celesrenata/clusterjellyfin[clusterjellyfin]

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -114,6 +114,52 @@ See link:adr/0007-transcode-first-with-smart-remux.adoc[ADR 0007],
 link:adr/0009-h264-plus-av1-codec-strategy.adoc[ADR 0009],
 link:adr/0013-stream-decision-architecture.adoc[ADR 0013].
 
+== Optional Distributed Transcoding
+
+link:adr/0018-direct-fenced-worker-control.adoc[ADR 0018] accepts an optional distributed
+control plane, but the current implementation remains local-only and opens no worker listener.
+The extraction preserves the local path as the default:
+
+----
+Local (default)
+
+control plane → application TranscodeWorkerPort → local FFmpeg engine
+----
+
+When distributed execution is implemented and explicitly enabled, PostgreSQL remains private to
+the control plane. It stores desired state, exact-worker assignment, generation, projected
+capacity, command intent, observations, and cleanup state. Workers receive no database credential
+and never consume database notifications.
+
+----
+Remote (accepted, not yet implemented)
+
+commit desired state + command intent in PostgreSQL
+  → dispatch protobuf over direct mTLS gRPC to the selected worker
+  → atomically admit and start one complete rendition ladder
+  → record observation and reconcile desired versus observed state
+  → relay worker-local segment bytes through Streamarr's playback gate
+----
+
+The worker registers and heartbeats outbound to the control plane, while the control plane must be
+able to dial the worker's advertised endpoint. The peer certificate, `worker_id`, endpoint, and
+per-process `boot_id` are bound together; a replacement invalidates old channels and observations.
+This first topology therefore does not support outbound-only or NAT-isolated workers.
+
+The remote contract uses `streamarr.transcode.v1` protobuf messages with command, job, session, and
+generation identity. Mutations are idempotent and generation-fenced. The control plane owns its
+projected capacity claim; the worker owns atomic physical admission inside `StartJob`. One worker
+owns the complete adaptive ladder, and PID, raw FFmpeg arguments, host paths, playback tokens, and
+signing material never cross the boundary.
+
+Sources use a logical mount/library id plus normalized relative key. Segments remain worker-local
+and return as bounded protobuf `SegmentChunk` streams over the selected worker's existing mTLS
+gRPC channel only after the authoritative playback gate succeeds. Streamarr translates that
+internal stream to the client's HLS HTTP response; workers expose no second byte-serving listener.
+NATS/JetStream is deferred until outbound-only or intermittently connected workers, remote leaf
+sites, or durable broker backlog become real requirements; Kafka and Redpanda are not part of this
+home-server control path.
+
 == Authentication and Revocation
 
 Identity, sessions, and token security follow
@@ -143,12 +189,12 @@ because a refetch on unknown `kid` can be answered with the cached pre-rotation 
 blank signing key generates an ephemeral key pair at startup (tokens die on restart; sessions
 recover through refresh).
 
-ES256 exists for the planned transcode split: horizontally scaled transcode nodes running
+ES256 also preserves verifier optionality for the accepted transcode split: horizontally scaled transcode nodes running
 FFmpeg are the most exposed tier and must never hold a token-minting secret. Signature
 verification alone never authorizes a request, though -- revocation is authoritative state,
 not signature checking. Every playlist, init, and segment request consults ADR 0017's joint
 stream-session/authorization-session authority; the first gate evaluated after committed session
-revocation denies. Under the recommended proxy topology for the transcode split (issue #76),
+revocation denies. Under ADR 0018's accepted proxy topology,
 workers never verify playback tokens at all.
 The public verification keys are served at `/.well-known/jwks.json` (ADR 0016).
 
@@ -209,4 +255,7 @@ See link:adr/[Architecture Decision Records] for detailed rationale. Summary:
 
 | Stream decision architecture
 | Per-stream decision records compose into TranscodeDecision; mode resolution considers all stream types (link:adr/0013-stream-decision-architecture.adoc[ADR 0013])
+
+| Optional distributed transcoding
+| Local by default; exact-worker protobuf/mTLS control, no worker database access, and topology-A bounded gRPC segment relay when enabled (link:adr/0018-direct-fenced-worker-control.adoc[ADR 0018])
 |===

--- a/docs/spikes/0018-artifact-and-runtime-footprint.adoc
+++ b/docs/spikes/0018-artifact-and-runtime-footprint.adoc
@@ -1,0 +1,205 @@
+= ADR 0018 Spike: Artifact and Runtime Footprint
+
+== Scope
+
+This bounded spike selects the repository artifact boundary and worker runtime for link:../adr/0018-direct-fenced-worker-control.adoc[ADR 0018].
+Every prototype lived under `/private/tmp/streamarr-p5-a0-artifact-spike-02091f81`; no spike implementation entered the repository.
+
+Baseline commit: `02091f81e1d14272e5a770e8e114b95991a81ffa`.
+
+Environment:
+
+----
+Darwin 25.5.0 arm64
+Oracle OpenJDK 25.0.1
+Apache Maven 3.9.16
+grpc-java 1.80.0
+protobuf-java 4.34.2
+Spring Boot 4.1.0
+----
+
+== Frozen baseline
+
+The exact B2 executable JAR is 143,562,940 bytes (136.91 MiB).
+The merged JaCoCo report covers 7,717 of 7,958 lines (96.97%) and 1,884 of 2,075 branches (90.80%).
+The current `src` tree contains 45,420 production and 56,439 test Java lines, 101,859 total.
+
+These values describe the frozen input, not an acceptance exception for future code.
+Every later pull request still needs its normal new-code coverage, duplication, issue, hotspot, and line-count gates.
+
+Baseline commands:
+
+----
+git rev-parse HEAD
+./mvnw verify
+stat -f '%z %N' target/server-0.0.1-SNAPSHOT.jar
+xmllint --xpath 'string(/report/counter[@type="LINE"]/@covered)' \
+  target/site/jacoco-merged-test-coverage-report/jacoco.xml
+xmllint --xpath 'string(/report/counter[@type="LINE"]/@missed)' \
+  target/site/jacoco-merged-test-coverage-report/jacoco.xml
+find src/main/java -name '*.java' -print0 | xargs -0 wc -l
+find src/test/java -name '*.java' -print0 | xargs -0 wc -l
+----
+
+== Reactor alternatives
+
+Three same-repository layouts were exercised.
+
+=== Root server JAR as aggregator
+
+The attractive low-churn idea was to keep the root application JAR and add `<modules>` beside it.
+Maven rejected the model before any build:
+
+----
+'packaging' with value 'jar' is invalid.
+Aggregator projects require 'pom' as packaging.
+----
+
+Characterization command:
+
+----
+./mvnw -f /private/tmp/streamarr-p5-a0-artifact-spike-02091f81/rootjar/pom.xml validate
+----
+
+This is not a viable Maven reactor.
+
+=== Nested reactor around the root server
+
+A separate `build/reactor/pom.xml` successfully aggregated modules outside its own directory, including the root server JAR.
+Maven topologically sorted deliberately misordered declarations and `-pl :split-server -am` built contract, engine, then server.
+
+----
+./mvnw \
+  -f /private/tmp/streamarr-p5-a0-artifact-spike-02091f81/splitreactor/build/reactor/pom.xml \
+  -pl :split-server -am package
+----
+
+Observed order:
+
+----
+split-contract
+split-engine
+split-server
+----
+
+The layout is technically valid but permanently exceptional:
+
+* ordinary `./mvnw verify` cannot resolve an uninstalled sibling engine and may silently omit module tests after local installation;
+* every full command needs the nested `-f` path or global Maven configuration that changes unrelated goal behavior;
+* `${maven.multiModuleProjectDirectory}` becomes `build/reactor`, so coverage paths escape through `../../`;
+* independent child POMs duplicate plugin and dependency management unless another nested parent is introduced;
+* Paketo needs custom reactor arguments and explicit artifact selection;
+* IDE import, Renovate, jOOQ generation, Sonar, CI, and release tooling must all understand the exception.
+
+One controlled structural move is cheaper than preserving those footguns indefinitely.
+
+=== Conventional root POM
+
+A root `packaging=pom` parent with ordinary server and worker child modules built successfully with the standard command shape:
+
+----
+./mvnw -f /private/tmp/streamarr-p5-a0-artifact-spike-02091f81/rootpom/pom.xml package
+----
+
+Select the conventional layout:
+
+----
+pom.xml                          root parent and aggregator
+streamarr-transcode-contract/    protobuf schema/generated transport
+streamarr-transcode-engine/      execution model and FFmpeg engine
+streamarr-server/                existing Spring Boot application
+streamarr-transcode-worker/      narrow worker application
+streamarr-coverage/              aggregate JaCoCo report
+----
+
+The application source tree must move into `streamarr-server/` without package renaming or behavior changes.
+The root owns shared version, compiler, formatting, Checkstyle, JaCoCo, and dependency management.
+Spring Boot packaging and Flyway/jOOQ generation stay server-only.
+Paketo selects `streamarr-server` through its documented multi-module build/module controls; the worker receives its own image and tag.
+
+== Sonar move risk
+
+The conventional conversion structurally moves more than 100,000 Java lines.
+Git can recognize exact renames, but Sonar does not promise that every moved-file lineage will remain old code in pull-request analysis.
+
+Make the conversion a behavior-neutral, move-only draft pull request before extraction or package renaming.
+Run exact-head Sonar immediately.
+If Sonar preserves the lineage, continue under ordinary gates.
+If it treats the application as roughly 45,000 new production lines, stop and resolve the structural-analysis policy explicitly.
+Do not add exclusions, distort new-code settings, mix behavior into the move, or adopt the nested reactor merely to evade analysis.
+
+After the move, use a dedicated `streamarr-coverage` module with `jacoco:report-aggregate`.
+Point each analyzed module at one reactor-level XML report and assert that the report exists and contains the moved engine classes before Sonar runs.
+Generated protobuf sources remain outside issue, duplication, and coverage analysis.
+
+== Worker runtime comparison
+
+Two minimal executable workers implemented one protobuf-capable unary gRPC service with shaded Netty.
+The plain worker owned its launcher and lifecycle directly.
+The Boot worker used Spring Boot 4.1's official `spring-boot-starter-grpc-server`.
+
+Both ran unloaded with:
+
+----
+-Xms16m -Xmx64m -XX:+UseSerialGC
+----
+
+[cols="1,1,1",options="header"]
+|===
+|Measurement |Plain Java |Spring Boot 4.1
+|Packaged JAR |18.98 MiB |28.83 MiB
+|Runtime artifacts |21 |46
+|Median startup, three runs |164 ms |791 ms
+|JVM threads |14 |16
+|Listening sockets |1 |1
+|Median idle RSS |45.5 MiB |123.0 MiB
+|===
+
+macOS RSS was noisy: plain ranged 33.7-63.0 MiB and Boot 54.3-129.2 MiB.
+Treat RSS as directional; artifact size, startup, and thread counts were steadier.
+
+Choose the Boot worker despite its measured distributed-only overhead.
+The official stack supplies consistent configuration, SSL bundles/mTLS integration, lifecycle, health, interceptors, graceful shutdown, and observability.
+Reimplementing those security and operations boundaries in a custom launcher would save memory but create more bespoke code at the most exposed tier.
+FFmpeg will dominate the resource use of installations that opt into a worker.
+
+The worker remains narrow.
+Using Boot does not permit GraphQL, JPA, Flyway, jOOQ, authentication repositories, token signing, or media-server domain wiring in its dependency graph.
+
+== Local zero-tax contract
+
+The future server-side contract, stubs, and remote client are projected to add about 14.28 MiB to the packaged baseline.
+Accept at most a 15 MiB packaged-server increase.
+If the implemented path exceeds it, revisit transport artifact splitting rather than silently moving the budget.
+
+With distributed mode absent or disabled, require exactly:
+
+* no worker process;
+* no gRPC or segment listener;
+* no gRPC transport, heartbeat, registration, or discovery thread;
+* no channel or endpoint resolution;
+* no certificate, worker, or broker configuration requirement;
+* unchanged local FFmpeg behavior.
+
+Pin these properties with an application-context integration test and an exact-process startup/socket/thread measurement after the real remote client lands.
+The server remains one published image; operational simplicity is worth the bounded binary overhead.
+
+== Later build gates
+
+* `./mvnw verify` from the repository root builds every module and executes every test/plugin once.
+* Reactor order places contract and engine before their consumers and coverage last.
+* Only the server runs Flyway/jOOQ generation and Spring Boot application packaging.
+* The aggregate JaCoCo XML contains server and engine classes and is non-empty before Sonar.
+* The ordinary local server starts without distributed configuration and opens no worker resource.
+* Paketo builds the explicit server artifact; a separate worker build produces the worker image.
+* Preview/release workflows, `spring-boot:run`, jOOQ generation, IDE import, Renovate, Snyk, and Sonar all discover the intended modules.
+* The move-only pull request remains behavior-neutral and uses the exact frozen B2 lineage.
+
+== References
+
+* https://maven.apache.org/guides/mini/guide-multiple-modules.html[Maven reactor guide]
+* https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven[SonarScanner for Maven]
+* https://docs.sonarsource.com/sonarqube-server/2025.5/analyzing-source-code/test-coverage/java-test-coverage[Sonar Java coverage aggregation]
+* https://docs.spring.io/spring-boot/reference/io/grpc.html[Spring Boot gRPC]
+* https://docs.spring.io/spring-grpc/reference/server.html[Spring gRPC server]
+* https://paketo.io/docs/howto/java/[Paketo Java multi-module builds]

--- a/docs/spikes/0018-control-trust-and-capacity.adoc
+++ b/docs/spikes/0018-control-trust-and-capacity.adoc
@@ -1,0 +1,174 @@
+= ADR 0018 Spike: Control Trust and Capacity
+
+== Scope
+
+This bounded spike tests the identity, endpoint-binding, idempotency, fencing, and two-authority capacity decisions in link:../adr/0018-direct-fenced-worker-control.adoc[ADR 0018].
+It is executable contract evidence, not production transport code.
+The disposable harness stayed under `/private/tmp` and no spike implementation entered the repository.
+
+Baseline commit: `02091f81e1d14272e5a770e8e114b95991a81ffa`.
+
+Environment:
+
+----
+Darwin 25.5.0 arm64
+OpenJDK 25.0.1
+Apache Maven 3.9.16
+Python 3.14.6
+----
+
+== Questions
+
+* Can physical capacity be checked separately from mutation without over-admission?
+* Can one `StartJob` atomically admit a complete ladder and subsume a separate reservation lease?
+* What must duplicate, lost-response, stale-generation, and worker-restart behavior mean?
+* How is an advertised endpoint bound to the registered worker rather than trusted as payload?
+* Which certificate bootstrap is proportionate for an optional home-server feature?
+* Which connection directions work without a service mesh, and what reachability do they exclude?
+
+== Disposable model
+
+The model represents one boot epoch of a worker with an atomic lock around command lookup, generation fencing, complete-ladder capacity admission, and result recording.
+A deliberately broken comparison performs capacity check and mutation separately.
+A registry model binds authenticated SPIFFE identity, worker id, `boot_id`, endpoint, and certificate fingerprint before returning a channel epoch.
+A controller model loses a successful start response, restarts from durable intent, inspects the worker, and records the existing allocation.
+
+Command:
+
+----
+python3 /private/tmp/streamarr-p5a0-control-spike/control_plane_sim.py
+----
+
+Observed result:
+
+----
+PASS: characterization: split capacity check over-admits
+PASS: simultaneous final-slot StartJob (500 rounds)
+PASS: duplicate StartJob and lost response
+PASS: same command ID with different payload
+PASS: lower generation
+PASS: worker restart boot_id fence
+PASS: endpoint/certificate identity binding
+PASS: control restart reconciliation
+----
+
+The characterization synchronizes two callers after both see one free slot and before either mutation.
+Both start, consuming two units from capacity one.
+The atomic model repeats the same synchronized final-slot race 500 times; exactly one complete ladder starts in every round.
+This reproduces the check-then-act failure and validates why physical admission belongs inside one worker operation.
+
+The duplicate and lost-response cases establish three distinct rules:
+
+* the same command id and canonical request digest returns the recorded result;
+* the same command id with different content is a conflict;
+* the same job, generation, and spec under a different command id returns the existing allocation rather than starting twice.
+
+The restart case establishes that `boot_id` is an execution epoch.
+Every mutation carries its target worker and boot, and the worker rejects a mismatch before idempotency lookup or side effects.
+The disposable harness does not model operating-system process ownership, so production additionally requires a crash-durable worker journal written before allocation and a container, cgroup, or operating-system job boundary that owns descendants.
+A new process must use those records to clean or quarantine prior-boot processes and generation directories before advertising ready, and must fail readiness when it cannot prove cleanup.
+Control restart recovery scans durable intent and inspects before redispatch; it does not infer failure from a lost response.
+
+== Trust decision
+
+Use an opt-in built-in Streamarr CA with a private root and online issuing intermediate.
+Requiring an administrator to create and rotate a private PKI would dominate the operational cost for the intended audience.
+An external issuer remains possible later because identities follow the SPIFFE URI shape, but the first release implements one bootstrap path.
+
+The trust domain is the installation UUID.
+Stable identities are:
+
+----
+spiffe://<installation-uuid>/streamarr/control/<control-node-uuid>
+spiffe://<installation-uuid>/streamarr/worker/<worker-uuid>
+----
+
+`boot_id` is a process incarnation and never a certificate identity.
+Each leaf contains one exact URI SAN and client/server authentication usage.
+Endpoint addresses are locators, not certificate identity.
+
+An enrollment grant is worker-specific, contains a 256-bit random single-use token, expires after roughly ten minutes, and is stored only as a digest.
+The operator transfers the token with the control endpoint and root fingerprint.
+The worker pins that fingerprint before sending the token, creates its private key locally, and submits a CSR.
+The issuer writes the identity from the grant rather than trusting CSR SAN authority.
+
+The first bootstrap node creates one installation CA secret and stores its public chain and
+fingerprint in PostgreSQL. Every control-plane replica mounts that same secret and refuses
+distributed startup if it is absent or mismatched. A PostgreSQL singleton leadership lease owns
+certificate signing and rotation, preventing replicas from creating competing authorities.
+
+Issuance first durably claims the enrollment request and fixes its worker, public-key digest,
+serial, validity, and extensions. The leader signs outside the database transaction, then
+atomically stores the certificate DER/chain and consumes the grant before returning it. A retry
+with the same request and key returns the stored certificate after a lost response; another key or
+worker is rejected. An expired claim may be signed again from the fixed parameters because no
+certificate is delivered before the storing transaction commits.
+
+CA and node private keys live in owner-only persistent state volumes, separate from PostgreSQL and
+JWT signing. The database and trust state must be backed up together; a mismatched restore requires
+re-enrollment.
+
+Leaf certificates initially live seven days and renew near half-life with jitter.
+This accepts a longer offline credential window than a datacenter SVID in exchange for several days of home-server outage tolerance.
+Authoritative revocation still removes the worker from scheduling, closes channels, invalidates its binding epoch, and distributes a signed revocation update that workers check per RPC.
+Root or issuer rotation is an explicit dual-trust maintenance operation.
+
+grpc-java exposes reloadable credential managers, but the advanced APIs are experimental.
+P5-B must prove live reload, old-channel drain, exact URI verification, expiry, and revocation with real mTLS before any mutating worker method is enabled.
+
+== Endpoint and connection decision
+
+Enrollment, registration, rotation, and heartbeat travel worker to control plane.
+Health proof, job mutation, inspection, and segment retrieval travel control plane to the exact worker.
+Registration derives worker identity from the TLS peer and rejects a mismatched payload id.
+
+Registration alone does not make an endpoint ready.
+The control plane dials the advertised endpoint, expects that worker's exact identity, sends a nonce proof, and requires the same `boot_id` and certificate observed during registration.
+Worker, boot, endpoint, and certificate form an increasing binding epoch; any change closes stale channels and invalidates old observations.
+
+This topology works on one LAN, a Compose network, a Kubernetes network, or an operator-provided VPN/port mapping without a service mesh.
+A worker-initiated unary registration connection is not a reverse unary-RPC tunnel.
+Outbound-only and CGNAT workers need a later bidirectional command stream or NATS transport, and their segment-return path must be solved at the same time.
+UPnP, STUN, and TURN are outside the design.
+
+== Capacity decision
+
+PostgreSQL owns a projected claim across control-plane replicas.
+The claim, desired assignment, and command intent are committed in one transaction by a conditional update or row lock.
+The worker owns physical admission and atomically accepts every required unit for the complete ladder or none.
+Every rendition writes into generation-scoped staging hidden from segment lookup.
+The worker atomically publishes the generation only after every rendition is alive and has produced its initialization data, playlist, and first playable segment; any startup failure publishes nothing, and a later rendition death fails the complete job.
+
+`StartJob` subsumes physical reservation.
+No measured operation needs to occur between a worker hold and process startup, so `ReserveJob` would add a lease id, TTL, expiry, unknown result, compensation, and restart protocol without closing a gap.
+It is reconsidered only if source staging, GPU partitioning, or another measured operation genuinely requires a physical hold before start.
+
+A timed-out start remains unknown.
+The controller retains its projected claim and retries the identical command against the identical worker/boot or inspects that job.
+It releases or reassigns only after authoritative rejection, confirmed absence, a boot change, or terminal authority.
+
+== Required production tests
+
+The later implementation repeats these contracts through public interfaces with real gRPC and PostgreSQL:
+
+* simultaneous final-slot admission;
+* duplicate `StartJob` and conflicting command digest;
+* successful start with a lost response;
+* lower-generation start and stop, plus an unknown command targeting an old boot;
+* worker restart and old-boot command rejection;
+* crash between admission journaling and process registration;
+* prior-boot process/segment quarantine and readiness refusal when cleanup is unprovable;
+* certificate/worker mismatch and endpoint reuse;
+* replicated-control startup with one CA fingerprint and conflicting-secret refusal;
+* lost-response enrollment issuance, concurrent issuers, expiry, revocation, leaf rotation, and old-channel drain;
+* all-rendition startup publication and later single-rendition death;
+* control-plane restart with pending and successfully applied intents.
+
+== References
+
+* https://spiffe.io/docs/latest/spiffe-specs/spiffe-id/[SPIFFE identity specification]
+* https://spiffe.io/docs/latest/spiffe-specs/x509-svid/[SPIFFE X.509-SVID profile]
+* https://spiffe.io/docs/latest/spiffe-specs/spiffe_trust_domain_and_bundle/[SPIFFE trust-domain and bundle profile]
+* https://github.com/grpc/grpc-java/security[grpc-java transport security]
+* https://grpc.io/docs/guides/keepalive/[gRPC keepalive]
+* https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/[Kubernetes TLS bootstrap]

--- a/docs/spikes/0018-segment-and-source-data-planes.adoc
+++ b/docs/spikes/0018-segment-and-source-data-planes.adoc
@@ -1,0 +1,286 @@
+= ADR 0018 spike: segment and source data planes
+:toc:
+
+== Status
+
+Disposable decision input, 2026-07-11. The executable harness lives only under
+`/private/tmp/streamarr-p5-dataplane-spike`; no spike implementation entered the repository.
+
+== Decision taken from this spike
+
+Use typed protobuf/gRPC for control messages and topology-A segment bytes. P5-A2 defines a
+`ReadSegment` server-streaming RPC whose `SegmentChunk` payload is bounded to 64 KiB.
+
+Both measured transports exceeded the 1 GbE payload budget. Raw HTTP was faster at ordinary
+concurrency, but gRPC allocated less, stopped server read-ahead sooner after cancellation, had far
+tighter high-concurrency first-byte tails, completed every fork, and reuses the worker's existing
+listener and mTLS identity. Those properties outweigh loopback throughput that the target network
+cannot consume.
+
+P5-D repeats the benchmark through the actual two-JVM, two-hop Streamarr path. Authenticated raw
+HTTP remains a fallback only if the production gRPC implementation misses the bounded-memory,
+cancellation, or link-throughput gates. Choosing that fallback would require an ADR amendment and
+would add a second listener, deployment port, and authentication surface.
+
+The first source adapter should be a worker-configured, read-only shared mount. It adds no source
+relay bandwidth and no mandatory infrastructure process. A ranged internal source endpoint and
+short-lived signed retrieval remain later adapters for installations that cannot share storage.
+The source reference below deliberately does not commit the domain to any adapter.
+
+== Current-code observations
+
+The current local path is not a streaming baseline:
+
+* `SegmentStore.readSegment` returns `byte[]`.
+* `LocalSegmentStore` calls `Files.readAllBytes`.
+* `StreamController` then returns `ResponseEntity<byte[]>`.
+
+Consequently, a remote implementation must not simply make `readSegment` call a remote service.
+P5-D needs a closeable streaming port with length/content-type metadata and a bounded source, used
+by both local files and the remote segment client. The controller must stream that source to the
+client rather than materialize a segment-sized array.
+
+The default segment duration is six seconds. The ladder is 0.8, 1.5, 3, and 5 Mbps video plus
+audio. This makes approximately
+512 KiB and 4 MiB representative ordinary segment sizes; 16 MiB covers high-bitrate remux/source
+material.
+
+`Library.filepathUri` and `MediaFile.filepathUri` are persisted absolute file URIs. `MediaFile`
+also carries `libraryId`. `FilepathCodec` maps those URIs back to host-local `Path` objects. None
+of those absolute paths may cross the worker boundary.
+
+== Portable source reference
+
+Use an application-owned value with two fields:
+
+[source,text]
+----
+MediaSourceRef {
+  source_namespace_id  // opaque configured namespace, commonly mapped from Library.id
+  relative_key         // exact UTF-8 '/'-separated path relative to that namespace root
+}
+----
+
+P5-A2 assigns protobuf field numbers and compatibility reservations when the first contract is
+committed; this spike fixes semantics, not wire numbering.
+
+The namespace lets different workers map the same logical library to different absolute mount
+roots. If the first implementation uses `Library.id` directly, the worker treats it as an opaque
+configuration key and never queries Streamarr's database. A later scheduling layer may map a
+library to an explicit advertised mount alias without changing `relative_key`.
+
+Canonical key rules:
+
+* non-empty and relative;
+* `/` is the only separator;
+* no leading slash, Windows drive prefix, backslash, NUL, empty segment, `.` segment, or `..`
+  segment;
+* no URI parsing or percent decoding; `%2e%2e` is literal filename data;
+* preserve exact Unicode code points and case. "Normalized" means structural path normalization,
+  not Unicode normalization or case folding.
+
+At job creation, the control plane must find the owning `Library`, decode both persisted paths,
+resolve their real paths, prove the media file is inside the library root, relativize, and encode
+the structural key once. At the worker, resolve the configured root with `toRealPath`, validate
+the key before constructing a `Path`, resolve the target with `toRealPath`, require that the real
+target still starts with the real root, and require a regular readable file.
+
+An internal symlink whose target remains inside the root may be accepted. A symlink whose target
+escapes the root is rejected. `toRealPath` plus a containment check is not an attacker-proof open:
+there is a check/open race if an actor can mutate symlinks concurrently. The initial shared mount
+must therefore be read-only in the worker, and the local filesystem administrator remains in the
+trusted deployment boundary. If that assumption changes, use a platform-specific secure-open
+strategy or reject every symlink component.
+
+The disposable test suite proved:
+
+* Unicode nested-key success;
+* rejection of `../secret.mkv`, `/etc/passwd`, `C:/Windows/system.ini`, duplicate separators,
+  `.`/`..` segments, backslashes, an empty key, and an unknown namespace;
+* rejection of a symlink inside the root whose target is outside the root;
+* literal `%2e%2e` remains inside the configured root because no URL decoding occurs.
+
+`MediaSourceResolverTest`: 5 tests, 0 failures, 0 errors.
+
+== Topology-A gRPC segment stream and authority
+
+The typed `ReadSegment` request names the exact target worker, target boot, job, generation,
+rendition, and segment. Before opening the file, the worker must validate all of the following:
+
+* the TLS peer has the control-plane client EKU and the expected SPIFFE-compatible control-plane
+  identity;
+* the target worker and boot equal this process's authenticated registration identity;
+* the job exists locally and the requested generation is exactly current;
+* the rendition and segment belong to that job's atomically published manifest rather than being
+  used as arbitrary filesystem paths.
+
+The control plane uses the channel established for the selected worker's authenticated
+registration binding. It verifies that the certificate identity equals that worker and never
+accepts an endpoint/certificate mismatch or load-balanced substitute.
+
+No bearer is required in the initial protocol because the worker accepts only the exact
+control-plane mTLS role and authorizes the exact boot/job/generation from local state. The
+benchmark also required a bearer so both candidates had an explicit request-auth rejection path;
+that was a comparison control, not evidence that two credentials are necessary. Add a short-lived,
+job/generation-scoped capability only if TLS is later terminated by an intermediary or another
+client class is allowed onto the endpoint. Never reuse an account, refresh, playback, worker, or
+enrollment token.
+
+Each `SegmentChunk` carries at most 64 KiB. Streamarr forwards those bytes into the existing HLS
+HTTP response without materializing a whole segment. A disconnected or cancelled downstream
+client cancels the worker stream and closes the file. Range support is not required for the first
+complete-segment path; add it only with an end-to-end client Range contract and tests.
+
+== Harness and method
+
+Environment:
+
+* MacBook Pro `Mac14,9`, Apple M2 Pro, 12 cores (8 performance + 4 efficiency), 16 GiB;
+* macOS 26.5.2 / Darwin 25.5.0, arm64;
+* OpenJDK 25.0.1+8-27, `-Xms512m -Xmx512m`, default collector;
+* grpc-java/netty-shaded 1.80.0;
+* TLS 1.3 with a disposable CA, server certificate for `localhost`, and client identity
+  `spiffe://streamarr.test/control-plane`;
+* both endpoints required mTLS and `Authorization: Bearer ...` before opening a file;
+* gRPC used its real Netty HTTP/2 flow control and a server-streaming method with a 64 KiB raw-byte
+  marshaller; HTTP used JDK `HttpsServer` plus JDK `HttpClient` HTTP/1.1;
+* server and client shared one JVM on loopback. Server reads were instrumented and capped at
+  64 KiB. Every complete response was checked by byte count and CRC32C;
+* files were warm/page-cached. Each fork warmed 8 x 512 KiB, 4 x 4 MiB, and 2 x 16 MiB transfers
+  before measurement;
+* request counts were 256 x 512 KiB, 64 x 4 MiB, and 16 x 16 MiB, rounded up to at least the
+  requested concurrency. Concurrency was 1, 8, and 32;
+* process CPU and cumulative thread allocation came from Java management beans. `/usr/bin/time -l`
+  supplied maximum resident set size and peak memory footprint.
+
+Exact test/build commands, run from `/private/tmp/streamarr-p5-dataplane-spike`:
+
+[source,shell]
+----
+mvn -q -Dtest=MediaSourceResolverTest test
+mvn -q -Dtest=SegmentTransportContractTest test
+mvn -q test package
+mvn -q dependency:build-classpath -Dmdep.outputFile=target/classpath.txt
+
+# HTTP fork
+/usr/bin/time -l java --enable-native-access=ALL-UNNAMED -Xms512m -Xmx512m \
+  -jar target/streamarr-p5-dataplane-spike-1.0-SNAPSHOT-jar-with-dependencies.jar \
+  http certs
+
+# gRPC fork; classpath form preserves every dependency's META-INF/services entry.
+CP=$(sed -n '1p' target/classpath.txt)
+/usr/bin/time -l java --enable-native-access=ALL-UNNAMED -Xms512m -Xmx512m \
+  -cp "target/classes:$CP" spike.DataPlaneSpike grpc certs
+----
+
+The tests were written in RED before the disposable implementations. `MediaSourceResolverTest`
+first failed compilation with the resolver/value absent, then passed 5/5. The transport contract
+first failed compilation with the transport API absent; after implementation and one correction
+that made HTTP consumer reads use the same 64 KiB application chunk, it passed 8/8.
+
+== Results
+
+The table below is one complete warmed fork for each transport. Throughput is aggregate loopback
+MiB/s. `alloc B/MiB` is total client+server allocated bytes per payload MiB. Latencies are request
+milliseconds.
+
+[cols="1,1,1,1,1,1,1,1,1",options="header"]
+|===
+|Size |C |Transport |MiB/s |alloc B/MiB |first p50 |first p95 |total p50 |total p95
+|512 KiB |1 |HTTP |345.62 |4,001,573 |0.568 |0.933 |1.362 |1.992
+|512 KiB |1 |gRPC |379.11 |3,527,391 |0.507 |0.711 |1.233 |1.601
+|512 KiB |8 |HTTP |1,015.73 |4,054,428 |0.878 |3.710 |2.471 |6.172
+|512 KiB |8 |gRPC |847.75 |3,525,160 |1.458 |2.865 |4.346 |7.829
+|512 KiB |32 |HTTP |1,393.42 |4,179,952 |2.456 |40.543 |7.477 |46.755
+|512 KiB |32 |gRPC |976.39 |3,526,685 |3.936 |5.616 |15.893 |19.911
+|4 MiB |1 |HTTP |649.55 |3,727,864 |0.522 |0.656 |6.012 |6.840
+|4 MiB |1 |gRPC |637.92 |3,420,817 |0.401 |0.589 |5.902 |8.236
+|4 MiB |8 |HTTP |2,235.39 |3,702,019 |1.079 |3.160 |13.460 |16.537
+|4 MiB |8 |gRPC |1,338.98 |3,420,918 |1.529 |2.487 |23.970 |25.802
+|4 MiB |32 |HTTP |1,712.24 |3,705,817 |16.321 |28.222 |71.396 |77.936
+|4 MiB |32 |gRPC |1,376.65 |3,417,103 |3.672 |5.310 |89.674 |97.019
+|16 MiB |1 |HTTP |713.43 |3,690,355 |0.671 |1.633 |22.319 |26.964
+|16 MiB |1 |gRPC |789.14 |3,407,739 |0.428 |1.374 |19.213 |30.709
+|16 MiB |8 |HTTP |2,445.82 |3,671,104 |1.885 |3.339 |50.644 |56.236
+|16 MiB |8 |gRPC |1,438.84 |3,412,974 |1.655 |2.023 |85.426 |93.707
+|16 MiB |32 |HTTP |1,977.82 |3,670,404 |22.960 |23.391 |257.609 |258.506
+|16 MiB |32 |gRPC |1,512.87 |3,403,238 |3.404 |3.790 |336.815 |338.241
+|===
+
+Three complete successful forks of each transport showed the same broad shape:
+
+* both exceeded 345 MiB/s sequentially, already multiple times a 1 GbE payload ceiling;
+* HTTP had materially higher aggregate throughput and lower total latency at ordinary concurrency
+  8, while gRPC was competitive sequentially;
+* gRPC allocated about 3.25-3.36 bytes per payload byte versus HTTP's approximately 3.47-3.99,
+  used less process CPU per payload at concurrency, and had far tighter concurrency-32 first-byte
+  tails;
+* successful HTTP forks reported maximum RSS 476,397,568-493,633,536 bytes; gRPC reported
+  521,109,504-552,992,768 bytes. HTTP peak-memory-footprint values were
+  461,309,152-467,354,824 bytes; gRPC was 541,263,120-565,495,056 bytes. This overstates the
+  incremental gRPC cost in the real worker because its control service already requires gRPC and
+  Netty.
+
+Failure/backpressure validation across the complete forks:
+
+[cols="1,1,1,1,1",options="header"]
+|===
+|Transport |Client cancellation threshold |Server bytes read after cancellation |Server bytes at 150 ms with slow consumer |Max application read
+|HTTP |131,072 |2,097,152-2,228,224 |2,621,440-3,211,264 |65,536
+|gRPC |131,072 |458,752 |2,097,152-2,621,440 |65,536
+|===
+
+Both transports rejected the wrong bearer before reading any segment byte. Neither completed or
+read the whole 16 MiB cancellation case. Neither read the whole 16 MiB slow-consumer case at the
+150 ms observation. gRPC's flow control allowed substantially less cancellation read-ahead.
+
+One of four attempted HTTP forks stalled in the 16 MiB/concurrency-32 scenario: at least one
+request exceeded the harness's 30-second timeout after every earlier scenario in that fork had
+completed. The other three HTTP forks completed in about six seconds; all three gRPC forks completed.
+This is a finding against the JDK `HttpsServer`/`HttpClient` spike implementation, not proof that
+HTTP as a protocol stalls. It is nevertheless why a production-stack two-hop repeat is a release
+gate rather than optional follow-up.
+
+== P5-D acceptance benchmark
+
+Before distributed playback is enabled, repeat with the generated `ReadSegment` implementation,
+the actual remote client, and the actual `StreamController` streaming response:
+
+* separate worker and control-plane JVMs;
+* one loopback baseline plus 1 GbE and a shaped 100 Mbps/20 ms path;
+* full topology A: worker file -> transport -> Streamarr -> slow/cancelled HLS client;
+* representative 512 KiB, 4 MiB, and 16 MiB segments at concurrency 1, 8, and 32;
+* cold connection once, then persistent-connection steady state;
+* allocation and peak RSS per process, not combined;
+* zero whole-segment arrays/resources at either hop; bounded outstanding bytes under a paused
+  downstream client;
+* deterministic cancellation propagation and no orphaned file descriptor or virtual thread;
+* at least 30 repeated high-concurrency forks with zero hangs/timeouts.
+
+Do not enable topology A unless the gRPC implementation passes that gate. A reasonable starting budget
+is first-byte p95 below 50 ms on the local network, application read/write chunks at most 64 KiB,
+bounded read-ahead below one ordinary 4 MiB segment after cancellation, and no throughput shortfall
+against a 1 GbE link. Tune those budgets from real deployment evidence rather than treating this
+loopback ceiling as a product promise. If gRPC misses a gate, rerun the same production-stack
+benchmark with authenticated raw HTTP and amend ADR 0018 before changing transport.
+
+== Limits
+
+* Loopback removes network loss, latency, MTU, and bandwidth effects.
+* Warm files remove storage behavior; CRC32C adds equal verification work to both candidates.
+* Client and server shared a JVM, so CPU/allocation/RSS are combined and JIT work can leak into a
+  scenario.
+* The gRPC method used real HTTP/2/TLS/flow control but raw 64 KiB response marshalling rather than
+  a generated protobuf `SegmentChunk`; generated-message allocation/copy cost may be higher.
+* The HTTP implementation was JDK `HttpsServer`/`HttpClient` HTTP/1.1, not the eventual worker and
+  Spring/Tomcat (or Netty) proxy stack.
+* The test proves bounded application reads, not zero buffering in TLS, HTTP/2, kernel socket, or
+  JDK client internals. Measured read-ahead is reported explicitly.
+* Connections were warmed and reused, matching long-lived worker channels but not enrollment or
+  cold-start handshakes.
+* grpc-netty-shaded 1.80.0 emitted Java 25 warnings for terminally deprecated `Unsafe` native
+  allocation. Track grpc-java/Netty Java 25 compatibility; the warning did not invalidate the
+  transport results.
+* `toRealPath` containment plus a read-only mount is appropriate for the stated trusted home-server
+  filesystem boundary, but it is not a capability-safe open against a hostile concurrent symlink
+  mutator.


### PR DESCRIPTION
## Summary

- records the bounded artifact, runtime, control, trust, capacity, segment, and source-data spikes
- adopts ADR 0018 for optional direct, fenced distributed transcoding
- keeps PostgreSQL private to the control plane and uses one exact-worker mTLS gRPC endpoint for typed commands and bounded segment streaming
- defines whole-ladder publication, worker-boot fencing, crash-durable cleanup, recoverable certificate issuance, and deletion-safe command authority
- aligns the authentication, playback-lifecycle, and architecture documentation

Distributed execution remains disabled. Local FFmpeg stays the default with no extra service, port, certificate, broker, channel, or background task.

## Validation

- full Maven verification
- AsciiDoc render and internal-link validation
- disposable TDD harnesses for capacity races, retries, restart fencing, endpoint binding, source containment, and segment-stream cancellation/backpressure

Refs #76
