### PR TITLE
[TEMP] Verify Snyk reactor child discovery

### DIFF
--- a/streamarr-server/pom.xml
+++ b/streamarr-server/pom.xml
@@ -13,6 +13,13 @@
     <description>Streamarr, the open source media server system.</description>
 
     <dependencies>
+        <!-- Disposable Snyk reactor-discovery probe; never merge. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>


### PR DESCRIPTION
Disposable negative-control probe. It adds a known-vulnerable dependency only to `streamarr-server/pom.xml` so the Snyk PR check proves whether the new child manifest is scanned. This PR must never merge and will be closed after the result is recorded.