### PR TITLE
Add complete local ladder execution

### DIFF
--- a/docs/adr/0018-direct-fenced-worker-control.adoc
+++ b/docs/adr/0018-direct-fenced-worker-control.adoc
@@ -96,7 +96,11 @@ Introduce an application-owned `TranscodeWorkerPort` instead of extending the pr
 `TranscodeExecutor` across a network boundary.
 One `StartJob` owns the complete requested variant ladder or publishes none of it.
 Every generation writes to worker-local staging that the segment gateway cannot resolve.
-Startup readiness requires every rendition process to remain alive and produce its required initialization/playlist artifacts plus the first playable segment.
+Startup readiness requires every rendition to remain healthy -- either running, or cleanly completed
+with a terminal playlist marker -- and produce its required initialization/playlist artifacts plus
+the first playable segment.
+Segment and initialization readiness uses no-follow file metadata rather than loading media bytes;
+playlist inspection is bounded so malformed or oversized output cannot exhaust the worker heap.
 Only after every rendition reaches that point does the worker atomically publish the generation; a start failure compensates every process and discards staging.
 If one rendition later dies, the complete job fails and stops rather than silently serving a partial ladder; recovery chooses a new generation and may deliberately choose a different complete ladder.
 The local adapter preserves the same staging, readiness, publication, and compensation rule.
@@ -115,6 +119,10 @@ with the exact job and generation. Read-only inspection names its target but has
 
 It returns typed admission and observation results.
 Inspection reports per-rendition state so the controller can still detect one dead member of a ladder.
+Aggregate observations are closed: admitting has only starting renditions; running has at least one
+running rendition and otherwise only completed renditions; completed has only completed renditions;
+failed has at least one failed rendition and no active rendition; stopped has only stopped
+renditions; absent has none.
 Every mutation carries target worker, target boot, `job_id`, and generation; a delayed old-boot start or stop is rejected and cannot affect a replacement.
 PID and `java.lang.Process` remain engine-local diagnostics.
 `forceStopAll` remains an engine/runtime shutdown operation and is never a remote method.
@@ -282,8 +290,12 @@ The first source adapter is a read-only shared mount.
 `MediaSourceRef` contains a logical library/mount id and a normalized relative key, never an absolute server path or URI.
 The media server derives it from the authoritative library root and media file.
 The worker maps the logical id to its configured local root.
+Here, portable means independent of a host-specific absolute path and safe for the protocol; it does not promise that every legal source filename is representable on every worker operating system.
+An administrator using the shared-mount adapter is responsible for compatible filename semantics across the media server and selected workers.
 
-Both sides reject absolute keys, `..` traversal, normalization escape, and symbolic-link escape after resolving real paths.
+Both sides reject absolute keys, `..` traversal, normalization escape, and symbolic-link escape whenever a reference is resolved.
+The shared mount is a trusted, stable namespace for the lifetime of an admitted job: an administrator or local principal that can replace a resolved file or ancestor after validation can redirect a pathname before FFmpeg opens it.
+Streamarr does not claim pathnames are capability handles; closing that final filesystem TOCTOU window would require an OS-specific open-handle or staged-input boundary and is deferred unless the shared-mount trust assumption becomes unacceptable.
 The worker opens the source read-only and FFmpeg never receives control-plane credentials.
 A ranged internal source endpoint and short-lived signed source URL are additive future adapters behind the same reference.
 Scan-time cached probe metadata remains the preferred way to remove API-side source probing from playback startup, but that storage change is outside this ADR's first implementation.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -152,7 +152,10 @@ projected capacity claim; the worker owns atomic physical admission inside `Star
 owns the complete adaptive ladder, and PID, raw FFmpeg arguments, host paths, playback tokens, and
 signing material never cross the boundary.
 
-Sources use a logical mount/library id plus normalized relative key. Segments remain worker-local
+Sources use a logical mount/library id plus normalized relative key. Shared source mounts are
+read-only from Streamarr's perspective and are trusted not to change path identity between
+resolution and FFmpeg open; real-path checks reject escape at each resolution but are not
+filesystem capability handles. Segments remain worker-local
 and return as bounded protobuf `SegmentChunk` streams over the selected worker's existing mTLS
 gRPC channel only after the authoritative playback gate succeeds. Streamarr translates that
 internal stream to the client's HLS HTTP response; workers expose no second byte-serving listener.

--- a/streamarr-server/src/main/java/com/streamarr/server/config/StreamingConfig.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/config/StreamingConfig.java
@@ -28,6 +28,7 @@ import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.LocalFfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
+import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -40,8 +41,13 @@ import tools.jackson.databind.ObjectMapper;
 public class StreamingConfig {
 
   @Bean
-  public LocalSegmentStore segmentStore(StreamingProperties properties) {
-    return new LocalSegmentStore(Path.of(properties.segmentBasePath()));
+  public LocalSegmentStorage localSegmentStorage(StreamingProperties properties) {
+    return new LocalSegmentStorage(Path.of(properties.segmentBasePath()));
+  }
+
+  @Bean
+  public LocalSegmentStore segmentStore(LocalSegmentStorage storage) {
+    return new LocalSegmentStore(storage);
   }
 
   @Bean

--- a/streamarr-server/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
@@ -1,8 +1,8 @@
 package com.streamarr.server.domain.streaming;
 
 import com.streamarr.transcode.engine.model.QualityVariant;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
@@ -66,11 +66,11 @@ public class StreamSession {
   }
 
   public TranscodeHandle getHandle() {
-    return variantHandles.get(TranscodeRequest.DEFAULT_VARIANT);
+    return variantHandles.get(RenditionRequest.DEFAULT_VARIANT);
   }
 
   public void setHandle(TranscodeHandle handle) {
-    variantHandles.put(TranscodeRequest.DEFAULT_VARIANT, handle);
+    variantHandles.put(RenditionRequest.DEFAULT_VARIANT, handle);
   }
 
   public void setVariantHandle(String variantLabel, TranscodeHandle handle) {

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -12,9 +12,9 @@ import com.streamarr.server.repositories.media.MediaFileRepository;
 import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.library.FilepathCodec;
 import com.streamarr.transcode.engine.model.QualityVariant;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
 import com.streamarr.transcode.engine.model.TranscodeMode;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -359,7 +359,7 @@ public class HlsStreamingService implements StreamingService {
   private void startSingleTranscode(StreamSession session, int seekPosition, int startNumber) {
     var probe = session.getMediaProbe();
     var request =
-        TranscodeRequest.builder()
+        RenditionRequest.builder()
             .sessionId(session.getSessionId())
             .sourcePath(session.getSourcePath())
             .seekPosition(seekPosition)
@@ -369,7 +369,7 @@ public class HlsStreamingService implements StreamingService {
             .width(probe.width())
             .height(probe.height())
             .bitrate(probe.bitrate())
-            .variantLabel(TranscodeRequest.DEFAULT_VARIANT)
+            .variantLabel(RenditionRequest.DEFAULT_VARIANT)
             .startNumber(startNumber)
             .build();
     var handle = startTranscode(request);
@@ -381,7 +381,7 @@ public class HlsStreamingService implements StreamingService {
       StreamSession session, List<QualityVariant> variants, int seekPosition, int startNumber) {
     for (var variant : variants) {
       var request =
-          TranscodeRequest.builder()
+          RenditionRequest.builder()
               .sessionId(session.getSessionId())
               .sourcePath(session.getSourcePath())
               .seekPosition(seekPosition)
@@ -400,7 +400,7 @@ public class HlsStreamingService implements StreamingService {
     }
   }
 
-  private TranscodeHandle startTranscode(TranscodeRequest request) {
+  private TranscodeHandle startTranscode(RenditionRequest request) {
     var start =
         sessionRepository
             .beginTranscodeStart(request.sessionId())

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/TranscodeExecutor.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/TranscodeExecutor.java
@@ -1,12 +1,12 @@
 package com.streamarr.server.services.streaming;
 
 import com.streamarr.server.domain.streaming.TranscodeHandle;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import java.util.UUID;
 
 public interface TranscodeExecutor {
 
-  TranscodeHandle start(TranscodeRequest request);
+  TranscodeHandle start(RenditionRequest request);
 
   void stop(UUID sessionId);
 

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
@@ -7,9 +7,9 @@ import com.streamarr.server.services.streaming.local.LocalSegmentStore;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
-import com.streamarr.transcode.engine.model.TranscodeJob;
+import com.streamarr.transcode.engine.model.RenditionJob;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.TranscodeMode;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.nio.file.Path;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
   private final TranscodeCapabilityService capabilityService;
 
   @Override
-  public TranscodeHandle start(TranscodeRequest request) {
+  public TranscodeHandle start(RenditionRequest request) {
     var job = resolveJob(request);
     var command = commandBuilder.buildCommand(job);
 
@@ -71,26 +71,26 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
     return capabilityService.isFfmpegAvailable();
   }
 
-  private TranscodeJob resolveJob(TranscodeRequest request) {
+  private RenditionJob resolveJob(RenditionRequest request) {
     var videoEncoder = resolveEncoder(request);
     var outputDir = resolveOutputDir(request);
 
-    return TranscodeJob.builder()
+    return RenditionJob.builder()
         .request(request)
         .videoEncoder(videoEncoder)
         .outputDir(outputDir)
         .build();
   }
 
-  private Path resolveOutputDir(TranscodeRequest request) {
-    if (TranscodeRequest.DEFAULT_VARIANT.equals(request.variantLabel())) {
+  private Path resolveOutputDir(RenditionRequest request) {
+    if (RenditionRequest.DEFAULT_VARIANT.equals(request.variantLabel())) {
       return segmentStore.getOutputDirectory(request.sessionId());
     }
 
     return segmentStore.getOutputDirectory(request.sessionId(), request.variantLabel());
   }
 
-  private String resolveEncoder(TranscodeRequest request) {
+  private String resolveEncoder(RenditionRequest request) {
     var mode = request.transcodeDecision().transcodeMode();
     if (mode == TranscodeMode.REMUX || mode == TranscodeMode.AUDIO_TRANSCODE) {
       return "copy";

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
@@ -4,6 +4,7 @@ import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.services.streaming.TranscodeExecutor;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
+import com.streamarr.transcode.engine.error.TranscodeException;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
@@ -51,7 +52,11 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
 
   @Override
   public void stop(UUID sessionId) {
-    processManager.stopJob(jobRef(sessionId));
+    var jobRef = jobRef(sessionId);
+    processManager.stopJob(jobRef);
+    if (!processManager.releaseJobObservation(jobRef)) {
+      throw new TranscodeException("Transcode cleanup is still pending");
+    }
     log.info("Stopped transcode for session {}", sessionId);
   }
 

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
@@ -5,10 +5,12 @@ import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.services.streaming.TranscodeExecutor;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
 import com.streamarr.transcode.engine.model.RenditionJob;
 import com.streamarr.transcode.engine.model.RenditionRequest;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import com.streamarr.transcode.engine.model.TranscodeMode;
 import java.nio.file.Path;
 import java.util.UUID;
@@ -18,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class LocalTranscodeExecutor implements TranscodeExecutor {
+
+  private static final long LEGACY_JOB_GENERATION = 1L;
 
   private final FfmpegCommandBuilder commandBuilder;
   private final FfmpegProcessManager processManager;
@@ -33,7 +37,7 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
 
     var process =
         processManager.startProcess(
-            request.sessionId(), request.variantLabel(), command, job.outputDir());
+            processKey(request.sessionId(), request.variantLabel()), command, job.outputDir());
 
     log.info(
         "Started transcode for session {} variant {} (encoder: {}, PID: {})",
@@ -47,7 +51,7 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
 
   @Override
   public void stop(UUID sessionId) {
-    processManager.stopProcess(sessionId);
+    processManager.stopJob(jobRef(sessionId));
     log.info("Stopped transcode for session {}", sessionId);
   }
 
@@ -58,12 +62,12 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
 
   @Override
   public boolean isRunning(UUID sessionId) {
-    return processManager.isRunning(sessionId);
+    return processManager.isRunning(jobRef(sessionId));
   }
 
   @Override
   public boolean isRunning(UUID sessionId, String variantLabel) {
-    return processManager.isRunning(sessionId, variantLabel);
+    return processManager.isRunning(processKey(sessionId, variantLabel));
   }
 
   @Override
@@ -97,5 +101,13 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
     }
 
     return capabilityService.resolveEncoder(request.transcodeDecision().videoCodecFamily());
+  }
+
+  private static FfmpegProcessKey processKey(UUID sessionId, String renditionLabel) {
+    return new FfmpegProcessKey(jobRef(sessionId), renditionLabel);
+  }
+
+  private static TranscodeJobRef jobRef(UUID sessionId) {
+    return new TranscodeJobRef(sessionId, LEGACY_JOB_GENERATION);
   }
 }

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/local/LocalSegmentStore.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/local/LocalSegmentStore.java
@@ -2,178 +2,70 @@ package com.streamarr.server.services.streaming.local;
 
 import com.streamarr.server.exceptions.InvalidSegmentPathException;
 import com.streamarr.server.services.streaming.SegmentStore;
-import com.streamarr.transcode.engine.error.TranscodeException;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
+import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class LocalSegmentStore implements SegmentStore {
 
-  private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
-
-  private final Path baseDir;
-  private final ConcurrentHashMap<UUID, Path> sessionDirs = new ConcurrentHashMap<>();
+  private final LocalSegmentStorage storage;
 
   public LocalSegmentStore(Path baseDir) {
-    this.baseDir = baseDir;
+    this(new LocalSegmentStorage(baseDir));
+  }
+
+  public LocalSegmentStore(LocalSegmentStorage storage) {
+    this.storage = storage;
   }
 
   @Override
   public byte[] readSegment(UUID sessionId, String segmentName) {
-    var segmentPath = resolveSegmentPath(sessionId, segmentName);
-
     try {
-      return Files.readAllBytes(segmentPath);
-    } catch (NoSuchFileException e) {
-      throw new TranscodeException("Segment not found: " + segmentName, e);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to read segment: " + segmentName, e);
+      return storage.readSegment(sessionId, segmentName);
+    } catch (com.streamarr.transcode.engine.segment.InvalidSegmentPathException _) {
+      throw new InvalidSegmentPathException(segmentName);
     }
   }
 
   @Override
   public boolean waitForSegment(UUID sessionId, String segmentName, Duration timeout) {
-    var segmentPath = resolveSegmentPath(sessionId, segmentName);
-    var deadline = System.nanoTime() + timeout.toNanos();
-
-    while (System.nanoTime() < deadline) {
-      if (Files.exists(segmentPath)) {
-        return true;
-      }
-      try {
-        Thread.sleep(POLL_INTERVAL.toMillis());
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return false;
-      }
+    try {
+      return storage.waitForSegment(sessionId, segmentName, timeout);
+    } catch (com.streamarr.transcode.engine.segment.InvalidSegmentPathException _) {
+      throw new InvalidSegmentPathException(segmentName);
     }
-    return Files.exists(segmentPath);
   }
 
   @Override
   public boolean segmentExists(UUID sessionId, String segmentName) {
     try {
-      return Files.exists(resolveSegmentPath(sessionId, segmentName));
-    } catch (TranscodeException e) {
-      return false;
+      return storage.segmentExists(sessionId, segmentName);
+    } catch (com.streamarr.transcode.engine.segment.InvalidSegmentPathException _) {
+      throw new InvalidSegmentPathException(segmentName);
     }
   }
 
   public Path getOutputDirectory(UUID sessionId) {
-    return sessionDirs.computeIfAbsent(sessionId, this::createSessionDirectory);
+    return storage.getOutputDirectory(sessionId);
   }
 
   public Path getOutputDirectory(UUID sessionId, String variantLabel) {
-    var sessionDir = getOutputDirectory(sessionId);
-    var variantDir = sessionDir.resolve(variantLabel);
-
-    try {
-      Files.createDirectories(variantDir);
-      return variantDir;
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to create variant directory", e);
-    }
+    return storage.getOutputDirectory(sessionId, variantLabel);
   }
 
   @Override
   public Set<UUID> snapshotStoredSessionIds() {
-    var sessionIds = new HashSet<UUID>();
-    try (var entries = Files.newDirectoryStream(baseDir)) {
-      for (var entry : entries) {
-        storedSessionId(entry).ifPresent(sessionIds::add);
-      }
-    } catch (NoSuchFileException _) {
-      return Set.of();
-    } catch (IOException exception) {
-      throw new UncheckedIOException("Failed to discover stored stream sessions", exception);
-    }
-    return Set.copyOf(sessionIds);
+    return storage.snapshotStoredSessionIds();
   }
 
   @Override
   public void deleteSession(UUID sessionId) {
-    sessionDirs.remove(sessionId);
-    var dir = baseDir.resolve(sessionId.toString());
-    if (Files.exists(dir, LinkOption.NOFOLLOW_LINKS)) {
-      deleteDirectoryRecursively(dir);
-    }
+    storage.deleteSession(sessionId);
   }
 
   public void shutdown() {
-    sessionDirs.clear();
-  }
-
-  private Path resolveSegmentPath(UUID sessionId, String segmentName) {
-    var dir = sessionDirs.get(sessionId);
-    if (dir == null) {
-      throw new TranscodeException("No output directory for session: " + sessionId);
-    }
-
-    var resolved = dir.resolve(segmentName).normalize();
-    if (!resolved.startsWith(dir)) {
-      throw new InvalidSegmentPathException(segmentName);
-    }
-
-    return resolved;
-  }
-
-  private Path createSessionDirectory(UUID sessionId) {
-    var dir = baseDir.resolve(sessionId.toString());
-
-    try {
-      Files.createDirectories(dir);
-      return dir;
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to create session directory", e);
-    }
-  }
-
-  private static Optional<UUID> storedSessionId(Path entry) {
-    var name = entry.getFileName().toString();
-    try {
-      var sessionId = UUID.fromString(name);
-      return sessionId.toString().equals(name) ? Optional.of(sessionId) : Optional.empty();
-    } catch (IllegalArgumentException _) {
-      return Optional.empty();
-    }
-  }
-
-  private void deleteDirectoryRecursively(Path dir) {
-    try {
-      Files.walkFileTree(
-          dir,
-          new SimpleFileVisitor<>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
-                throws IOException {
-              Files.deleteIfExists(file);
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path directory, IOException exception)
-                throws IOException {
-              if (exception != null) {
-                throw exception;
-              }
-              Files.deleteIfExists(directory);
-              return FileVisitResult.CONTINUE;
-            }
-          });
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to clean up session directory: " + dir, e);
-    }
+    storage.shutdown();
   }
 }

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/source/LibraryMediaSourceCatalog.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/source/LibraryMediaSourceCatalog.java
@@ -1,0 +1,79 @@
+package com.streamarr.server.services.streaming.source;
+
+import com.streamarr.server.repositories.LibraryRepository;
+import com.streamarr.server.repositories.media.MediaFileRepository;
+import com.streamarr.server.services.library.FilepathCodec;
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LibraryMediaSourceCatalog implements MediaSourceCatalog {
+
+  private final MediaFileRepository mediaFileRepository;
+  private final LibraryRepository libraryRepository;
+  private final FileSystem fileSystem;
+
+  @Override
+  public MediaSourceRef referenceFor(UUID mediaFileId) {
+    var mediaFile =
+        mediaFileRepository.findById(mediaFileId).orElseThrow(MediaSourceUnavailableException::new);
+    var library =
+        libraryRepository
+            .findById(mediaFile.getLibraryId())
+            .orElseThrow(MediaSourceUnavailableException::new);
+
+    try {
+      var libraryRoot = toRealPath(library.getFilepathUri());
+      var sourcePath = requireAvailableFile(libraryRoot, toRealPath(mediaFile.getFilepathUri()));
+      var relativePath = libraryRoot.relativize(sourcePath);
+      var relativeKey = relativePath.toString().replace(fileSystem.getSeparator(), "/");
+      return new MediaSourceRef(library.getId(), relativeKey);
+    } catch (IOException | SecurityException | IllegalArgumentException exception) {
+      throw new MediaSourceUnavailableException(exception);
+    }
+  }
+
+  @Override
+  public Path resolve(MediaSourceRef source) {
+    var library =
+        libraryRepository
+            .findById(source.namespaceId())
+            .orElseThrow(MediaSourceUnavailableException::new);
+
+    try {
+      var libraryRoot = toRealPath(library.getFilepathUri());
+      var sourcePath = resolveKey(libraryRoot, source.relativeKey()).toRealPath();
+      return requireAvailableFile(libraryRoot, sourcePath);
+    } catch (IOException | SecurityException | IllegalArgumentException exception) {
+      throw new MediaSourceUnavailableException(exception);
+    }
+  }
+
+  private Path toRealPath(String filepathUri) throws IOException {
+    return FilepathCodec.decode(fileSystem, filepathUri).toRealPath();
+  }
+
+  private static Path resolveKey(Path libraryRoot, String relativeKey) {
+    var sourcePath = libraryRoot;
+    for (var segment : relativeKey.split("/")) {
+      sourcePath = sourcePath.resolve(segment);
+    }
+    return sourcePath;
+  }
+
+  private static Path requireAvailableFile(Path libraryRoot, Path sourcePath) {
+    if (!sourcePath.startsWith(libraryRoot)
+        || !Files.isRegularFile(sourcePath)
+        || !Files.isReadable(sourcePath)) {
+      throw new MediaSourceUnavailableException();
+    }
+    return sourcePath;
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/source/MediaSourceCatalog.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/source/MediaSourceCatalog.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.source;
+
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import java.nio.file.Path;
+import java.util.UUID;
+
+public interface MediaSourceCatalog {
+
+  MediaSourceRef referenceFor(UUID mediaFileId);
+
+  Path resolve(MediaSourceRef source);
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/source/MediaSourceUnavailableException.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/source/MediaSourceUnavailableException.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.source;
+
+public class MediaSourceUnavailableException extends RuntimeException {
+
+  public MediaSourceUnavailableException() {
+    super("Media source is unavailable");
+  }
+
+  public MediaSourceUnavailableException(Throwable cause) {
+    super("Media source is unavailable", cause);
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/InspectJobQuery.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/InspectJobQuery.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.worker;
+
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+
+public record InspectJobQuery(WorkerTarget target, TranscodeJobRef jobRef) {
+
+  public InspectJobQuery {
+    if (target == null || jobRef == null) {
+      throw new IllegalArgumentException("Inspection query values are required");
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StartJobCommand.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StartJobCommand.java
@@ -1,0 +1,15 @@
+package com.streamarr.server.services.streaming.worker;
+
+import com.streamarr.transcode.engine.model.TranscodeJobSpec;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record StartJobCommand(UUID commandId, WorkerTarget target, TranscodeJobSpec specification) {
+
+  public StartJobCommand {
+    if (commandId == null || target == null || specification == null) {
+      throw new IllegalArgumentException("Start command values are required");
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StartJobRejection.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StartJobRejection.java
@@ -1,0 +1,11 @@
+package com.streamarr.server.services.streaming.worker;
+
+public enum StartJobRejection {
+  TARGET_MISMATCH,
+  STALE_GENERATION,
+  COMMAND_CONFLICT,
+  JOB_CONFLICT,
+  CAPACITY_EXHAUSTED,
+  INVALID_SPECIFICATION,
+  STARTUP_FAILED
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StartJobResult.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StartJobResult.java
@@ -1,0 +1,35 @@
+package com.streamarr.server.services.streaming.worker;
+
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+
+public sealed interface StartJobResult
+    permits StartJobResult.Accepted, StartJobResult.Rejected, StartJobResult.CleanupPending {
+
+  record Accepted(TranscodeJobObservation observation) implements StartJobResult {
+
+    public Accepted {
+      requireValue(observation, "Start observation is required");
+    }
+  }
+
+  record Rejected(StartJobRejection reason) implements StartJobResult {
+
+    public Rejected {
+      requireValue(reason, "Start rejection reason is required");
+    }
+  }
+
+  record CleanupPending(TranscodeJobRef jobRef) implements StartJobResult {
+
+    public CleanupPending {
+      requireValue(jobRef, "Cleanup-pending job reference is required");
+    }
+  }
+
+  private static void requireValue(Object value, String message) {
+    if (value == null) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StopJobCommand.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StopJobCommand.java
@@ -1,0 +1,15 @@
+package com.streamarr.server.services.streaming.worker;
+
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record StopJobCommand(UUID commandId, WorkerTarget target, TranscodeJobRef jobRef) {
+
+  public StopJobCommand {
+    if (commandId == null || target == null || jobRef == null) {
+      throw new IllegalArgumentException("Stop command values are required");
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StopJobRejection.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StopJobRejection.java
@@ -1,0 +1,7 @@
+package com.streamarr.server.services.streaming.worker;
+
+public enum StopJobRejection {
+  TARGET_MISMATCH,
+  STALE_GENERATION,
+  COMMAND_CONFLICT
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StopJobResult.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/StopJobResult.java
@@ -1,0 +1,44 @@
+package com.streamarr.server.services.streaming.worker;
+
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+
+public sealed interface StopJobResult
+    permits StopJobResult.Stopped,
+        StopJobResult.AlreadyAbsent,
+        StopJobResult.CleanupPending,
+        StopJobResult.Rejected {
+
+  record Stopped(TranscodeJobRef jobRef) implements StopJobResult {
+
+    public Stopped {
+      requireValue(jobRef, "Stopped job reference is required");
+    }
+  }
+
+  record AlreadyAbsent(TranscodeJobRef jobRef) implements StopJobResult {
+
+    public AlreadyAbsent {
+      requireValue(jobRef, "Absent job reference is required");
+    }
+  }
+
+  record CleanupPending(TranscodeJobRef jobRef) implements StopJobResult {
+
+    public CleanupPending {
+      requireValue(jobRef, "Cleanup-pending job reference is required");
+    }
+  }
+
+  record Rejected(StopJobRejection reason) implements StopJobResult {
+
+    public Rejected {
+      requireValue(reason, "Stop rejection reason is required");
+    }
+  }
+
+  private static void requireValue(Object value, String message) {
+    if (value == null) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerPort.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerPort.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.worker;
+
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+
+public interface TranscodeWorkerPort {
+
+  StartJobResult start(StartJobCommand command);
+
+  StopJobResult stop(StopJobCommand command);
+
+  TranscodeJobObservation inspect(InspectJobQuery query);
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/WorkerTarget.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/worker/WorkerTarget.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.worker;
+
+import java.util.UUID;
+
+public record WorkerTarget(UUID workerId, UUID bootId) {
+
+  public WorkerTarget {
+    if (workerId == null || bootId == null) {
+      throw new IllegalArgumentException("Worker and boot identities are required");
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeFfmpegProcessManager.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeFfmpegProcessManager.java
@@ -1,51 +1,82 @@
 package com.streamarr.server.fakes;
 
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessObservation;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessState;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
 public class FakeFfmpegProcessManager implements FfmpegProcessManager {
 
-  private record ProcessKey(UUID sessionId, String variantLabel) {}
-
-  private final Set<ProcessKey> running = new HashSet<>();
+  private final Set<FfmpegProcessKey> running = new HashSet<>();
+  private final Map<FfmpegProcessKey, FfmpegProcessObservation> terminalObservations =
+      new HashMap<>();
   private final Set<UUID> started = new HashSet<>();
   private final Set<UUID> stopped = new HashSet<>();
 
   @Override
-  public Process startProcess(
-      UUID sessionId, String variantLabel, List<String> command, Path workingDir) {
-    running.add(new ProcessKey(sessionId, variantLabel));
-    started.add(sessionId);
+  public Process startProcess(FfmpegProcessKey key, List<String> command, Path workingDir) {
+    running.add(key);
+    terminalObservations.remove(key);
+    started.add(key.jobRef().jobId());
     return new StubProcess();
   }
 
   @Override
-  public void stopProcess(UUID sessionId) {
-    running.removeIf(key -> key.sessionId().equals(sessionId));
-    stopped.add(sessionId);
+  public void stopProcess(FfmpegProcessKey key) {
+    retainStopped(key);
+    stopped.add(key.jobRef().jobId());
+  }
+
+  @Override
+  public void stopJob(TranscodeJobRef jobRef) {
+    running.stream()
+        .filter(key -> key.jobRef().equals(jobRef))
+        .toList()
+        .forEach(this::retainStopped);
+    stopped.add(jobRef.jobId());
   }
 
   @Override
   public void forceStopAll() {
-    running.clear();
+    List.copyOf(running).forEach(this::retainStopped);
   }
 
   @Override
-  public boolean isRunning(UUID sessionId) {
-    return running.stream().anyMatch(key -> key.sessionId().equals(sessionId));
+  public boolean isRunning(TranscodeJobRef jobRef) {
+    return running.stream().anyMatch(key -> key.jobRef().equals(jobRef));
   }
 
   @Override
-  public boolean isRunning(UUID sessionId, String variantLabel) {
-    return running.contains(new ProcessKey(sessionId, variantLabel));
+  public boolean isRunning(FfmpegProcessKey key) {
+    return running.contains(key);
+  }
+
+  @Override
+  public FfmpegProcessObservation observe(FfmpegProcessKey key) {
+    if (running.contains(key)) {
+      return FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.RUNNING);
+    }
+    return terminalObservations.getOrDefault(
+        key, FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.ABSENT));
+  }
+
+  private void retainStopped(FfmpegProcessKey key) {
+    if (running.remove(key)) {
+      terminalObservations.put(
+          key, FfmpegProcessObservation.withExitCode(FfmpegProcessState.STOPPED, 0));
+    }
   }
 
   public Set<UUID> getStarted() {

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeFfmpegProcessManager.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeFfmpegProcessManager.java
@@ -24,6 +24,7 @@ public class FakeFfmpegProcessManager implements FfmpegProcessManager {
       new HashMap<>();
   private final Set<UUID> started = new HashSet<>();
   private final Set<UUID> stopped = new HashSet<>();
+  private boolean observationReleaseAllowed = true;
 
   @Override
   public Process startProcess(FfmpegProcessKey key, List<String> command, Path workingDir) {
@@ -74,7 +75,7 @@ public class FakeFfmpegProcessManager implements FfmpegProcessManager {
 
   @Override
   public boolean releaseJobObservation(TranscodeJobRef jobRef) {
-    if (isRunning(jobRef)) {
+    if (!observationReleaseAllowed || isRunning(jobRef)) {
       return false;
     }
     terminalObservations.keySet().removeIf(key -> key.jobRef().equals(jobRef));
@@ -94,6 +95,10 @@ public class FakeFfmpegProcessManager implements FfmpegProcessManager {
 
   public Set<UUID> getStopped() {
     return Set.copyOf(stopped);
+  }
+
+  public void preventObservationRelease() {
+    observationReleaseAllowed = false;
   }
 
   private static class StubProcess extends Process {

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeFfmpegProcessManager.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeFfmpegProcessManager.java
@@ -72,6 +72,15 @@ public class FakeFfmpegProcessManager implements FfmpegProcessManager {
         key, FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.ABSENT));
   }
 
+  @Override
+  public boolean releaseJobObservation(TranscodeJobRef jobRef) {
+    if (isRunning(jobRef)) {
+      return false;
+    }
+    terminalObservations.keySet().removeIf(key -> key.jobRef().equals(jobRef));
+    return true;
+  }
+
   private void retainStopped(FfmpegProcessKey key) {
     if (running.remove(key)) {
       terminalObservations.put(

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeTranscodeExecutor.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeTranscodeExecutor.java
@@ -3,7 +3,7 @@ package com.streamarr.server.fakes;
 import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.services.streaming.TranscodeExecutor;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -18,11 +18,11 @@ public class FakeTranscodeExecutor implements TranscodeExecutor {
   private final Set<ProcessKey> running = new HashSet<>();
   private final Set<ProcessKey> started = new HashSet<>();
   private final Set<UUID> stopped = new HashSet<>();
-  private final List<TranscodeRequest> startedRequests = new ArrayList<>();
+  private final List<RenditionRequest> startedRequests = new ArrayList<>();
   private int forceStopAllAttempts;
 
   @Override
-  public TranscodeHandle start(TranscodeRequest request) {
+  public TranscodeHandle start(RenditionRequest request) {
     startedRequests.add(request);
     var key = new ProcessKey(request.sessionId(), request.variantLabel());
     running.add(key);
@@ -85,7 +85,7 @@ public class FakeTranscodeExecutor implements TranscodeExecutor {
     running.remove(new ProcessKey(sessionId, variantLabel));
   }
 
-  public List<TranscodeRequest> getStartedRequests() {
+  public List<RenditionRequest> getStartedRequests() {
     return List.copyOf(startedRequests);
   }
 

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/SecurityExceptionFileSystem.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/SecurityExceptionFileSystem.java
@@ -26,8 +26,12 @@ public class SecurityExceptionFileSystem extends FileSystem {
   private final SecurityExceptionProvider provider;
 
   public SecurityExceptionFileSystem(FileSystem delegate) {
+    this(delegate, false);
+  }
+
+  public SecurityExceptionFileSystem(FileSystem delegate, boolean checkedAccessDenial) {
     this.delegate = delegate;
-    this.provider = new SecurityExceptionProvider(delegate.provider(), this);
+    this.provider = new SecurityExceptionProvider(delegate.provider(), this, checkedAccessDenial);
   }
 
   @Override
@@ -236,10 +240,15 @@ public class SecurityExceptionFileSystem extends FileSystem {
 
     private final FileSystemProvider delegate;
     private final SecurityExceptionFileSystem fileSystem;
+    private final boolean checkedAccessDenial;
 
-    SecurityExceptionProvider(FileSystemProvider delegate, SecurityExceptionFileSystem fileSystem) {
+    SecurityExceptionProvider(
+        FileSystemProvider delegate,
+        SecurityExceptionFileSystem fileSystem,
+        boolean checkedAccessDenial) {
       this.delegate = delegate;
       this.fileSystem = fileSystem;
+      this.checkedAccessDenial = checkedAccessDenial;
     }
 
     private static Path unwrap(Path path) {
@@ -247,7 +256,10 @@ public class SecurityExceptionFileSystem extends FileSystem {
     }
 
     @Override
-    public void checkAccess(Path path, java.nio.file.AccessMode... modes) {
+    public void checkAccess(Path path, java.nio.file.AccessMode... modes) throws IOException {
+      if (checkedAccessDenial) {
+        throw new java.nio.file.AccessDeniedException(path.toString());
+      }
       throw new SecurityException("Simulated security manager denial for path: " + path);
     }
 

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -25,8 +25,8 @@ import com.streamarr.server.fakes.FakeSegmentStore;
 import com.streamarr.server.fakes.FakeStreamSessionRepository;
 import com.streamarr.server.fakes.FakeTranscodeExecutor;
 import com.streamarr.server.services.concurrency.MutexFactory;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.TranscodeMode;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -1057,10 +1057,10 @@ class HlsStreamingServiceTest {
             .subList(requestsBefore, transcodeExecutor.getStartedRequests().size());
 
     assertThat(resumeRequests).hasSize(variantLabels.size());
-    assertThat(resumeRequests).extracting(TranscodeRequest::startNumber).containsOnly(5);
-    assertThat(resumeRequests).extracting(TranscodeRequest::seekPosition).containsOnly(30);
+    assertThat(resumeRequests).extracting(RenditionRequest::startNumber).containsOnly(5);
+    assertThat(resumeRequests).extracting(RenditionRequest::seekPosition).containsOnly(30);
     assertThat(resumeRequests)
-        .extracting(TranscodeRequest::variantLabel)
+        .extracting(RenditionRequest::variantLabel)
         .containsExactlyInAnyOrderElementsOf(variantLabels);
     for (var label : variantLabels) {
       assertThat(session.getVariantHandle(label).status()).isEqualTo(TranscodeStatus.ACTIVE);
@@ -1163,7 +1163,7 @@ class HlsStreamingServiceTest {
     private final CountDownLatch allowStart = new CountDownLatch(1);
 
     @Override
-    public TranscodeHandle start(TranscodeRequest request) {
+    public TranscodeHandle start(RenditionRequest request) {
       startEntered.countDown();
       await(allowStart);
       return delegate.start(request);

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingSmokeTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingSmokeTest.java
@@ -17,9 +17,11 @@ import com.streamarr.server.services.streaming.ffmpeg.LocalTranscodeExecutor;
 import com.streamarr.server.services.streaming.local.InMemoryStreamSessionRepository;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
 import com.streamarr.transcode.engine.ffmpeg.LocalFfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
 import com.streamarr.transcode.engine.model.ContainerFormat;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import com.streamarr.transcode.engine.model.TranscodeMode;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -357,6 +359,8 @@ class HlsStreamingSmokeTest {
   @DisplayName("Should not deadlock when FFmpeg produces verbose stderr output")
   void shouldNotDeadlockWhenFfmpegProducesVerboseStderrOutput() {
     var sessionId = UUID.randomUUID();
+    var jobRef = new TranscodeJobRef(sessionId, 1L);
+    var processKey = new FfmpegProcessKey(jobRef, "deadlock-test");
     var processManager = new LocalFfmpegProcessManager();
 
     // -loglevel debug produces ~200KB+ of stderr for a 10s video, well beyond the ~64KB pipe
@@ -365,8 +369,7 @@ class HlsStreamingSmokeTest {
     var command =
         List.of("ffmpeg", "-loglevel", "debug", "-i", TEST_VIDEO.toString(), "-f", "null", "-");
 
-    var process =
-        processManager.startProcess(sessionId, "deadlock-test", command, TEST_VIDEO.getParent());
+    var process = processManager.startProcess(processKey, command, TEST_VIDEO.getParent());
 
     await()
         .atMost(Duration.ofSeconds(30))
@@ -376,6 +379,6 @@ class HlsStreamingSmokeTest {
               assertThat(process.exitValue()).isZero();
             });
 
-    processManager.stopProcess(sessionId);
+    processManager.stopJob(jobRef);
   }
 }

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/PlaybackSessionCreationServiceIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/PlaybackSessionCreationServiceIT.java
@@ -58,7 +58,7 @@ import com.streamarr.server.services.streaming.local.InMemoryStreamSessionReposi
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
 import com.streamarr.server.support.AuthTestSupport;
 import com.streamarr.server.support.AuthTestSupport.TestIdentity;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
@@ -2133,7 +2133,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     }
 
     @Override
-    public TranscodeHandle start(TranscodeRequest request) {
+    public TranscodeHandle start(RenditionRequest request) {
       attemptedSessionId = request.sessionId();
       startAttempts++;
       if (startAttempts == 1 && firstStartObserver != null) {

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
@@ -144,7 +144,7 @@ class SessionReaperTest {
     session.setHandle(new TranscodeHandle(1234L, TranscodeStatus.ACTIVE));
     streamingService.addSession(session);
     executor.start(
-        com.streamarr.transcode.engine.model.TranscodeRequest.builder()
+        com.streamarr.transcode.engine.model.RenditionRequest.builder()
             .sessionId(session.getSessionId())
             .sourcePath(Path.of("/media/movie.mkv"))
             .seekPosition(0)
@@ -195,7 +195,7 @@ class SessionReaperTest {
     session.setVariantHandle("720p", new TranscodeHandle(101L, TranscodeStatus.FAILED));
 
     executor.start(
-        com.streamarr.transcode.engine.model.TranscodeRequest.builder()
+        com.streamarr.transcode.engine.model.RenditionRequest.builder()
             .sessionId(session.getSessionId())
             .sourcePath(Path.of("/media/movie.mkv"))
             .seekPosition(0)
@@ -230,7 +230,7 @@ class SessionReaperTest {
     session.setVariantHandle("720p", new TranscodeHandle(101L, TranscodeStatus.ACTIVE));
 
     executor.start(
-        com.streamarr.transcode.engine.model.TranscodeRequest.builder()
+        com.streamarr.transcode.engine.model.RenditionRequest.builder()
             .sessionId(session.getSessionId())
             .sourcePath(Path.of("/media/movie.mkv"))
             .seekPosition(0)
@@ -243,7 +243,7 @@ class SessionReaperTest {
             .variantLabel("1080p")
             .build());
     executor.start(
-        com.streamarr.transcode.engine.model.TranscodeRequest.builder()
+        com.streamarr.transcode.engine.model.RenditionRequest.builder()
             .sessionId(session.getSessionId())
             .sourcePath(Path.of("/media/movie.mkv"))
             .seekPosition(0)

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutorTest.java
@@ -1,10 +1,12 @@
 package com.streamarr.server.services.streaming.ffmpeg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.fakes.FakeFfmpegProcessManager;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
+import com.streamarr.transcode.engine.error.TranscodeException;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessState;
@@ -139,6 +141,19 @@ class LocalTranscodeExecutorTest {
     var key =
         new FfmpegProcessKey(new TranscodeJobRef(request.sessionId(), 1), request.variantLabel());
     assertThat(processManager.observe(key).state()).isEqualTo(FfmpegProcessState.ABSENT);
+  }
+
+  @Test
+  @DisplayName("Should reject stop when terminal observation cleanup is pending")
+  void shouldRejectStopWhenTerminalObservationCleanupIsPending() {
+    var request = createRequest(TranscodeMode.FULL_TRANSCODE, "h264", "720p");
+    var sessionId = request.sessionId();
+    executor.start(request);
+    processManager.preventObservationRelease();
+
+    assertThatThrownBy(() -> executor.stop(sessionId))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessage("Transcode cleanup is still pending");
   }
 
   @Test

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutorTest.java
@@ -6,6 +6,8 @@ import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.fakes.FakeFfmpegProcessManager;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessState;
 import com.streamarr.transcode.engine.ffmpeg.HardwareEncodingCapability;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
 import com.streamarr.transcode.engine.model.AudioDecision;
@@ -13,6 +15,7 @@ import com.streamarr.transcode.engine.model.ContainerFormat;
 import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.SubtitleDecision;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import com.streamarr.transcode.engine.model.TranscodeMode;
 import java.nio.file.Path;
 import java.util.Map;
@@ -123,6 +126,19 @@ class LocalTranscodeExecutorTest {
 
     assertThat(executor.isRunning(request.sessionId())).isFalse();
     assertThat(processManager.getStopped()).contains(request.sessionId());
+  }
+
+  @Test
+  @DisplayName("Should release terminal process observation when transcode is stopped")
+  void shouldReleaseTerminalProcessObservationWhenTranscodeIsStopped() {
+    var request = createRequest(TranscodeMode.FULL_TRANSCODE, "h264", "720p");
+    executor.start(request);
+
+    executor.stop(request.sessionId());
+
+    var key =
+        new FfmpegProcessKey(new TranscodeJobRef(request.sessionId(), 1), request.variantLabel());
+    assertThat(processManager.observe(key).state()).isEqualTo(FfmpegProcessState.ABSENT);
   }
 
   @Test

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutorTest.java
@@ -10,10 +10,10 @@ import com.streamarr.transcode.engine.ffmpeg.HardwareEncodingCapability;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
 import com.streamarr.transcode.engine.model.AudioDecision;
 import com.streamarr.transcode.engine.model.ContainerFormat;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.SubtitleDecision;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
 import com.streamarr.transcode.engine.model.TranscodeMode;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
@@ -53,13 +53,13 @@ class LocalTranscodeExecutorTest {
         new LocalTranscodeExecutor(commandBuilder, processManager, segmentStore, capabilityService);
   }
 
-  private TranscodeRequest createRequest(TranscodeMode mode, String codecFamily) {
+  private RenditionRequest createRequest(TranscodeMode mode, String codecFamily) {
     return createRequest(mode, codecFamily, null);
   }
 
-  private TranscodeRequest createRequest(
+  private RenditionRequest createRequest(
       TranscodeMode mode, String codecFamily, String variantLabel) {
-    return TranscodeRequest.builder()
+    return RenditionRequest.builder()
         .sessionId(UUID.randomUUID())
         .sourcePath(Path.of("/media/movie.mkv"))
         .seekPosition(0)

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/local/LocalSegmentStoreTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/local/LocalSegmentStoreTest.java
@@ -238,6 +238,19 @@ class LocalSegmentStoreTest {
   }
 
   @Test
+  @DisplayName("Should reject segment path traversal for wait and existence checks")
+  void shouldRejectSegmentPathTraversalForWaitAndExistenceChecks() {
+    var sessionId = UUID.randomUUID();
+    var timeout = Duration.ofMillis(1);
+    store.getOutputDirectory(sessionId);
+
+    assertThatThrownBy(() -> store.waitForSegment(sessionId, "../segment0.ts", timeout))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThatThrownBy(() -> store.segmentExists(sessionId, "../segment0.ts"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
   @DisplayName("Should read segment when name includes valid subdirectory")
   void shouldReadSegmentWhenNameIncludesValidSubdirectory() throws IOException {
     var sessionId = UUID.randomUUID();

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/local/LocalSegmentStoreTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/local/LocalSegmentStoreTest.java
@@ -160,14 +160,13 @@ class LocalSegmentStoreTest {
   }
 
   @Test
-  @DisplayName("Should fail stored session discovery when base path is not a directory")
-  void shouldFailStoredSessionDiscoveryWhenBasePathIsNotDirectory() throws IOException {
+  @DisplayName("Should fail fast when base path is not a directory")
+  void shouldFailFastWhenBasePathIsNotDirectory() throws IOException {
     var baseFile = Files.writeString(tempDir.resolve("segments.file"), "not a directory");
-    store = new LocalSegmentStore(baseFile);
 
-    assertThatThrownBy(store::snapshotStoredSessionIds)
+    assertThatThrownBy(() -> new LocalSegmentStore(baseFile))
         .isInstanceOf(java.io.UncheckedIOException.class)
-        .hasMessage("Failed to discover stored stream sessions");
+        .hasMessage("Failed to initialize segment storage");
   }
 
   @Test

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/source/LibraryMediaSourceCatalogTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/source/LibraryMediaSourceCatalogTest.java
@@ -1,0 +1,312 @@
+package com.streamarr.server.services.streaming.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.streamarr.server.domain.Library;
+import com.streamarr.server.domain.media.MediaFile;
+import com.streamarr.server.fakes.FakeLibraryRepository;
+import com.streamarr.server.fakes.FakeMediaFileRepository;
+import com.streamarr.server.fakes.SecurityExceptionFileSystem;
+import com.streamarr.server.services.library.FilepathCodec;
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+@DisplayName("Library Media Source Catalog Tests")
+class LibraryMediaSourceCatalogTest {
+
+  @TempDir private Path tempDirectory;
+
+  private FileSystem fileSystem;
+  private FakeLibraryRepository libraryRepository;
+  private FakeMediaFileRepository mediaFileRepository;
+  private MediaSourceCatalog catalog;
+
+  @BeforeEach
+  void setUp() {
+    fileSystem = Jimfs.newFileSystem(Configuration.unix());
+    libraryRepository = new FakeLibraryRepository();
+    mediaFileRepository = new FakeMediaFileRepository();
+    catalog = new LibraryMediaSourceCatalog(mediaFileRepository, libraryRepository, fileSystem);
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    fileSystem.close();
+  }
+
+  @Test
+  @DisplayName("Should create portable reference when media file is inside library")
+  void shouldCreatePortableReferenceWhenMediaFileIsInsideLibrary() throws IOException {
+    var libraryRoot = createDirectory("/media");
+    var mediaPath = createFile("/media/Films/Amélie (2001).mkv");
+    var libraryId = saveLibrary(libraryRoot);
+    var mediaFileId = saveMediaFile(libraryId, mediaPath);
+
+    var reference = catalog.referenceFor(mediaFileId);
+
+    assertThat(reference.namespaceId()).isEqualTo(libraryId);
+    assertThat(reference.relativeKey()).isEqualTo("Films/Amélie (2001).mkv");
+  }
+
+  @Test
+  @DisplayName("Should resolve readable media file when reference belongs to library")
+  void shouldResolveReadableMediaFileWhenReferenceBelongsToLibrary() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    var mediaPath = createFile("/media/Films/Arrival.mkv");
+
+    var resolved = catalog.resolve(new MediaSourceRef(libraryId, "Films/Arrival.mkv"));
+
+    assertThat(resolved).isEqualTo(mediaPath.toRealPath());
+  }
+
+  @Test
+  @DisplayName("Should reject reference when catalog entry names a directory")
+  void shouldRejectReferenceWhenCatalogEntryNamesDirectory() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    var mediaFileId = saveMediaFile(libraryId, createDirectory("/media/Films"));
+
+    assertUnavailable(() -> catalog.referenceFor(mediaFileId));
+  }
+
+  @Test
+  @DisplayName("Should reject reference when media file is unknown")
+  void shouldRejectReferenceWhenMediaFileIsUnknown() {
+    assertUnavailable(() -> catalog.referenceFor(UUID.randomUUID()));
+  }
+
+  @Test
+  @DisplayName("Should reject reference when owning library is unknown")
+  void shouldRejectReferenceWhenOwningLibraryIsUnknown() {
+    var mediaFileId = saveMediaFile(UUID.randomUUID(), "/media/movie.mkv");
+
+    assertUnavailable(() -> catalog.referenceFor(mediaFileId));
+  }
+
+  @Test
+  @DisplayName("Should reject reference when media file is missing")
+  void shouldRejectReferenceWhenMediaFileIsMissing() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    var mediaFileId = saveMediaFile(libraryId, "/media/missing.mkv");
+
+    assertUnavailable(() -> catalog.referenceFor(mediaFileId));
+  }
+
+  @Test
+  @DisplayName("Should reject reference when media file escapes library root")
+  void shouldRejectReferenceWhenMediaFileEscapesLibraryRoot() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    var mediaFileId = saveMediaFile(libraryId, createFile("/private/movie.mkv"));
+
+    assertUnavailable(() -> catalog.referenceFor(mediaFileId));
+  }
+
+  @Test
+  @DisplayName("Should reject reference when symbolic link escapes library root")
+  void shouldRejectReferenceWhenSymbolicLinkEscapesLibraryRoot() throws IOException {
+    var libraryRoot = createDirectory("/media");
+    var outsidePath = createFile("/private/movie.mkv");
+    var link = libraryRoot.resolve("movie.mkv");
+    Files.createSymbolicLink(link, outsidePath);
+    var mediaFileId = saveMediaFile(saveLibrary(libraryRoot), link);
+
+    assertUnavailable(() -> catalog.referenceFor(mediaFileId));
+  }
+
+  @Test
+  @DisplayName("Should canonicalize symbolic link when target remains inside library")
+  void shouldCanonicalizeSymbolicLinkWhenTargetRemainsInsideLibrary() throws IOException {
+    var libraryRoot = createDirectory("/media");
+    var target = createFile("/media/canonical/movie.mkv");
+    var link = libraryRoot.resolve("aliases/movie.mkv");
+    Files.createDirectories(link.getParent());
+    Files.createSymbolicLink(link, target);
+    var mediaFileId = saveMediaFile(saveLibrary(libraryRoot), link);
+
+    var reference = catalog.referenceFor(mediaFileId);
+
+    assertThat(reference.relativeKey()).isEqualTo("canonical/movie.mkv");
+    assertThat(catalog.resolve(reference)).isEqualTo(target.toRealPath());
+  }
+
+  @Test
+  @DisplayName("Should preserve percent escapes as literal filename data")
+  void shouldPreservePercentEscapesAsLiteralFilenameData() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    var mediaPath = createFile("/media/Films/%2e%2e.mkv");
+    var mediaFileId = saveMediaFile(libraryId, mediaPath);
+
+    var reference = catalog.referenceFor(mediaFileId);
+
+    assertThat(reference.relativeKey()).isEqualTo("Films/%2e%2e.mkv");
+    assertThat(catalog.resolve(reference)).isEqualTo(mediaPath.toRealPath());
+  }
+
+  @Test
+  @DisplayName("Should reject resolution when source namespace is unknown")
+  void shouldRejectResolutionWhenSourceNamespaceIsUnknown() {
+    var source = new MediaSourceRef(UUID.randomUUID(), "Films/movie.mkv");
+
+    assertUnavailable(() -> catalog.resolve(source));
+  }
+
+  @Test
+  @DisplayName("Should reject resolution when referenced file is missing")
+  void shouldRejectResolutionWhenReferencedFileIsMissing() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    var source = new MediaSourceRef(libraryId, "Films/missing.mkv");
+
+    assertUnavailable(() -> catalog.resolve(source));
+  }
+
+  @Test
+  @DisplayName("Should reject resolution when symbolic link escapes library root")
+  void shouldRejectResolutionWhenSymbolicLinkEscapesLibraryRoot() throws IOException {
+    var libraryRoot = createDirectory("/media");
+    var outsidePath = createFile("/private/movie.mkv");
+    Files.createSymbolicLink(libraryRoot.resolve("movie.mkv"), outsidePath);
+    var libraryId = saveLibrary(libraryRoot);
+    var source = new MediaSourceRef(libraryId, "movie.mkv");
+
+    assertUnavailable(() -> catalog.resolve(source));
+  }
+
+  @Test
+  @DisplayName("Should revalidate containment whenever source is resolved")
+  void shouldRevalidateContainmentWheneverSourceIsResolved() throws IOException {
+    var libraryRoot = createDirectory("/media");
+    var libraryId = saveLibrary(libraryRoot);
+    var mediaPath = createFile("/media/movie.mkv");
+    var source = new MediaSourceRef(libraryId, "movie.mkv");
+    assertThat(catalog.resolve(source)).isEqualTo(mediaPath.toRealPath());
+
+    var outsidePath = createFile("/private/movie.mkv");
+    Files.delete(mediaPath);
+    Files.createSymbolicLink(mediaPath, outsidePath);
+
+    assertUnavailable(() -> catalog.resolve(source));
+  }
+
+  @Test
+  @DisplayName("Should create forward-slash key when host filesystem uses backslashes")
+  void shouldCreateForwardSlashKeyWhenHostFilesystemUsesBackslashes() throws IOException {
+    fileSystem.close();
+    fileSystem = Jimfs.newFileSystem(Configuration.windows());
+    catalog = new LibraryMediaSourceCatalog(mediaFileRepository, libraryRepository, fileSystem);
+    var libraryRoot = fileSystem.getPath("C:\\media");
+    var mediaPath = libraryRoot.resolve("Films\\Amélie.mkv");
+    Files.createDirectories(mediaPath.getParent());
+    Files.createFile(mediaPath);
+    var libraryId = saveLibrary(libraryRoot);
+    var mediaFileId = saveMediaFile(libraryId, mediaPath);
+
+    var reference = catalog.referenceFor(mediaFileId);
+
+    assertThat(reference.relativeKey()).isEqualTo("Films/Amélie.mkv");
+    assertThat(catalog.resolve(reference)).isEqualTo(mediaPath.toRealPath());
+  }
+
+  @Test
+  @DisplayName("Should decode persisted file URIs through filepath codec")
+  void shouldDecodePersistedFileUrisThroughFilepathCodec() throws IOException {
+    var localCatalog =
+        new LibraryMediaSourceCatalog(
+            mediaFileRepository, libraryRepository, tempDirectory.getFileSystem());
+    var libraryRoot = tempDirectory.resolve("media");
+    var mediaPath = libraryRoot.resolve("Films/Arrival (2016).mkv");
+    Files.createDirectories(mediaPath.getParent());
+    Files.createFile(mediaPath);
+    var libraryId = saveLibrary(FilepathCodec.encode(libraryRoot));
+    var mediaFileId = saveMediaFile(libraryId, FilepathCodec.encode(mediaPath));
+
+    var reference = localCatalog.referenceFor(mediaFileId);
+
+    assertThat(reference.relativeKey()).isEqualTo("Films/Arrival (2016).mkv");
+    assertThat(localCatalog.resolve(reference)).isEqualTo(mediaPath.toRealPath());
+  }
+
+  @Test
+  @DisplayName("Should reject resolution when file access is denied")
+  void shouldRejectResolutionWhenFileAccessIsDenied() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    createFile("/media/movie.mkv");
+    var restrictedFileSystem = new SecurityExceptionFileSystem(fileSystem);
+    var restrictedCatalog =
+        new LibraryMediaSourceCatalog(mediaFileRepository, libraryRepository, restrictedFileSystem);
+    var source = new MediaSourceRef(libraryId, "movie.mkv");
+
+    assertUnavailable(() -> restrictedCatalog.resolve(source));
+  }
+
+  @Test
+  @DisplayName("Should reject resolution when media file is unreadable")
+  void shouldRejectResolutionWhenMediaFileIsUnreadable() throws IOException {
+    var libraryId = UUID.randomUUID();
+    var libraryRoot = fileSystem.getPath("/media");
+    Files.createDirectories(libraryRoot);
+    Files.createFile(libraryRoot.resolve("movie.mkv"));
+    libraryRepository.save(Library.builder().id(libraryId).filepathUri("/media").build());
+    var unreadableFileSystem = new SecurityExceptionFileSystem(fileSystem, true);
+    var unreadableCatalog =
+        new LibraryMediaSourceCatalog(mediaFileRepository, libraryRepository, unreadableFileSystem);
+    var source = new MediaSourceRef(libraryId, "movie.mkv");
+
+    assertUnavailable(() -> unreadableCatalog.resolve(source));
+  }
+
+  @Test
+  @DisplayName("Should reject resolution when reference names a directory")
+  void shouldRejectResolutionWhenReferenceNamesDirectory() throws IOException {
+    var libraryId = saveLibrary(createDirectory("/media"));
+    createDirectory("/media/Films");
+    var source = new MediaSourceRef(libraryId, "Films");
+
+    assertUnavailable(() -> catalog.resolve(source));
+  }
+
+  private Path createDirectory(String path) throws IOException {
+    return Files.createDirectories(fileSystem.getPath(path));
+  }
+
+  private Path createFile(String path) throws IOException {
+    var file = fileSystem.getPath(path);
+    Files.createDirectories(file.getParent());
+    return Files.createFile(file);
+  }
+
+  private UUID saveLibrary(Path libraryRoot) {
+    return saveLibrary(libraryRoot.toString());
+  }
+
+  private UUID saveLibrary(String filepathUri) {
+    return libraryRepository.save(Library.builder().filepathUri(filepathUri).build()).getId();
+  }
+
+  private UUID saveMediaFile(UUID libraryId, Path mediaPath) {
+    return saveMediaFile(libraryId, mediaPath.toString());
+  }
+
+  private UUID saveMediaFile(UUID libraryId, String filepathUri) {
+    return mediaFileRepository
+        .save(MediaFile.builder().libraryId(libraryId).filepathUri(filepathUri).build())
+        .getId();
+  }
+
+  private static void assertUnavailable(ThrowingCallable operation) {
+    assertThatThrownBy(operation).isInstanceOf(MediaSourceUnavailableException.class);
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerContractValuesTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerContractValuesTest.java
@@ -3,16 +3,20 @@ package com.streamarr.server.services.streaming.worker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.streamarr.transcode.engine.model.AudioDecision;
+import com.streamarr.transcode.engine.model.ContainerFormat;
 import com.streamarr.transcode.engine.model.MediaSourceRef;
 import com.streamarr.transcode.engine.model.RenditionObservation;
 import com.streamarr.transcode.engine.model.RenditionSpec;
 import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.SubtitleDecision;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
 import com.streamarr.transcode.engine.model.TranscodeExecutionParameters;
 import com.streamarr.transcode.engine.model.TranscodeJobObservation;
 import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import com.streamarr.transcode.engine.model.TranscodeJobSpec;
 import com.streamarr.transcode.engine.model.TranscodeJobState;
+import com.streamarr.transcode.engine.model.TranscodeMode;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -168,7 +172,14 @@ class TranscodeWorkerContractValuesTest {
         .sessionId(UUID.randomUUID())
         .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
         .source(new MediaSourceRef(UUID.randomUUID(), "Movies/movie.mkv"))
-        .decision(TranscodeDecision.builder().build())
+        .decision(
+            TranscodeDecision.builder()
+                .transcodeMode(TranscodeMode.FULL_TRANSCODE)
+                .videoCodecFamily("h264")
+                .audioDecision(AudioDecision.stereoAac())
+                .subtitleDecision(SubtitleDecision.exclude())
+                .containerFormat(ContainerFormat.MPEGTS)
+                .build())
         .execution(
             TranscodeExecutionParameters.builder()
                 .seekPosition(0)

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerContractValuesTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerContractValuesTest.java
@@ -58,30 +58,13 @@ class TranscodeWorkerContractValuesTest {
     assertThat(command.commandId()).isEqualTo(commandId);
     assertThat(command.target()).isEqualTo(target);
     assertThat(command.specification()).isEqualTo(specification);
-    assertThatThrownBy(
-            () ->
-                StartJobCommand.builder()
-                    .commandId(null)
-                    .target(target)
-                    .specification(specification)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(
-            () ->
-                StartJobCommand.builder()
-                    .commandId(commandId)
-                    .target(null)
-                    .specification(specification)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(
-            () ->
-                StartJobCommand.builder()
-                    .commandId(commandId)
-                    .target(target)
-                    .specification(null)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class);
+    var missingCommandId = StartJobCommand.builder().target(target).specification(specification);
+    var missingTarget = StartJobCommand.builder().commandId(commandId).specification(specification);
+    var missingSpecification = StartJobCommand.builder().commandId(commandId).target(target);
+
+    assertThatThrownBy(missingCommandId::build).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(missingTarget::build).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(missingSpecification::build).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -97,15 +80,13 @@ class TranscodeWorkerContractValuesTest {
     assertThat(command.commandId()).isEqualTo(commandId);
     assertThat(command.target()).isEqualTo(target);
     assertThat(command.jobRef()).isEqualTo(jobRef);
-    assertThatThrownBy(
-            () -> StopJobCommand.builder().commandId(null).target(target).jobRef(jobRef).build())
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(
-            () -> StopJobCommand.builder().commandId(commandId).target(null).jobRef(jobRef).build())
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(
-            () -> StopJobCommand.builder().commandId(commandId).target(target).jobRef(null).build())
-        .isInstanceOf(IllegalArgumentException.class);
+    var missingCommandId = StopJobCommand.builder().target(target).jobRef(jobRef);
+    var missingTarget = StopJobCommand.builder().commandId(commandId).jobRef(jobRef);
+    var missingJobRef = StopJobCommand.builder().commandId(commandId).target(target);
+
+    assertThatThrownBy(missingCommandId::build).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(missingTarget::build).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(missingJobRef::build).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerContractValuesTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/worker/TranscodeWorkerContractValuesTest.java
@@ -1,0 +1,191 @@
+package com.streamarr.server.services.streaming.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import com.streamarr.transcode.engine.model.RenditionObservation;
+import com.streamarr.transcode.engine.model.RenditionSpec;
+import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.TranscodeDecision;
+import com.streamarr.transcode.engine.model.TranscodeExecutionParameters;
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import com.streamarr.transcode.engine.model.TranscodeJobSpec;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Transcode Worker Contract Value Tests")
+class TranscodeWorkerContractValuesTest {
+
+  @Test
+  @DisplayName("Should require exact worker and boot identities for a worker target")
+  void shouldRequireExactWorkerAndBootIdentitiesForWorkerTarget() {
+    var workerId = UUID.randomUUID();
+    var bootId = UUID.randomUUID();
+
+    assertThat(new WorkerTarget(workerId, bootId)).isEqualTo(new WorkerTarget(workerId, bootId));
+    assertThatThrownBy(() -> new WorkerTarget(null, bootId))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new WorkerTarget(workerId, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should require delivery identity, exact target, and job intent for a start command")
+  void shouldRequireDeliveryIdentityExactTargetAndJobIntentForStartCommand() {
+    var commandId = UUID.randomUUID();
+    var target = workerTarget();
+    var specification = jobSpecification();
+
+    var command =
+        StartJobCommand.builder()
+            .commandId(commandId)
+            .target(target)
+            .specification(specification)
+            .build();
+
+    assertThat(command.commandId()).isEqualTo(commandId);
+    assertThat(command.target()).isEqualTo(target);
+    assertThat(command.specification()).isEqualTo(specification);
+    assertThatThrownBy(
+            () ->
+                StartJobCommand.builder()
+                    .commandId(null)
+                    .target(target)
+                    .specification(specification)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                StartJobCommand.builder()
+                    .commandId(commandId)
+                    .target(null)
+                    .specification(specification)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () ->
+                StartJobCommand.builder()
+                    .commandId(commandId)
+                    .target(target)
+                    .specification(null)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should require delivery identity, exact target, and generation for a stop command")
+  void shouldRequireDeliveryIdentityExactTargetAndGenerationForStopCommand() {
+    var commandId = UUID.randomUUID();
+    var target = workerTarget();
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 2);
+
+    var command =
+        StopJobCommand.builder().commandId(commandId).target(target).jobRef(jobRef).build();
+
+    assertThat(command.commandId()).isEqualTo(commandId);
+    assertThat(command.target()).isEqualTo(target);
+    assertThat(command.jobRef()).isEqualTo(jobRef);
+    assertThatThrownBy(
+            () -> StopJobCommand.builder().commandId(null).target(target).jobRef(jobRef).build())
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> StopJobCommand.builder().commandId(commandId).target(null).jobRef(jobRef).build())
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> StopJobCommand.builder().commandId(commandId).target(target).jobRef(null).build())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should require exact target and generation for an inspection query")
+  void shouldRequireExactTargetAndGenerationForInspectionQuery() {
+    var target = workerTarget();
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 3);
+
+    var query = new InspectJobQuery(target, jobRef);
+
+    assertThat(query.target()).isEqualTo(target);
+    assertThat(query.jobRef()).isEqualTo(jobRef);
+    assertThatThrownBy(() -> new InspectJobQuery(null, jobRef))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new InspectJobQuery(target, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should model start acceptance, rejection, and cleanup uncertainty explicitly")
+  void shouldModelStartAcceptanceRejectionAndCleanupUncertaintyExplicitly() {
+    var observation = runningObservation();
+    var jobRef = observation.jobRef();
+
+    assertThat(new StartJobResult.Accepted(observation).observation()).isEqualTo(observation);
+    assertThat(new StartJobResult.Rejected(StartJobRejection.CAPACITY_EXHAUSTED).reason())
+        .isEqualTo(StartJobRejection.CAPACITY_EXHAUSTED);
+    assertThat(new StartJobResult.CleanupPending(jobRef).jobRef()).isEqualTo(jobRef);
+    assertThatThrownBy(() -> new StartJobResult.Accepted(null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new StartJobResult.Rejected(null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new StartJobResult.CleanupPending(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName(
+      "Should model stop completion, absence, rejection, and cleanup uncertainty explicitly")
+  void shouldModelStopCompletionAbsenceRejectionAndCleanupUncertaintyExplicitly() {
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 4);
+
+    assertThat(new StopJobResult.Stopped(jobRef).jobRef()).isEqualTo(jobRef);
+    assertThat(new StopJobResult.AlreadyAbsent(jobRef).jobRef()).isEqualTo(jobRef);
+    assertThat(new StopJobResult.CleanupPending(jobRef).jobRef()).isEqualTo(jobRef);
+    assertThat(new StopJobResult.Rejected(StopJobRejection.STALE_GENERATION).reason())
+        .isEqualTo(StopJobRejection.STALE_GENERATION);
+    assertThatThrownBy(() -> new StopJobResult.Stopped(null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new StopJobResult.AlreadyAbsent(null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new StopJobResult.CleanupPending(null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new StopJobResult.Rejected(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static WorkerTarget workerTarget() {
+    return new WorkerTarget(UUID.randomUUID(), UUID.randomUUID());
+  }
+
+  private static TranscodeJobSpec jobSpecification() {
+    return TranscodeJobSpec.builder()
+        .sessionId(UUID.randomUUID())
+        .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
+        .source(new MediaSourceRef(UUID.randomUUID(), "Movies/movie.mkv"))
+        .decision(TranscodeDecision.builder().build())
+        .execution(
+            TranscodeExecutionParameters.builder()
+                .seekPosition(0)
+                .segmentDuration(6)
+                .framerate(23.976)
+                .startNumber(0)
+                .startupTimeout(Duration.ofSeconds(45))
+                .build())
+        .renditions(List.of(new RenditionSpec("720p", 1280, 720, 3_000_000L)))
+        .build();
+  }
+
+  private static TranscodeJobObservation runningObservation() {
+    return TranscodeJobObservation.builder()
+        .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
+        .state(TranscodeJobState.RUNNING)
+        .renditions(List.of(new RenditionObservation("720p", RenditionState.RUNNING)))
+        .build();
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegCommandBuilder.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegCommandBuilder.java
@@ -2,11 +2,11 @@ package com.streamarr.transcode.engine.ffmpeg;
 
 import com.streamarr.transcode.engine.model.AudioDecision;
 import com.streamarr.transcode.engine.model.AudioMode;
+import com.streamarr.transcode.engine.model.RenditionJob;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.SubtitleDecision;
 import com.streamarr.transcode.engine.model.SubtitleMode;
-import com.streamarr.transcode.engine.model.TranscodeJob;
 import com.streamarr.transcode.engine.model.TranscodeMode;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +35,7 @@ public class FfmpegCommandBuilder {
   private static final Set<String> FORCE_KEYFRAME_ENCODERS =
       Set.of("libx264", "libx265", "h264_vaapi", "hevc_vaapi", "av1_vaapi");
 
-  public List<String> buildCommand(TranscodeJob job) {
+  public List<String> buildCommand(RenditionJob job) {
     var cmd = new ArrayList<String>();
     var decision = job.request().transcodeDecision();
     var mode = decision.transcodeMode();
@@ -56,7 +56,7 @@ public class FfmpegCommandBuilder {
     return List.copyOf(cmd);
   }
 
-  private void addInputArgs(List<String> cmd, TranscodeRequest request) {
+  private void addInputArgs(List<String> cmd, RenditionRequest request) {
     cmd.add(ffmpegPath);
     cmd.add("-y");
 
@@ -94,7 +94,7 @@ public class FfmpegCommandBuilder {
             "5000000"));
   }
 
-  private void addCodecArgs(List<String> cmd, TranscodeJob job) {
+  private void addCodecArgs(List<String> cmd, RenditionJob job) {
     var decision = job.request().transcodeDecision();
     var mode = decision.transcodeMode();
 
@@ -123,7 +123,7 @@ public class FfmpegCommandBuilder {
     cmd.addAll(List.of("-b:a", audio.bitrate() / 1000 + "k"));
   }
 
-  private void addScaleAndBitrateArgs(List<String> cmd, TranscodeRequest request) {
+  private void addScaleAndBitrateArgs(List<String> cmd, RenditionRequest request) {
     cmd.addAll(List.of("-vf", "scale=-2:" + request.height()));
     var bitrate = String.valueOf(request.bitrate());
     cmd.addAll(
@@ -133,7 +133,7 @@ public class FfmpegCommandBuilder {
             "-bufsize", String.valueOf(request.bitrate() * 2)));
   }
 
-  private void addKeyframeArgs(List<String> cmd, TranscodeJob job) {
+  private void addKeyframeArgs(List<String> cmd, RenditionJob job) {
     var encoder = job.videoEncoder();
 
     cmd.addAll(List.of("-forced-idr", "1"));
@@ -148,7 +148,7 @@ public class FfmpegCommandBuilder {
     }
   }
 
-  private void addGopSizeArgs(List<String> cmd, TranscodeJob job) {
+  private void addGopSizeArgs(List<String> cmd, RenditionJob job) {
     var gopSize = (int) Math.ceil(job.request().segmentDuration() * job.request().framerate());
     cmd.addAll(
         List.of(
@@ -156,7 +156,7 @@ public class FfmpegCommandBuilder {
             "-keyint_min:v:0", String.valueOf(gopSize)));
   }
 
-  private void addForceKeyframeExprArgs(List<String> cmd, TranscodeJob job) {
+  private void addForceKeyframeExprArgs(List<String> cmd, RenditionJob job) {
     cmd.addAll(
         List.of(
             "-force_key_frames:0", "expr:gte(t,n_forced*" + job.request().segmentDuration() + ")"));
@@ -167,7 +167,7 @@ public class FfmpegCommandBuilder {
   }
 
   @SuppressWarnings("java:S1301") // exhaustive enum switch preferred over if/else per project style
-  private void addHlsArgs(List<String> cmd, TranscodeJob job) {
+  private void addHlsArgs(List<String> cmd, RenditionJob job) {
     var request = job.request();
     var decision = request.transcodeDecision();
     var container = decision.containerFormat();

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessKey.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessKey.java
@@ -1,5 +1,14 @@
 package com.streamarr.transcode.engine.ffmpeg;
 
+import com.streamarr.transcode.engine.model.RenditionSpec;
 import com.streamarr.transcode.engine.model.TranscodeJobRef;
 
-public record FfmpegProcessKey(TranscodeJobRef jobRef, String renditionLabel) {}
+public record FfmpegProcessKey(TranscodeJobRef jobRef, String renditionLabel) {
+
+  public FfmpegProcessKey {
+    if (jobRef == null) {
+      throw new IllegalArgumentException("Transcode job reference is required");
+    }
+    RenditionSpec.requirePortableLabel(renditionLabel);
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessKey.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessKey.java
@@ -1,0 +1,5 @@
+package com.streamarr.transcode.engine.ffmpeg;
+
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+
+public record FfmpegProcessKey(TranscodeJobRef jobRef, String renditionLabel) {}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessManager.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessManager.java
@@ -1,18 +1,22 @@
 package com.streamarr.transcode.engine.ffmpeg;
 
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.UUID;
 
 public interface FfmpegProcessManager {
 
-  Process startProcess(UUID sessionId, String variantLabel, List<String> command, Path workingDir);
+  Process startProcess(FfmpegProcessKey key, List<String> command, Path workingDir);
 
-  void stopProcess(UUID sessionId);
+  void stopProcess(FfmpegProcessKey key);
+
+  void stopJob(TranscodeJobRef jobRef);
 
   void forceStopAll();
 
-  boolean isRunning(UUID sessionId);
+  boolean isRunning(TranscodeJobRef jobRef);
 
-  boolean isRunning(UUID sessionId, String variantLabel);
+  boolean isRunning(FfmpegProcessKey key);
+
+  FfmpegProcessObservation observe(FfmpegProcessKey key);
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessManager.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessManager.java
@@ -19,4 +19,6 @@ public interface FfmpegProcessManager {
   boolean isRunning(FfmpegProcessKey key);
 
   FfmpegProcessObservation observe(FfmpegProcessKey key);
+
+  boolean releaseJobObservation(TranscodeJobRef jobRef);
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessObservation.java
@@ -1,13 +1,21 @@
 package com.streamarr.transcode.engine.ffmpeg;
 
-import java.util.Objects;
 import java.util.OptionalInt;
 
 public record FfmpegProcessObservation(FfmpegProcessState state, OptionalInt exitCode) {
 
   public FfmpegProcessObservation {
-    Objects.requireNonNull(state, "state must not be null");
-    Objects.requireNonNull(exitCode, "exitCode must not be null");
+    if (state == null || exitCode == null) {
+      throw new IllegalArgumentException("Process observation values are required");
+    }
+    var terminal =
+        switch (state) {
+          case COMPLETED, FAILED, STOPPED -> true;
+          case RUNNING, ABSENT -> false;
+        };
+    if (terminal != exitCode.isPresent()) {
+      throw new IllegalArgumentException("Process state and exit code contradict");
+    }
   }
 
   public static FfmpegProcessObservation withoutExitCode(FfmpegProcessState state) {

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessObservation.java
@@ -1,0 +1,20 @@
+package com.streamarr.transcode.engine.ffmpeg;
+
+import java.util.Objects;
+import java.util.OptionalInt;
+
+public record FfmpegProcessObservation(FfmpegProcessState state, OptionalInt exitCode) {
+
+  public FfmpegProcessObservation {
+    Objects.requireNonNull(state, "state must not be null");
+    Objects.requireNonNull(exitCode, "exitCode must not be null");
+  }
+
+  public static FfmpegProcessObservation withoutExitCode(FfmpegProcessState state) {
+    return new FfmpegProcessObservation(state, OptionalInt.empty());
+  }
+
+  public static FfmpegProcessObservation withExitCode(FfmpegProcessState state, int exitCode) {
+    return new FfmpegProcessObservation(state, OptionalInt.of(exitCode));
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessState.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessState.java
@@ -1,0 +1,9 @@
+package com.streamarr.transcode.engine.ffmpeg;
+
+public enum FfmpegProcessState {
+  RUNNING,
+  COMPLETED,
+  FAILED,
+  STOPPED,
+  ABSENT
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManager.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManager.java
@@ -253,6 +253,15 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
     return retainTerminalObservation(key, managed);
   }
 
+  @Override
+  public boolean releaseJobObservation(TranscodeJobRef jobRef) {
+    if (isRunning(jobRef)) {
+      return false;
+    }
+    terminalObservations.keySet().removeIf(key -> key.jobRef().equals(jobRef));
+    return true;
+  }
+
   private FfmpegProcessObservation retainTerminalObservation(
       FfmpegProcessKey key, ManagedProcess managed) {
     if (!managed.stopRequested().get()) {

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManager.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManager.java
@@ -1,12 +1,15 @@
 package com.streamarr.transcode.engine.ffmpeg;
 
 import com.streamarr.transcode.engine.error.TranscodeException;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -14,18 +17,25 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
 
   private static final long GRACEFUL_SHUTDOWN_SECONDS = 5;
 
-  private record ProcessKey(UUID sessionId, String variantLabel) {}
+  private record ManagedProcess(
+      Process process, StderrDrainer drainer, AtomicBoolean stopRequested) {
 
-  private record ManagedProcess(Process process, StderrDrainer drainer) {}
+    private void requestStop() {
+      if (process.isAlive()) {
+        stopRequested.set(true);
+      }
+    }
+  }
 
-  private final ConcurrentHashMap<ProcessKey, ManagedProcess> processes = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<FfmpegProcessKey, ManagedProcess> processes =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<FfmpegProcessKey, FfmpegProcessObservation> terminalObservations =
+      new ConcurrentHashMap<>();
 
   @Override
-  public Process startProcess(
-      UUID sessionId, String variantLabel, List<String> command, Path workingDir) {
-    var key = new ProcessKey(sessionId, variantLabel);
+  public Process startProcess(FfmpegProcessKey key, List<String> command, Path workingDir) {
     if (processes.containsKey(key)) {
-      throw duplicateProcess(sessionId, variantLabel);
+      throw duplicateProcess(key);
     }
 
     try {
@@ -34,55 +44,76 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
 
       var process = processBuilder.start();
       var drainer = new StderrDrainer(process.getErrorStream());
-      var managed = new ManagedProcess(process, drainer);
+      var managed = new ManagedProcess(process, drainer, new AtomicBoolean());
       var existing = processes.putIfAbsent(key, managed);
       if (existing != null) {
-        shutdownManagedProcess(managed, sessionId);
-        throw duplicateProcess(sessionId, variantLabel);
+        shutdownManagedProcess(managed, key.jobRef());
+        throw duplicateProcess(key);
       }
+      terminalObservations.remove(key);
 
       log.info(
-          "Started FFmpeg process (PID {}) for session {} variant {}",
+          "Started FFmpeg process (PID {}) for job {} generation {} rendition {}",
           process.pid(),
-          sessionId,
-          variantLabel);
+          key.jobRef().jobId(),
+          key.jobRef().generation(),
+          key.renditionLabel());
       return process;
-    } catch (IOException e) {
-      log.error("Failed to start FFmpeg process for session: {}", sessionId, e);
-      throw new TranscodeException(TranscodeException.GENERIC_MESSAGE, e);
+    } catch (IOException exception) {
+      log.error("Failed to start FFmpeg process for job: {}", key.jobRef().jobId(), exception);
+      throw new TranscodeException(TranscodeException.GENERIC_MESSAGE, exception);
     }
   }
 
-  private TranscodeException duplicateProcess(UUID sessionId, String variantLabel) {
+  private TranscodeException duplicateProcess(FfmpegProcessKey key) {
     log.error(
-        "Refusing duplicate FFmpeg process for session {} variant {}", sessionId, variantLabel);
+        "Refusing duplicate FFmpeg process for job {} generation {} rendition {}",
+        key.jobRef().jobId(),
+        key.jobRef().generation(),
+        key.renditionLabel());
     return new TranscodeException(TranscodeException.GENERIC_MESSAGE);
   }
 
   @Override
-  public void stopProcess(UUID sessionId) {
+  public void stopProcess(FfmpegProcessKey key) {
+    var managed = processes.get(key);
+    stopProcesses(managed == null ? List.of() : List.of(Map.entry(key, managed)), key.jobRef());
+  }
+
+  @Override
+  public void stopJob(TranscodeJobRef jobRef) {
     var entriesToStop =
         processes.entrySet().stream()
-            .filter(entry -> entry.getKey().sessionId().equals(sessionId))
+            .filter(entry -> entry.getKey().jobRef().equals(jobRef))
             .toList();
-    var failures = new java.util.ArrayList<RuntimeException>();
+    stopProcesses(entriesToStop, jobRef);
+  }
+
+  private void stopProcesses(
+      List<? extends Map.Entry<FfmpegProcessKey, ManagedProcess>> entriesToStop,
+      TranscodeJobRef jobRef) {
+    var failures = new ArrayList<RuntimeException>();
     var interrupted = !entriesToStop.isEmpty() && Thread.interrupted();
 
     for (var entry : entriesToStop) {
+      entry.getValue().requestStop();
       try {
-        shutdownManagedProcess(entry.getValue(), sessionId);
+        shutdownManagedProcess(entry.getValue(), jobRef);
       } catch (RuntimeException failure) {
         failures.add(failure);
         interrupted |= recoverInterruptedStop(entry.getKey(), entry.getValue(), failure);
       } finally {
         if (!entry.getValue().process().isAlive()) {
-          processes.remove(entry.getKey(), entry.getValue());
+          retainTerminalObservation(entry.getKey(), entry.getValue());
         }
       }
     }
 
     if (!entriesToStop.isEmpty()) {
-      log.info("Stopped FFmpeg process(es) for session {}", sessionId);
+      log.info(
+          "Stopped FFmpeg process(es) for job {} generation {}",
+          jobRef.jobId(),
+          jobRef.generation());
     }
 
     if (interrupted) {
@@ -100,7 +131,7 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
   }
 
   private boolean recoverInterruptedStop(
-      ProcessKey key, ManagedProcess managed, RuntimeException failure) {
+      FfmpegProcessKey key, ManagedProcess managed, RuntimeException failure) {
     if (!Thread.interrupted()) {
       return false;
     }
@@ -116,8 +147,9 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
 
   @Override
   public void forceStopAll() {
-    var failures = new java.util.ArrayList<RuntimeException>();
+    var failures = new ArrayList<RuntimeException>();
     for (var entry : List.copyOf(processes.entrySet())) {
+      entry.getValue().requestStop();
       try {
         forceStop(entry.getKey(), entry.getValue());
       } catch (RuntimeException exception) {
@@ -129,7 +161,7 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
     }
   }
 
-  private void forceStop(ProcessKey key, ManagedProcess managed) {
+  private void forceStop(FfmpegProcessKey key, ManagedProcess managed) {
     try {
       if (managed.process().isAlive()) {
         managed.process().destroyForcibly();
@@ -142,13 +174,12 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
       throw new TranscodeException(TranscodeException.GENERIC_MESSAGE, exception);
     } finally {
       if (!managed.process().isAlive()) {
-        managed.drainer().close();
-        processes.remove(key, managed);
+        retainTerminalObservation(key, managed);
       }
     }
   }
 
-  private void shutdownManagedProcess(ManagedProcess managed, UUID sessionId) {
+  private void shutdownManagedProcess(ManagedProcess managed, TranscodeJobRef jobRef) {
     if (managed == null) {
       return;
     }
@@ -159,8 +190,8 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
     }
 
     try {
-      sendQuitSignal(managed.process(), sessionId);
-      awaitShutdown(managed.process(), sessionId);
+      sendQuitSignal(managed.process(), jobRef);
+      awaitShutdown(managed.process(), jobRef);
     } finally {
       if (!managed.process().isAlive()) {
         managed.drainer().close();
@@ -168,78 +199,97 @@ public class LocalFfmpegProcessManager implements FfmpegProcessManager {
     }
   }
 
-  private void sendQuitSignal(Process process, UUID sessionId) {
+  private void sendQuitSignal(Process process, TranscodeJobRef jobRef) {
     try {
       var outputStream = process.getOutputStream();
       outputStream.write('q');
       outputStream.flush();
-    } catch (IOException e) {
-      log.debug("Failed to write quit signal to FFmpeg stdin for session {}", sessionId);
+    } catch (IOException _) {
+      log.debug("Failed to write quit signal to FFmpeg stdin for job {}", jobRef.jobId());
     }
   }
 
-  private void awaitShutdown(Process process, UUID sessionId) {
+  private void awaitShutdown(Process process, TranscodeJobRef jobRef) {
     try {
       if (process.waitFor(GRACEFUL_SHUTDOWN_SECONDS, TimeUnit.SECONDS)) {
         return;
       }
 
-      log.warn("FFmpeg did not stop gracefully for session {}, forcing", sessionId);
+      log.warn("FFmpeg did not stop gracefully for job {}, forcing", jobRef.jobId());
       process.destroyForcibly();
       if (!process.waitFor(GRACEFUL_SHUTDOWN_SECONDS, TimeUnit.SECONDS)) {
         throw new TranscodeException(TranscodeException.GENERIC_MESSAGE);
       }
-    } catch (InterruptedException e) {
+    } catch (InterruptedException exception) {
       Thread.currentThread().interrupt();
       process.destroyForcibly();
-      throw new TranscodeException(TranscodeException.GENERIC_MESSAGE, e);
+      throw new TranscodeException(TranscodeException.GENERIC_MESSAGE, exception);
     }
   }
 
   @Override
-  public boolean isRunning(UUID sessionId) {
+  public boolean isRunning(TranscodeJobRef jobRef) {
     return processes.entrySet().stream()
-        .filter(e -> e.getKey().sessionId().equals(sessionId))
-        .anyMatch(e -> isAliveOrCleanup(e.getKey(), e.getValue()));
+        .filter(entry -> entry.getKey().jobRef().equals(jobRef))
+        .anyMatch(entry -> observe(entry.getKey()).state() == FfmpegProcessState.RUNNING);
   }
 
   @Override
-  public boolean isRunning(UUID sessionId, String variantLabel) {
-    var key = new ProcessKey(sessionId, variantLabel);
+  public boolean isRunning(FfmpegProcessKey key) {
+    return observe(key).state() == FfmpegProcessState.RUNNING;
+  }
+
+  @Override
+  public FfmpegProcessObservation observe(FfmpegProcessKey key) {
     var managed = processes.get(key);
     if (managed == null) {
-      return false;
+      return terminalObservations.getOrDefault(
+          key, FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.ABSENT));
+    }
+    if (managed.process().isAlive()) {
+      return FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.RUNNING);
     }
 
-    return isAliveOrCleanup(key, managed);
+    return retainTerminalObservation(key, managed);
   }
 
-  private boolean isAliveOrCleanup(ProcessKey key, ManagedProcess managed) {
-    if (!managed.process().isAlive()) {
+  private FfmpegProcessObservation retainTerminalObservation(
+      FfmpegProcessKey key, ManagedProcess managed) {
+    if (!managed.stopRequested().get()) {
       logExitDetails(key, managed);
-      managed.drainer().close();
-      processes.remove(key, managed);
-      return false;
     }
-
-    return true;
+    managed.drainer().close();
+    var exitCode = managed.process().exitValue();
+    var state = terminalState(managed, exitCode);
+    var observation = FfmpegProcessObservation.withExitCode(state, exitCode);
+    terminalObservations.put(key, observation);
+    processes.remove(key, managed);
+    return observation;
   }
 
-  private void logExitDetails(ProcessKey key, ManagedProcess managed) {
+  private FfmpegProcessState terminalState(ManagedProcess managed, int exitCode) {
+    if (managed.stopRequested().get()) {
+      return FfmpegProcessState.STOPPED;
+    }
+    return exitCode == 0 ? FfmpegProcessState.COMPLETED : FfmpegProcessState.FAILED;
+  }
+
+  private void logExitDetails(FfmpegProcessKey key, ManagedProcess managed) {
     try {
       var exitCode = managed.process().exitValue();
       var recentLines = managed.drainer().getRecentOutput();
       if (!recentLines.isEmpty()) {
         var stderr = String.join("\n", recentLines);
         log.warn(
-            "FFmpeg exited with code {} for session {} variant {}: {}",
+            "FFmpeg exited with code {} for job {} generation {} rendition {}: {}",
             exitCode,
-            key.sessionId(),
-            key.variantLabel(),
+            key.jobRef().jobId(),
+            key.jobRef().generation(),
+            key.renditionLabel(),
             stderr.substring(0, Math.min(stderr.length(), 2000)));
       }
     } catch (Exception _) {
-      log.debug("Could not read FFmpeg exit details for session {}", key.sessionId());
+      log.debug("Could not read FFmpeg exit details for job {}", key.jobRef().jobId());
     }
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
@@ -1,0 +1,595 @@
+package com.streamarr.transcode.engine.job;
+
+import com.streamarr.transcode.engine.error.TranscodeException;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
+import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
+import com.streamarr.transcode.engine.model.RenditionJob;
+import com.streamarr.transcode.engine.model.RenditionObservation;
+import com.streamarr.transcode.engine.model.RenditionRequest;
+import com.streamarr.transcode.engine.model.RenditionSpec;
+import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.SubtitleMode;
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import com.streamarr.transcode.engine.model.TranscodeJobSpec;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
+import com.streamarr.transcode.engine.model.TranscodeMode;
+import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
+import com.streamarr.transcode.engine.segment.SegmentGeneration;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Builder;
+
+@Builder
+public class LocalTranscodeEngine {
+
+  private static final Duration READINESS_POLL_INTERVAL = Duration.ofMillis(25);
+  private final FfmpegCommandBuilder commandBuilder;
+  private final FfmpegProcessManager processManager;
+  private final LocalSegmentStorage segmentStorage;
+  private final TranscodeCapabilityService capabilityService;
+
+  @Builder.Default
+  private final ConcurrentHashMap<TranscodeJobRef, JobRun> runs = new ConcurrentHashMap<>();
+
+  @Builder.Default
+  private final ConcurrentHashMap<UUID, Long> highestGenerationByJobId = new ConcurrentHashMap<>();
+
+  @Builder.Default
+  private final ConcurrentHashMap<UUID, UUID> sessionIdByJobId = new ConcurrentHashMap<>();
+
+  @Builder.Default
+  private final ConcurrentHashMap<UUID, UUID> sessionOwnerBySessionId = new ConcurrentHashMap<>();
+
+  @Builder.Default private final Object lifecycleMonitor = new Object();
+  private volatile boolean shuttingDown;
+
+  public TranscodeJobObservation start(TranscodeJobSpec specification, Path resolvedSource) {
+    validateSpecification(specification);
+    var admission = admit(specification, resolvedSource);
+    if (!admission.owner()) {
+      var existing = admission.run();
+      if (!existing.startup().isDone() || existing.startup().isCompletedExceptionally()) {
+        return await(existing.startup());
+      }
+      if (existing.cleanupComplete || existing.published) {
+        return existing.observation;
+      }
+      return await(existing.startup());
+    }
+    var run = admission.run();
+    SegmentGeneration generation = null;
+    try {
+      fenceSuperseded(admission.superseded());
+      assertAdmitted(run);
+      generation =
+          segmentStorage.prepareGeneration(specification.sessionId(), specification.jobRef());
+      run.generation = generation;
+      for (var rendition : specification.renditions()) {
+        assertAdmitted(run);
+        startRendition(specification, resolvedSource, generation, rendition);
+        assertAdmitted(run);
+      }
+      awaitReadiness(run, generation);
+      var started = healthyObservation(specification, generation);
+      synchronized (lifecycleMonitor) {
+        assertAdmitted(run);
+        segmentStorage.publish(generation);
+        runs.values().stream()
+            .filter(
+                candidate -> candidate.specification.sessionId().equals(specification.sessionId()))
+            .forEach(candidate -> candidate.published = false);
+        run.published = true;
+        run.observation = started;
+      }
+      run.startup().complete(started);
+      return started;
+    } catch (RuntimeException exception) {
+      var failure = compensate(run, generation, exception);
+      run.observation = observation(specification, TranscodeJobState.FAILED, RenditionState.FAILED);
+      run.startup().completeExceptionally(failure);
+      throw failure;
+    }
+  }
+
+  public TranscodeJobObservation inspect(TranscodeJobRef jobRef) {
+    var run = runs.get(jobRef);
+    if (run == null) {
+      return absent(jobRef);
+    }
+    if (run.observation.state() != TranscodeJobState.RUNNING) {
+      return run.observation;
+    }
+    try {
+      assertProcessesHealthy(run.specification, run.generation);
+      var healthy = healthyObservation(run.specification, run.generation);
+      synchronized (lifecycleMonitor) {
+        if (run.observation.state() == TranscodeJobState.RUNNING) {
+          run.observation = healthy;
+        }
+        return run.observation;
+      }
+    } catch (RuntimeException exception) {
+      if (exception instanceof TranscodeEngineException engineException
+          && engineException.reason() != TranscodeEngineException.Reason.STARTUP_FAILED) {
+        throw engineException;
+      }
+      return fail(run);
+    }
+  }
+
+  private TranscodeJobObservation fail(JobRun run) {
+    var jobRef = run.specification.jobRef();
+    try {
+      processManager.stopJob(jobRef);
+      if (processManager.isRunning(jobRef)) {
+        throw new IllegalStateException("Exact transcode processes remain active");
+      }
+      synchronized (run) {
+        synchronized (lifecycleMonitor) {
+          if (run.cancelled || run.observation.state() == TranscodeJobState.STOPPED) {
+            run.observation =
+                observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+            return run.observation;
+          }
+          segmentStorage.withdraw(run.specification.sessionId(), jobRef);
+          run.published = false;
+          run.observation =
+              observation(run.specification, TranscodeJobState.FAILED, RenditionState.FAILED);
+          run.cleanupComplete = true;
+          return run.observation;
+        }
+      }
+    } catch (RuntimeException cleanupFailure) {
+      throw cleanupPending("Failed transcode job cleanup is pending", cleanupFailure);
+    }
+  }
+
+  public TranscodeJobObservation stop(TranscodeJobRef jobRef) {
+    var run = runs.get(jobRef);
+    if (run == null) {
+      return absent(jobRef);
+    }
+    synchronized (lifecycleMonitor) {
+      if (run.observation.state() == TranscodeJobState.STOPPED && run.cleanupComplete) {
+        return run.observation;
+      }
+      run.cancelled = true;
+    }
+    try {
+      processManager.stopJob(jobRef);
+      run.startup().handle((_, _) -> null).join();
+      processManager.stopJob(jobRef);
+      if (processManager.isRunning(jobRef)) {
+        throw new IllegalStateException("Exact transcode processes remain active");
+      }
+      synchronized (run) {
+        if (run.observation.state() == TranscodeJobState.STOPPED && run.cleanupComplete) {
+          return run.observation;
+        }
+        synchronized (lifecycleMonitor) {
+          if (run.published
+              && highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
+            segmentStorage.withdraw(run.specification.sessionId(), jobRef);
+            run.published = false;
+          } else if (!run.published && !run.cleanupComplete && run.generation != null) {
+            segmentStorage.discard(run.generation);
+          }
+          run.observation =
+              observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+          run.cleanupComplete = true;
+          if (highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
+            sessionOwnerBySessionId.remove(run.specification.sessionId(), jobRef.jobId());
+          }
+          return run.observation;
+        }
+      }
+    } catch (RuntimeException exception) {
+      throw cleanupPending("Transcode job cleanup is pending", exception);
+    }
+  }
+
+  public boolean releaseObservation(TranscodeJobRef jobRef) {
+    var run = runs.get(jobRef);
+    if (run == null) {
+      return true;
+    }
+    if (!run.cleanupComplete || run.published) {
+      return false;
+    }
+    if (!processManager.releaseJobObservation(jobRef)) {
+      return false;
+    }
+    synchronized (lifecycleMonitor) {
+      runs.remove(jobRef, run);
+      if (highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
+        sessionOwnerBySessionId.remove(run.specification.sessionId(), jobRef.jobId());
+      }
+    }
+    return true;
+  }
+
+  public void shutdown() {
+    List<JobRun> snapshot;
+    synchronized (lifecycleMonitor) {
+      shuttingDown = true;
+      snapshot = List.copyOf(runs.values());
+      snapshot.forEach(run -> run.cancelled = true);
+    }
+    try {
+      processManager.forceStopAll();
+      snapshot.forEach(run -> run.startup().handle((_, _) -> null).join());
+      processManager.forceStopAll();
+      snapshot.forEach(
+          run -> {
+            synchronized (run) {
+              if (run.published) {
+                segmentStorage.withdraw(run.specification.sessionId(), run.specification.jobRef());
+                run.published = false;
+              } else if (!run.cleanupComplete && run.generation != null) {
+                segmentStorage.discard(run.generation);
+              }
+              run.observation =
+                  observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+              run.cleanupComplete = true;
+            }
+          });
+      sessionOwnerBySessionId.clear();
+      segmentStorage.shutdown();
+    } catch (RuntimeException exception) {
+      throw cleanupPending("Transcode engine shutdown cleanup is pending", exception);
+    }
+  }
+
+  private static void validateSpecification(TranscodeJobSpec specification) {
+    if (specification.decision().subtitleDecision().mode() != SubtitleMode.EXCLUDE) {
+      throw new TranscodeEngineException(
+          TranscodeEngineException.Reason.INVALID_SPECIFICATION,
+          "Local transcoding does not support the requested subtitle mode");
+    }
+  }
+
+  private static TranscodeJobObservation absent(TranscodeJobRef jobRef) {
+    return new TranscodeJobObservation(jobRef, TranscodeJobState.ABSENT, List.of());
+  }
+
+  private Admission admit(TranscodeJobSpec specification, Path resolvedSource) {
+    synchronized (lifecycleMonitor) {
+      if (shuttingDown) {
+        throw new TranscodeEngineException(
+            TranscodeEngineException.Reason.SHUTTING_DOWN, "Transcode engine is shutting down");
+      }
+      var existing = runs.get(specification.jobRef());
+      if (existing != null) {
+        if (!existing.matches(specification, resolvedSource)) {
+          throw new TranscodeEngineException(
+              TranscodeEngineException.Reason.JOB_CONFLICT,
+              "Transcode job content conflicts with its exact identity");
+        }
+        return new Admission(existing, false);
+      }
+      var jobRef = specification.jobRef();
+      var boundSessionId = sessionIdByJobId.get(jobRef.jobId());
+      if (boundSessionId != null && !boundSessionId.equals(specification.sessionId())) {
+        throw new TranscodeEngineException(
+            TranscodeEngineException.Reason.JOB_CONFLICT,
+            "Transcode job identity belongs to a different session");
+      }
+      var sessionOwner = sessionOwnerBySessionId.get(specification.sessionId());
+      if (sessionOwner != null && !sessionOwner.equals(jobRef.jobId())) {
+        throw new TranscodeEngineException(
+            TranscodeEngineException.Reason.SESSION_CONFLICT,
+            "Transcode session is already owned by a different job");
+      }
+      var highestGeneration = highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L);
+      if (jobRef.generation() <= highestGeneration) {
+        throw new TranscodeEngineException(
+            TranscodeEngineException.Reason.STALE_GENERATION, "Transcode job generation is stale");
+      }
+      var run = new JobRun(specification, resolvedSource);
+      var superseded =
+          runs.values().stream()
+              .filter(candidate -> candidate.jobId().equals(jobRef.jobId()))
+              .filter(candidate -> candidate.generation() < jobRef.generation())
+              .toList();
+      superseded.forEach(candidate -> candidate.cancelled = true);
+      highestGenerationByJobId.put(jobRef.jobId(), jobRef.generation());
+      sessionIdByJobId.put(jobRef.jobId(), specification.sessionId());
+      sessionOwnerBySessionId.put(specification.sessionId(), jobRef.jobId());
+      runs.put(jobRef, run);
+      return new Admission(run, true, superseded);
+    }
+  }
+
+  private void fenceSuperseded(List<JobRun> superseded) {
+    try {
+      for (var run : superseded) {
+        var jobRef = run.specification.jobRef();
+        processManager.stopJob(jobRef);
+        run.startup().handle((_, _) -> null).join();
+        processManager.stopJob(jobRef);
+        if (processManager.isRunning(jobRef)) {
+          throw new TranscodeException("Superseded transcode process is still running");
+        }
+        synchronized (run) {
+          if (!run.published && !run.cleanupComplete && run.generation != null) {
+            segmentStorage.discard(run.generation);
+          }
+          run.observation =
+              observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+          run.cleanupComplete = true;
+        }
+      }
+    } catch (RuntimeException exception) {
+      throw cleanupPending("Superseded transcode cleanup is pending", exception);
+    }
+  }
+
+  private void assertAdmitted(JobRun run) {
+    var jobRef = run.specification.jobRef();
+    if (run.cancelled
+        || highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) > jobRef.generation()) {
+      throw new TranscodeEngineException(
+          TranscodeEngineException.Reason.STALE_GENERATION,
+          "Transcode job generation was superseded");
+    }
+  }
+
+  private RuntimeException compensate(
+      JobRun run, SegmentGeneration generation, RuntimeException failure) {
+    var startupFailure =
+        failure instanceof TranscodeEngineException
+            ? failure
+            : new TranscodeEngineException(
+                TranscodeEngineException.Reason.STARTUP_FAILED, failure.getMessage(), failure);
+    try {
+      processManager.stopJob(run.specification.jobRef());
+      if (generation != null) {
+        segmentStorage.discard(generation);
+      }
+      run.cleanupComplete = true;
+    } catch (RuntimeException cleanupFailure) {
+      var pending = cleanupPending("Transcode startup cleanup is pending", cleanupFailure);
+      pending.addSuppressed(startupFailure);
+      return pending;
+    }
+    return startupFailure;
+  }
+
+  private static TranscodeJobObservation await(CompletableFuture<TranscodeJobObservation> startup) {
+    try {
+      return startup.join();
+    } catch (CompletionException exception) {
+      if (exception.getCause() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw exception;
+    }
+  }
+
+  private void startRendition(
+      TranscodeJobSpec specification,
+      Path resolvedSource,
+      SegmentGeneration generation,
+      RenditionSpec rendition) {
+    var outputDirectory = outputDirectory(specification, generation, rendition);
+    var request = request(specification, resolvedSource, rendition);
+    var job =
+        RenditionJob.builder()
+            .request(request)
+            .videoEncoder(resolveEncoder(specification))
+            .outputDir(outputDirectory)
+            .build();
+    var key = new FfmpegProcessKey(specification.jobRef(), rendition.label());
+    processManager.startProcess(key, commandBuilder.buildCommand(job), outputDirectory);
+  }
+
+  private static RenditionRequest request(
+      TranscodeJobSpec specification, Path resolvedSource, RenditionSpec rendition) {
+    var execution = specification.execution();
+    return RenditionRequest.builder()
+        .sessionId(specification.sessionId())
+        .sourcePath(resolvedSource)
+        .seekPosition(execution.seekPosition())
+        .segmentDuration(execution.segmentDuration())
+        .framerate(execution.framerate())
+        .transcodeDecision(specification.decision())
+        .width(rendition.width())
+        .height(rendition.height())
+        .bitrate(rendition.videoBitrate())
+        .variantLabel(rendition.label())
+        .startNumber(execution.startNumber())
+        .build();
+  }
+
+  private Path outputDirectory(
+      TranscodeJobSpec specification, SegmentGeneration generation, RenditionSpec rendition) {
+    if (specification.renditions().size() == 1
+        && RenditionRequest.DEFAULT_VARIANT.equals(rendition.label())) {
+      return generation.outputDirectory();
+    }
+    return segmentStorage.prepareRenditionDirectory(generation, rendition.label());
+  }
+
+  private String resolveEncoder(TranscodeJobSpec specification) {
+    var mode = specification.decision().transcodeMode();
+    if (mode == TranscodeMode.REMUX || mode == TranscodeMode.AUDIO_TRANSCODE) {
+      return "copy";
+    }
+    return capabilityService.resolveEncoder(specification.decision().videoCodecFamily());
+  }
+
+  private void awaitReadiness(JobRun run, SegmentGeneration generation) {
+    var specification = run.specification;
+    var startedAt = System.nanoTime();
+    var startupTimeoutNanos = specification.execution().startupTimeout().toNanos();
+    while (System.nanoTime() - startedAt < startupTimeoutNanos) {
+      assertAdmitted(run);
+      assertProcessesHealthy(specification, generation);
+      if (allRenditionsReady(specification, generation)) {
+        return;
+      }
+      try {
+        Thread.sleep(READINESS_POLL_INTERVAL);
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+        throw new TranscodeException("Transcode startup interrupted", exception);
+      }
+    }
+    assertProcessesHealthy(specification, generation);
+    if (!allRenditionsReady(specification, generation)) {
+      throw new TranscodeException("Transcode startup timed out");
+    }
+  }
+
+  private void assertProcessesHealthy(
+      TranscodeJobSpec specification, SegmentGeneration generation) {
+    for (var rendition : specification.renditions()) {
+      healthyState(specification, generation, rendition);
+    }
+  }
+
+  private RenditionState healthyState(
+      TranscodeJobSpec specification, SegmentGeneration generation, RenditionSpec rendition) {
+    var key = new FfmpegProcessKey(specification.jobRef(), rendition.label());
+    return switch (processManager.observe(key).state()) {
+      case RUNNING -> RenditionState.RUNNING;
+      case COMPLETED -> {
+        if (playlistHasEndMarker(specification, generation, rendition)) {
+          yield RenditionState.COMPLETED;
+        }
+        throw startupFailure();
+      }
+      case FAILED, STOPPED, ABSENT -> throw startupFailure();
+    };
+  }
+
+  private static TranscodeEngineException startupFailure() {
+    return new TranscodeEngineException(
+        TranscodeEngineException.Reason.STARTUP_FAILED,
+        "Transcode rendition failed during startup");
+  }
+
+  private static TranscodeEngineException cleanupPending(String message, RuntimeException cause) {
+    return new TranscodeEngineException(
+        TranscodeEngineException.Reason.CLEANUP_PENDING, message, cause);
+  }
+
+  private boolean playlistHasEndMarker(
+      TranscodeJobSpec specification, SegmentGeneration generation, RenditionSpec rendition) {
+    return segmentStorage
+        .readStagedArtifact(generation, artifactName(specification, rendition, "stream.m3u8"))
+        .map(contents -> new String(contents, StandardCharsets.UTF_8))
+        .stream()
+        .flatMap(String::lines)
+        .anyMatch("#EXT-X-ENDLIST"::equals);
+  }
+
+  private boolean allRenditionsReady(TranscodeJobSpec specification, SegmentGeneration generation) {
+    return specification.renditions().stream()
+        .allMatch(rendition -> renditionReady(specification, generation, rendition));
+  }
+
+  private boolean renditionReady(
+      TranscodeJobSpec specification, SegmentGeneration generation, RenditionSpec rendition) {
+    var firstSegment =
+        "segment"
+            + specification.execution().startNumber()
+            + specification.decision().containerFormat().segmentExtension();
+    if (!nonEmpty(generation, artifactName(specification, rendition, "stream.m3u8"))
+        || !nonEmpty(generation, artifactName(specification, rendition, firstSegment))) {
+      return false;
+    }
+    return specification.decision().containerFormat().segmentExtension().equals(".ts")
+        || nonEmpty(generation, artifactName(specification, rendition, "init.mp4"));
+  }
+
+  private static String artifactName(
+      TranscodeJobSpec specification, RenditionSpec rendition, String filename) {
+    if (specification.renditions().size() == 1
+        && RenditionRequest.DEFAULT_VARIANT.equals(rendition.label())) {
+      return filename;
+    }
+    return rendition.label() + "/" + filename;
+  }
+
+  private boolean nonEmpty(SegmentGeneration generation, String relativeName) {
+    return segmentStorage.isStagedArtifactNonEmpty(generation, relativeName);
+  }
+
+  private static TranscodeJobObservation observation(
+      TranscodeJobSpec specification, TranscodeJobState jobState, RenditionState renditionState) {
+    var renditions =
+        specification.renditions().stream()
+            .map(rendition -> new RenditionObservation(rendition.label(), renditionState))
+            .toList();
+    return new TranscodeJobObservation(specification.jobRef(), jobState, List.copyOf(renditions));
+  }
+
+  private TranscodeJobObservation healthyObservation(
+      TranscodeJobSpec specification, SegmentGeneration generation) {
+    var renditions =
+        specification.renditions().stream()
+            .map(
+                rendition ->
+                    new RenditionObservation(
+                        rendition.label(), healthyState(specification, generation, rendition)))
+            .toList();
+    var jobState =
+        renditions.stream().allMatch(rendition -> rendition.state() == RenditionState.COMPLETED)
+            ? TranscodeJobState.COMPLETED
+            : TranscodeJobState.RUNNING;
+    return new TranscodeJobObservation(specification.jobRef(), jobState, renditions);
+  }
+
+  private record Admission(JobRun run, boolean owner, List<JobRun> superseded) {
+
+    private Admission(JobRun run, boolean owner) {
+      this(run, owner, List.of());
+    }
+  }
+
+  private static final class JobRun {
+
+    private final TranscodeJobSpec specification;
+    private final Path resolvedSource;
+    private final CompletableFuture<TranscodeJobObservation> startup = new CompletableFuture<>();
+    private volatile SegmentGeneration generation;
+    private volatile TranscodeJobObservation observation;
+    private volatile boolean cancelled;
+    private volatile boolean published;
+    private volatile boolean cleanupComplete;
+
+    private JobRun(TranscodeJobSpec specification, Path resolvedSource) {
+      this.specification = specification;
+      this.resolvedSource = resolvedSource;
+      observation =
+          LocalTranscodeEngine.observation(
+              specification, TranscodeJobState.ADMITTING, RenditionState.STARTING);
+    }
+
+    private CompletableFuture<TranscodeJobObservation> startup() {
+      return startup;
+    }
+
+    private boolean matches(TranscodeJobSpec otherSpecification, Path otherSource) {
+      return specification.equals(otherSpecification) && resolvedSource.equals(otherSource);
+    }
+
+    private UUID jobId() {
+      return specification.jobRef().jobId();
+    }
+
+    private long generation() {
+      return specification.jobRef().generation();
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
@@ -50,6 +50,9 @@ public class LocalTranscodeEngine {
   @Builder.Default
   private final ConcurrentHashMap<UUID, UUID> sessionOwnerBySessionId = new ConcurrentHashMap<>();
 
+  @Builder.Default
+  private final ConcurrentHashMap<UUID, TranscodeJobRef> publications = new ConcurrentHashMap<>();
+
   @Builder.Default private final Object lifecycleMonitor = new Object();
   private volatile boolean shuttingDown;
 
@@ -61,7 +64,7 @@ public class LocalTranscodeEngine {
       if (!existing.startup().isDone() || existing.startup().isCompletedExceptionally()) {
         return await(existing.startup());
       }
-      if (existing.cleanupComplete || existing.published) {
+      if (existing.cleanupComplete || isPublished(existing)) {
         return existing.observation.get();
       }
       return await(existing.startup());
@@ -84,11 +87,7 @@ public class LocalTranscodeEngine {
       synchronized (lifecycleMonitor) {
         assertAdmitted(run);
         segmentStorage.publish(generation);
-        runs.values().stream()
-            .filter(
-                candidate -> candidate.specification.sessionId().equals(specification.sessionId()))
-            .forEach(candidate -> candidate.published = false);
-        run.published = true;
+        publications.put(specification.sessionId(), specification.jobRef());
         run.observation.set(started);
       }
       run.startup().complete(started);
@@ -142,8 +141,7 @@ public class LocalTranscodeEngine {
                 observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED));
             return run.observation.get();
           }
-          segmentStorage.withdraw(run.specification.sessionId(), jobRef);
-          run.published = false;
+          withdrawPublication(run.specification.sessionId());
           run.observation.set(
               observation(run.specification, TranscodeJobState.FAILED, RenditionState.FAILED));
           run.cleanupComplete = true;
@@ -178,17 +176,17 @@ public class LocalTranscodeEngine {
           return run.observation.get();
         }
         synchronized (lifecycleMonitor) {
-          if (run.published
-              && highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
-            segmentStorage.withdraw(run.specification.sessionId(), jobRef);
-            run.published = false;
-          } else if (!run.published && !run.cleanupComplete && run.generation.get() != null) {
+          var current =
+              highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation();
+          if (current && publications.containsKey(run.specification.sessionId())) {
+            withdrawPublication(run.specification.sessionId());
+          } else if (!isPublished(run) && !run.cleanupComplete && run.generation.get() != null) {
             segmentStorage.discard(run.generation.get());
           }
           run.observation.set(
               observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED));
           run.cleanupComplete = true;
-          if (highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
+          if (current) {
             sessionOwnerBySessionId.remove(run.specification.sessionId(), jobRef.jobId());
           }
           return run.observation.get();
@@ -204,13 +202,13 @@ public class LocalTranscodeEngine {
     if (run == null) {
       return true;
     }
-    if (!run.cleanupComplete || run.published) {
-      return false;
-    }
-    if (!processManager.releaseJobObservation(jobRef)) {
-      return false;
-    }
     synchronized (lifecycleMonitor) {
+      if (!run.cleanupComplete || isPublished(run) || holdsFallbackStopAuthority(run)) {
+        return false;
+      }
+      if (!processManager.releaseJobObservation(jobRef)) {
+        return false;
+      }
       runs.remove(jobRef, run);
       if (highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
         sessionOwnerBySessionId.remove(run.specification.sessionId(), jobRef.jobId());
@@ -233,9 +231,8 @@ public class LocalTranscodeEngine {
       snapshot.forEach(
           run -> {
             synchronized (run.monitor) {
-              if (run.published) {
-                segmentStorage.withdraw(run.specification.sessionId(), run.specification.jobRef());
-                run.published = false;
+              if (isPublished(run)) {
+                withdrawPublication(run.specification.sessionId());
               } else if (!run.cleanupComplete && run.generation.get() != null) {
                 segmentStorage.discard(run.generation.get());
               }
@@ -323,7 +320,7 @@ public class LocalTranscodeEngine {
           throw new TranscodeException("Superseded transcode process is still running");
         }
         synchronized (run.monitor) {
-          if (!run.published && !run.cleanupComplete && run.generation.get() != null) {
+          if (!isPublished(run) && !run.cleanupComplete && run.generation.get() != null) {
             segmentStorage.discard(run.generation.get());
           }
           run.observation.set(
@@ -376,6 +373,27 @@ public class LocalTranscodeEngine {
       }
       throw exception;
     }
+  }
+
+  private boolean isPublished(JobRun run) {
+    return run.specification.jobRef().equals(publications.get(run.specification.sessionId()));
+  }
+
+  private boolean holdsFallbackStopAuthority(JobRun run) {
+    var jobRef = run.specification.jobRef();
+    var sessionId = run.specification.sessionId();
+    return publications.containsKey(sessionId)
+        && highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()
+        && jobRef.jobId().equals(sessionOwnerBySessionId.get(sessionId));
+  }
+
+  private void withdrawPublication(UUID sessionId) {
+    var jobRef = publications.get(sessionId);
+    if (jobRef == null) {
+      return;
+    }
+    segmentStorage.withdraw(sessionId, jobRef);
+    publications.remove(sessionId, jobRef);
   }
 
   private void startRendition(
@@ -569,7 +587,6 @@ public class LocalTranscodeEngine {
     private final AtomicReference<SegmentGeneration> generation = new AtomicReference<>();
     private final AtomicReference<TranscodeJobObservation> observation = new AtomicReference<>();
     private volatile boolean cancelled;
-    private volatile boolean published;
     private volatile boolean cleanupComplete;
 
     private JobRun(TranscodeJobSpec specification, Path resolvedSource) {

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.Builder;
 
 @Builder
@@ -61,7 +62,7 @@ public class LocalTranscodeEngine {
         return await(existing.startup());
       }
       if (existing.cleanupComplete || existing.published) {
-        return existing.observation;
+        return existing.observation.get();
       }
       return await(existing.startup());
     }
@@ -72,7 +73,7 @@ public class LocalTranscodeEngine {
       assertAdmitted(run);
       generation =
           segmentStorage.prepareGeneration(specification.sessionId(), specification.jobRef());
-      run.generation = generation;
+      run.generation.set(generation);
       for (var rendition : specification.renditions()) {
         assertAdmitted(run);
         startRendition(specification, resolvedSource, generation, rendition);
@@ -88,13 +89,14 @@ public class LocalTranscodeEngine {
                 candidate -> candidate.specification.sessionId().equals(specification.sessionId()))
             .forEach(candidate -> candidate.published = false);
         run.published = true;
-        run.observation = started;
+        run.observation.set(started);
       }
       run.startup().complete(started);
       return started;
     } catch (RuntimeException exception) {
       var failure = compensate(run, generation, exception);
-      run.observation = observation(specification, TranscodeJobState.FAILED, RenditionState.FAILED);
+      run.observation.set(
+          observation(specification, TranscodeJobState.FAILED, RenditionState.FAILED));
       run.startup().completeExceptionally(failure);
       throw failure;
     }
@@ -105,17 +107,17 @@ public class LocalTranscodeEngine {
     if (run == null) {
       return absent(jobRef);
     }
-    if (run.observation.state() != TranscodeJobState.RUNNING) {
-      return run.observation;
+    if (run.observation.get().state() != TranscodeJobState.RUNNING) {
+      return run.observation.get();
     }
     try {
-      assertProcessesHealthy(run.specification, run.generation);
-      var healthy = healthyObservation(run.specification, run.generation);
+      assertProcessesHealthy(run.specification, run.generation.get());
+      var healthy = healthyObservation(run.specification, run.generation.get());
       synchronized (lifecycleMonitor) {
-        if (run.observation.state() == TranscodeJobState.RUNNING) {
-          run.observation = healthy;
+        if (run.observation.get().state() == TranscodeJobState.RUNNING) {
+          run.observation.set(healthy);
         }
-        return run.observation;
+        return run.observation.get();
       }
     } catch (RuntimeException exception) {
       if (exception instanceof TranscodeEngineException engineException
@@ -133,19 +135,19 @@ public class LocalTranscodeEngine {
       if (processManager.isRunning(jobRef)) {
         throw new IllegalStateException("Exact transcode processes remain active");
       }
-      synchronized (run) {
+      synchronized (run.monitor) {
         synchronized (lifecycleMonitor) {
-          if (run.cancelled || run.observation.state() == TranscodeJobState.STOPPED) {
-            run.observation =
-                observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
-            return run.observation;
+          if (run.cancelled || run.observation.get().state() == TranscodeJobState.STOPPED) {
+            run.observation.set(
+                observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED));
+            return run.observation.get();
           }
           segmentStorage.withdraw(run.specification.sessionId(), jobRef);
           run.published = false;
-          run.observation =
-              observation(run.specification, TranscodeJobState.FAILED, RenditionState.FAILED);
+          run.observation.set(
+              observation(run.specification, TranscodeJobState.FAILED, RenditionState.FAILED));
           run.cleanupComplete = true;
-          return run.observation;
+          return run.observation.get();
         }
       }
     } catch (RuntimeException cleanupFailure) {
@@ -159,8 +161,8 @@ public class LocalTranscodeEngine {
       return absent(jobRef);
     }
     synchronized (lifecycleMonitor) {
-      if (run.observation.state() == TranscodeJobState.STOPPED && run.cleanupComplete) {
-        return run.observation;
+      if (run.observation.get().state() == TranscodeJobState.STOPPED && run.cleanupComplete) {
+        return run.observation.get();
       }
       run.cancelled = true;
     }
@@ -171,25 +173,25 @@ public class LocalTranscodeEngine {
       if (processManager.isRunning(jobRef)) {
         throw new IllegalStateException("Exact transcode processes remain active");
       }
-      synchronized (run) {
-        if (run.observation.state() == TranscodeJobState.STOPPED && run.cleanupComplete) {
-          return run.observation;
+      synchronized (run.monitor) {
+        if (run.observation.get().state() == TranscodeJobState.STOPPED && run.cleanupComplete) {
+          return run.observation.get();
         }
         synchronized (lifecycleMonitor) {
           if (run.published
               && highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
             segmentStorage.withdraw(run.specification.sessionId(), jobRef);
             run.published = false;
-          } else if (!run.published && !run.cleanupComplete && run.generation != null) {
-            segmentStorage.discard(run.generation);
+          } else if (!run.published && !run.cleanupComplete && run.generation.get() != null) {
+            segmentStorage.discard(run.generation.get());
           }
-          run.observation =
-              observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+          run.observation.set(
+              observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED));
           run.cleanupComplete = true;
           if (highestGenerationByJobId.getOrDefault(jobRef.jobId(), 0L) == jobRef.generation()) {
             sessionOwnerBySessionId.remove(run.specification.sessionId(), jobRef.jobId());
           }
-          return run.observation;
+          return run.observation.get();
         }
       }
     } catch (RuntimeException exception) {
@@ -230,15 +232,16 @@ public class LocalTranscodeEngine {
       processManager.forceStopAll();
       snapshot.forEach(
           run -> {
-            synchronized (run) {
+            synchronized (run.monitor) {
               if (run.published) {
                 segmentStorage.withdraw(run.specification.sessionId(), run.specification.jobRef());
                 run.published = false;
-              } else if (!run.cleanupComplete && run.generation != null) {
-                segmentStorage.discard(run.generation);
+              } else if (!run.cleanupComplete && run.generation.get() != null) {
+                segmentStorage.discard(run.generation.get());
               }
-              run.observation =
-                  observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+              run.observation.set(
+                  observation(
+                      run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED));
               run.cleanupComplete = true;
             }
           });
@@ -319,12 +322,12 @@ public class LocalTranscodeEngine {
         if (processManager.isRunning(jobRef)) {
           throw new TranscodeException("Superseded transcode process is still running");
         }
-        synchronized (run) {
-          if (!run.published && !run.cleanupComplete && run.generation != null) {
-            segmentStorage.discard(run.generation);
+        synchronized (run.monitor) {
+          if (!run.published && !run.cleanupComplete && run.generation.get() != null) {
+            segmentStorage.discard(run.generation.get());
           }
-          run.observation =
-              observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED);
+          run.observation.set(
+              observation(run.specification, TranscodeJobState.STOPPED, RenditionState.STOPPED));
           run.cleanupComplete = true;
         }
       }
@@ -562,8 +565,9 @@ public class LocalTranscodeEngine {
     private final TranscodeJobSpec specification;
     private final Path resolvedSource;
     private final CompletableFuture<TranscodeJobObservation> startup = new CompletableFuture<>();
-    private volatile SegmentGeneration generation;
-    private volatile TranscodeJobObservation observation;
+    private final Object monitor = new Object();
+    private final AtomicReference<SegmentGeneration> generation = new AtomicReference<>();
+    private final AtomicReference<TranscodeJobObservation> observation = new AtomicReference<>();
     private volatile boolean cancelled;
     private volatile boolean published;
     private volatile boolean cleanupComplete;
@@ -571,9 +575,9 @@ public class LocalTranscodeEngine {
     private JobRun(TranscodeJobSpec specification, Path resolvedSource) {
       this.specification = specification;
       this.resolvedSource = resolvedSource;
-      observation =
+      observation.set(
           LocalTranscodeEngine.observation(
-              specification, TranscodeJobState.ADMITTING, RenditionState.STARTING);
+              specification, TranscodeJobState.ADMITTING, RenditionState.STARTING));
     }
 
     private CompletableFuture<TranscodeJobObservation> startup() {

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/LocalTranscodeEngine.java
@@ -15,7 +15,6 @@ import com.streamarr.transcode.engine.model.TranscodeJobObservation;
 import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import com.streamarr.transcode.engine.model.TranscodeJobSpec;
 import com.streamarr.transcode.engine.model.TranscodeJobState;
-import com.streamarr.transcode.engine.model.TranscodeMode;
 import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
 import com.streamarr.transcode.engine.segment.SegmentGeneration;
 import java.nio.charset.StandardCharsets;
@@ -61,13 +60,13 @@ public class LocalTranscodeEngine {
     var admission = admit(specification, resolvedSource);
     if (!admission.owner()) {
       var existing = admission.run();
-      if (!existing.startup().isDone() || existing.startup().isCompletedExceptionally()) {
-        return await(existing.startup());
+      if (!existing.startup.isDone() || existing.startup.isCompletedExceptionally()) {
+        return await(existing.startup);
       }
       if (existing.cleanupComplete || isPublished(existing)) {
         return existing.observation.get();
       }
-      return await(existing.startup());
+      return await(existing.startup);
     }
     var run = admission.run();
     SegmentGeneration generation = null;
@@ -90,13 +89,13 @@ public class LocalTranscodeEngine {
         publications.put(specification.sessionId(), specification.jobRef());
         run.observation.set(started);
       }
-      run.startup().complete(started);
+      run.startup.complete(started);
       return started;
     } catch (RuntimeException exception) {
       var failure = compensate(run, generation, exception);
       run.observation.set(
           observation(specification, TranscodeJobState.FAILED, RenditionState.FAILED));
-      run.startup().completeExceptionally(failure);
+      run.startup.completeExceptionally(failure);
       throw failure;
     }
   }
@@ -166,7 +165,7 @@ public class LocalTranscodeEngine {
     }
     try {
       processManager.stopJob(jobRef);
-      run.startup().handle((_, _) -> null).join();
+      run.startup.handle((_, _) -> null).join();
       processManager.stopJob(jobRef);
       if (processManager.isRunning(jobRef)) {
         throw new IllegalStateException("Exact transcode processes remain active");
@@ -226,7 +225,7 @@ public class LocalTranscodeEngine {
     }
     try {
       processManager.forceStopAll();
-      snapshot.forEach(run -> run.startup().handle((_, _) -> null).join());
+      snapshot.forEach(run -> run.startup.handle((_, _) -> null).join());
       processManager.forceStopAll();
       snapshot.forEach(
           run -> {
@@ -274,7 +273,7 @@ public class LocalTranscodeEngine {
               TranscodeEngineException.Reason.JOB_CONFLICT,
               "Transcode job content conflicts with its exact identity");
         }
-        return new Admission(existing, false);
+        return new Admission(existing, false, List.of());
       }
       var jobRef = specification.jobRef();
       var boundSessionId = sessionIdByJobId.get(jobRef.jobId());
@@ -297,8 +296,9 @@ public class LocalTranscodeEngine {
       var run = new JobRun(specification, resolvedSource);
       var superseded =
           runs.values().stream()
-              .filter(candidate -> candidate.jobId().equals(jobRef.jobId()))
-              .filter(candidate -> candidate.generation() < jobRef.generation())
+              .filter(candidate -> candidate.specification.jobRef().jobId().equals(jobRef.jobId()))
+              .filter(
+                  candidate -> candidate.specification.jobRef().generation() < jobRef.generation())
               .toList();
       superseded.forEach(candidate -> candidate.cancelled = true);
       highestGenerationByJobId.put(jobRef.jobId(), jobRef.generation());
@@ -314,7 +314,7 @@ public class LocalTranscodeEngine {
       for (var run : superseded) {
         var jobRef = run.specification.jobRef();
         processManager.stopJob(jobRef);
-        run.startup().handle((_, _) -> null).join();
+        run.startup.handle((_, _) -> null).join();
         processManager.stopJob(jobRef);
         if (processManager.isRunning(jobRef)) {
           throw new TranscodeException("Superseded transcode process is still running");
@@ -433,19 +433,17 @@ public class LocalTranscodeEngine {
 
   private Path outputDirectory(
       TranscodeJobSpec specification, SegmentGeneration generation, RenditionSpec rendition) {
-    if (specification.renditions().size() == 1
-        && RenditionRequest.DEFAULT_VARIANT.equals(rendition.label())) {
-      return generation.outputDirectory();
-    }
-    return segmentStorage.prepareRenditionDirectory(generation, rendition.label());
+    return specification.renditions().size() == 1
+            && RenditionRequest.DEFAULT_VARIANT.equals(rendition.label())
+        ? generation.outputDirectory()
+        : segmentStorage.prepareRenditionDirectory(generation, rendition.label());
   }
 
   private String resolveEncoder(TranscodeJobSpec specification) {
-    var mode = specification.decision().transcodeMode();
-    if (mode == TranscodeMode.REMUX || mode == TranscodeMode.AUDIO_TRANSCODE) {
-      return "copy";
-    }
-    return capabilityService.resolveEncoder(specification.decision().videoCodecFamily());
+    return switch (specification.decision().transcodeMode()) {
+      case REMUX, AUDIO_TRANSCODE -> "copy";
+      default -> capabilityService.resolveEncoder(specification.decision().videoCodecFamily());
+    };
   }
 
   private void awaitReadiness(JobRun run, SegmentGeneration generation) {
@@ -535,11 +533,10 @@ public class LocalTranscodeEngine {
 
   private static String artifactName(
       TranscodeJobSpec specification, RenditionSpec rendition, String filename) {
-    if (specification.renditions().size() == 1
-        && RenditionRequest.DEFAULT_VARIANT.equals(rendition.label())) {
-      return filename;
-    }
-    return rendition.label() + "/" + filename;
+    return specification.renditions().size() == 1
+            && RenditionRequest.DEFAULT_VARIANT.equals(rendition.label())
+        ? filename
+        : rendition.label() + "/" + filename;
   }
 
   private boolean nonEmpty(SegmentGeneration generation, String relativeName) {
@@ -571,12 +568,7 @@ public class LocalTranscodeEngine {
     return new TranscodeJobObservation(specification.jobRef(), jobState, renditions);
   }
 
-  private record Admission(JobRun run, boolean owner, List<JobRun> superseded) {
-
-    private Admission(JobRun run, boolean owner) {
-      this(run, owner, List.of());
-    }
-  }
+  private record Admission(JobRun run, boolean owner, List<JobRun> superseded) {}
 
   private static final class JobRun {
 
@@ -597,20 +589,8 @@ public class LocalTranscodeEngine {
               specification, TranscodeJobState.ADMITTING, RenditionState.STARTING));
     }
 
-    private CompletableFuture<TranscodeJobObservation> startup() {
-      return startup;
-    }
-
     private boolean matches(TranscodeJobSpec otherSpecification, Path otherSource) {
       return specification.equals(otherSpecification) && resolvedSource.equals(otherSource);
-    }
-
-    private UUID jobId() {
-      return specification.jobRef().jobId();
-    }
-
-    private long generation() {
-      return specification.jobRef().generation();
     }
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/TranscodeEngineException.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/job/TranscodeEngineException.java
@@ -1,0 +1,32 @@
+package com.streamarr.transcode.engine.job;
+
+import com.streamarr.transcode.engine.error.TranscodeException;
+
+public final class TranscodeEngineException extends TranscodeException {
+
+  public enum Reason {
+    STALE_GENERATION,
+    JOB_CONFLICT,
+    SESSION_CONFLICT,
+    INVALID_SPECIFICATION,
+    STARTUP_FAILED,
+    CLEANUP_PENDING,
+    SHUTTING_DOWN
+  }
+
+  private final Reason reason;
+
+  public TranscodeEngineException(Reason reason, String message) {
+    super(message);
+    this.reason = reason;
+  }
+
+  public TranscodeEngineException(Reason reason, String message, Throwable cause) {
+    super(message, cause);
+    this.reason = reason;
+  }
+
+  public Reason reason() {
+    return reason;
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/AudioDecision.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/AudioDecision.java
@@ -5,6 +5,28 @@ import lombok.Builder;
 @Builder
 public record AudioDecision(AudioMode mode, String codec, int channels, long bitrate) {
 
+  private static final long MAX_SAFE_BITRATE = Long.MAX_VALUE / 2;
+
+  public AudioDecision {
+    if (mode == null) {
+      throw new IllegalArgumentException("Audio mode is required");
+    }
+    if (mode == AudioMode.NONE && (codec != null || channels != 0 || bitrate != 0)) {
+      throw new IllegalArgumentException("Excluded audio cannot carry encoding values");
+    }
+    if (mode != AudioMode.NONE
+        && (codec == null
+            || codec.isBlank()
+            || channels < 1
+            || bitrate < 0
+            || bitrate > MAX_SAFE_BITRATE)) {
+      throw new IllegalArgumentException("Included audio values are invalid");
+    }
+    if (mode == AudioMode.TRANSCODE && bitrate == 0) {
+      throw new IllegalArgumentException("Transcoded audio bitrate must be positive");
+    }
+  }
+
   public static AudioDecision stereoAac() {
     return new AudioDecision(AudioMode.TRANSCODE, "aac", 2, 128_000L);
   }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/MediaSourceRef.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/MediaSourceRef.java
@@ -1,0 +1,34 @@
+package com.streamarr.transcode.engine.model;
+
+import java.util.UUID;
+
+public record MediaSourceRef(UUID namespaceId, String relativeKey) {
+
+  public MediaSourceRef {
+    if (namespaceId == null) {
+      throw new IllegalArgumentException("Source namespace is required");
+    }
+    if (!isPortable(relativeKey)) {
+      throw new IllegalArgumentException("Source key must be a normalized portable relative path");
+    }
+  }
+
+  private static boolean isPortable(String key) {
+    if (key == null || key.isEmpty() || key.indexOf('\\') >= 0 || key.indexOf('\0') >= 0) {
+      return false;
+    }
+    if (key.charAt(0) == '/' || hasWindowsDrivePrefix(key)) {
+      return false;
+    }
+    for (var segment : key.split("/", -1)) {
+      if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean hasWindowsDrivePrefix(String key) {
+    return key.length() >= 2 && Character.isLetter(key.charAt(0)) && key.charAt(1) == ':';
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionJob.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionJob.java
@@ -4,4 +4,4 @@ import java.nio.file.Path;
 import lombok.Builder;
 
 @Builder
-public record TranscodeJob(TranscodeRequest request, String videoEncoder, Path outputDir) {}
+public record RenditionJob(RenditionRequest request, String videoEncoder, Path outputDir) {}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionObservation.java
@@ -1,0 +1,13 @@
+package com.streamarr.transcode.engine.model;
+
+public record RenditionObservation(String label, RenditionState state) {
+
+  public RenditionObservation {
+    if (label == null || label.isBlank()) {
+      throw new IllegalArgumentException("Rendition label must not be blank");
+    }
+    if (state == null) {
+      throw new IllegalArgumentException("Rendition state must not be null");
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionObservation.java
@@ -3,9 +3,7 @@ package com.streamarr.transcode.engine.model;
 public record RenditionObservation(String label, RenditionState state) {
 
   public RenditionObservation {
-    if (label == null || label.isBlank()) {
-      throw new IllegalArgumentException("Rendition label must not be blank");
-    }
+    RenditionSpec.requirePortableLabel(label);
     if (state == null) {
       throw new IllegalArgumentException("Rendition state must not be null");
     }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionRequest.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionRequest.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record TranscodeRequest(
+public record RenditionRequest(
     UUID sessionId,
     Path sourcePath,
     int seekPosition,
@@ -20,7 +20,7 @@ public record TranscodeRequest(
 
   public static final String DEFAULT_VARIANT = "default";
 
-  public TranscodeRequest {
+  public RenditionRequest {
     variantLabel = variantLabel != null ? variantLabel : DEFAULT_VARIANT;
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionSpec.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionSpec.java
@@ -6,6 +6,13 @@ import lombok.Builder;
 public record RenditionSpec(String label, int width, int height, long videoBitrate) {
 
   public RenditionSpec {
+    requirePortableLabel(label);
+    if (width < 1 || height < 1 || videoBitrate < 1 || videoBitrate > Long.MAX_VALUE / 2) {
+      throw new IllegalArgumentException("Rendition dimensions and bitrate are invalid");
+    }
+  }
+
+  public static void requirePortableLabel(String label) {
     if (label == null || label.isBlank()) {
       throw new IllegalArgumentException("Rendition label is required");
     }
@@ -15,9 +22,6 @@ public record RenditionSpec(String label, int width, int height, long videoBitra
         || label.indexOf('\\') >= 0
         || label.indexOf('\0') >= 0) {
       throw new IllegalArgumentException("Rendition label must be one portable path segment");
-    }
-    if (width < 1 || height < 1 || videoBitrate < 1) {
-      throw new IllegalArgumentException("Rendition dimensions and bitrate must be positive");
     }
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionSpec.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionSpec.java
@@ -1,0 +1,23 @@
+package com.streamarr.transcode.engine.model;
+
+import lombok.Builder;
+
+@Builder
+public record RenditionSpec(String label, int width, int height, long videoBitrate) {
+
+  public RenditionSpec {
+    if (label == null || label.isBlank()) {
+      throw new IllegalArgumentException("Rendition label is required");
+    }
+    if (label.equals(".")
+        || label.equals("..")
+        || label.indexOf('/') >= 0
+        || label.indexOf('\\') >= 0
+        || label.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException("Rendition label must be one portable path segment");
+    }
+    if (width < 1 || height < 1 || videoBitrate < 1) {
+      throw new IllegalArgumentException("Rendition dimensions and bitrate must be positive");
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionState.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/RenditionState.java
@@ -1,0 +1,10 @@
+package com.streamarr.transcode.engine.model;
+
+public enum RenditionState {
+  STARTING,
+  RUNNING,
+  COMPLETED,
+  FAILED,
+  STOPPED,
+  ABSENT
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/SubtitleDecision.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/SubtitleDecision.java
@@ -6,6 +6,21 @@ import java.util.OptionalInt;
 public record SubtitleDecision(
     SubtitleMode mode, Optional<String> codec, OptionalInt streamIndex, Optional<String> language) {
 
+  public SubtitleDecision {
+    if (mode == null || codec == null || streamIndex == null || language == null) {
+      throw new IllegalArgumentException("Subtitle decision values are required");
+    }
+    if (codec.filter(String::isBlank).isPresent()
+        || language.filter(String::isBlank).isPresent()
+        || streamIndex.stream().anyMatch(index -> index < 0)) {
+      throw new IllegalArgumentException("Subtitle decision values are invalid");
+    }
+    if (mode == SubtitleMode.EXCLUDE
+        && (codec.isPresent() || streamIndex.isPresent() || language.isPresent())) {
+      throw new IllegalArgumentException("Excluded subtitles cannot carry stream values");
+    }
+  }
+
   public static SubtitleDecision exclude() {
     return new SubtitleDecision(
         SubtitleMode.EXCLUDE, Optional.empty(), OptionalInt.empty(), Optional.empty());

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/SubtitleDecision.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/SubtitleDecision.java
@@ -6,6 +6,8 @@ import java.util.OptionalInt;
 public record SubtitleDecision(
     SubtitleMode mode, Optional<String> codec, OptionalInt streamIndex, Optional<String> language) {
 
+  // Optional components are part of this public record boundary and share its validation contract.
+  @SuppressWarnings("java:S2789")
   public SubtitleDecision {
     if (mode == null || codec == null || streamIndex == null || language == null) {
       throw new IllegalArgumentException("Subtitle decision values are required");

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeDecision.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeDecision.java
@@ -9,4 +9,16 @@ public record TranscodeDecision(
     AudioDecision audioDecision,
     SubtitleDecision subtitleDecision,
     ContainerFormat containerFormat,
-    boolean needsKeyframeAlignment) {}
+    boolean needsKeyframeAlignment) {
+
+  public TranscodeDecision {
+    if (transcodeMode == null
+        || videoCodecFamily == null
+        || videoCodecFamily.isBlank()
+        || audioDecision == null
+        || subtitleDecision == null
+        || containerFormat == null) {
+      throw new IllegalArgumentException("Transcode decision values are required");
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeExecutionParameters.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeExecutionParameters.java
@@ -1,0 +1,28 @@
+package com.streamarr.transcode.engine.model;
+
+import java.time.Duration;
+import lombok.Builder;
+
+@Builder
+public record TranscodeExecutionParameters(
+    int seekPosition,
+    int segmentDuration,
+    double framerate,
+    int startNumber,
+    Duration startupTimeout) {
+
+  public TranscodeExecutionParameters {
+    if (seekPosition < 0 || startNumber < 0) {
+      throw new IllegalArgumentException("Seek position and start number cannot be negative");
+    }
+    if (segmentDuration < 1) {
+      throw new IllegalArgumentException("Segment duration must be positive");
+    }
+    if (!Double.isFinite(framerate) || framerate <= 0) {
+      throw new IllegalArgumentException("Framerate must be finite and positive");
+    }
+    if (startupTimeout == null || startupTimeout.isZero() || startupTimeout.isNegative()) {
+      throw new IllegalArgumentException("Startup timeout must be positive");
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeExecutionParameters.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeExecutionParameters.java
@@ -25,7 +25,7 @@ public record TranscodeExecutionParameters(
       throw new IllegalArgumentException("Startup timeout must be positive");
     }
     try {
-      startupTimeout.toNanos();
+      startupTimeout = Duration.ofNanos(startupTimeout.toNanos());
     } catch (ArithmeticException exception) {
       throw new IllegalArgumentException(
           "Startup timeout must fit nanosecond precision", exception);

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeExecutionParameters.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeExecutionParameters.java
@@ -24,5 +24,11 @@ public record TranscodeExecutionParameters(
     if (startupTimeout == null || startupTimeout.isZero() || startupTimeout.isNegative()) {
       throw new IllegalArgumentException("Startup timeout must be positive");
     }
+    try {
+      startupTimeout.toNanos();
+    } catch (ArithmeticException exception) {
+      throw new IllegalArgumentException(
+          "Startup timeout must fit nanosecond precision", exception);
+    }
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobObservation.java
@@ -1,0 +1,23 @@
+package com.streamarr.transcode.engine.model;
+
+import java.util.HashSet;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record TranscodeJobObservation(
+    TranscodeJobRef jobRef, TranscodeJobState state, List<RenditionObservation> renditions) {
+
+  public TranscodeJobObservation {
+    if (jobRef == null || state == null || renditions == null) {
+      throw new IllegalArgumentException("Transcode job observation values are required");
+    }
+    var labels = new HashSet<String>();
+    for (var rendition : renditions) {
+      if (!labels.add(rendition.label())) {
+        throw new IllegalArgumentException("Transcode job rendition labels must be unique");
+      }
+    }
+    renditions = List.copyOf(renditions);
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobObservation.java
@@ -2,6 +2,7 @@ package com.streamarr.transcode.engine.model;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import lombok.Builder;
 
 @Builder
@@ -12,12 +13,48 @@ public record TranscodeJobObservation(
     if (jobRef == null || state == null || renditions == null) {
       throw new IllegalArgumentException("Transcode job observation values are required");
     }
+    if (renditions.stream().anyMatch(rendition -> rendition == null)) {
+      throw new IllegalArgumentException("Transcode job observation values are required");
+    }
+    if ((state == TranscodeJobState.ABSENT) != renditions.isEmpty()) {
+      throw new IllegalArgumentException("Job presence and rendition snapshot contradict");
+    }
+    if (!statesAgree(state, renditions)) {
+      throw new IllegalArgumentException("Job state and rendition snapshot contradict");
+    }
     var labels = new HashSet<String>();
     for (var rendition : renditions) {
-      if (!labels.add(rendition.label())) {
+      if (!labels.add(rendition.label().toLowerCase(Locale.ROOT))) {
         throw new IllegalArgumentException("Transcode job rendition labels must be unique");
       }
     }
     renditions = List.copyOf(renditions);
+  }
+
+  private static boolean statesAgree(
+      TranscodeJobState state, List<RenditionObservation> renditions) {
+    return switch (state) {
+      case ABSENT -> true;
+      case ADMITTING ->
+          renditions.stream().allMatch(rendition -> rendition.state() == RenditionState.STARTING);
+      case RUNNING ->
+          renditions.stream().anyMatch(rendition -> rendition.state() == RenditionState.RUNNING)
+              && renditions.stream()
+                  .allMatch(
+                      rendition ->
+                          rendition.state() == RenditionState.RUNNING
+                              || rendition.state() == RenditionState.COMPLETED);
+      case COMPLETED ->
+          renditions.stream().allMatch(rendition -> rendition.state() == RenditionState.COMPLETED);
+      case FAILED ->
+          renditions.stream().anyMatch(rendition -> rendition.state() == RenditionState.FAILED)
+              && renditions.stream()
+                  .noneMatch(
+                      rendition ->
+                          rendition.state() == RenditionState.STARTING
+                              || rendition.state() == RenditionState.RUNNING);
+      case STOPPED ->
+          renditions.stream().allMatch(rendition -> rendition.state() == RenditionState.STOPPED);
+    };
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobObservation.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobObservation.java
@@ -13,7 +13,7 @@ public record TranscodeJobObservation(
     if (jobRef == null || state == null || renditions == null) {
       throw new IllegalArgumentException("Transcode job observation values are required");
     }
-    if (renditions.stream().anyMatch(rendition -> rendition == null)) {
+    if (renditions.stream().anyMatch(java.util.Objects::isNull)) {
       throw new IllegalArgumentException("Transcode job observation values are required");
     }
     if ((state == TranscodeJobState.ABSENT) != renditions.isEmpty()) {

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobRef.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobRef.java
@@ -1,0 +1,15 @@
+package com.streamarr.transcode.engine.model;
+
+import java.util.UUID;
+
+public record TranscodeJobRef(UUID jobId, long generation) {
+
+  public TranscodeJobRef {
+    if (jobId == null) {
+      throw new IllegalArgumentException("Transcode job identity is required");
+    }
+    if (generation < 1) {
+      throw new IllegalArgumentException("Transcode generation must be positive");
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobSpec.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobSpec.java
@@ -1,0 +1,37 @@
+package com.streamarr.transcode.engine.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record TranscodeJobSpec(
+    UUID sessionId,
+    TranscodeJobRef jobRef,
+    MediaSourceRef source,
+    TranscodeDecision decision,
+    TranscodeExecutionParameters execution,
+    List<RenditionSpec> renditions) {
+
+  public TranscodeJobSpec {
+    if (sessionId == null
+        || jobRef == null
+        || source == null
+        || decision == null
+        || execution == null
+        || renditions == null) {
+      throw new IllegalArgumentException("Transcode job values are required");
+    }
+    if (renditions.isEmpty()) {
+      throw new IllegalArgumentException("Transcode job requires at least one rendition");
+    }
+    var labels = new HashSet<String>();
+    for (var rendition : renditions) {
+      if (!labels.add(rendition.label())) {
+        throw new IllegalArgumentException("Transcode job rendition labels must be unique");
+      }
+    }
+    renditions = List.copyOf(renditions);
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobSpec.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobSpec.java
@@ -2,6 +2,7 @@ package com.streamarr.transcode.engine.model;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -28,8 +29,8 @@ public record TranscodeJobSpec(
     }
     var labels = new HashSet<String>();
     for (var rendition : renditions) {
-      if (!labels.add(rendition.label())) {
-        throw new IllegalArgumentException("Transcode job rendition labels must be unique");
+      if (rendition == null || !labels.add(rendition.label().toLowerCase(Locale.ROOT))) {
+        throw new IllegalArgumentException("Transcode job renditions and labels must be unique");
       }
     }
     renditions = List.copyOf(renditions);

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobState.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/model/TranscodeJobState.java
@@ -1,0 +1,10 @@
+package com.streamarr.transcode.engine.model;
+
+public enum TranscodeJobState {
+  ADMITTING,
+  RUNNING,
+  COMPLETED,
+  FAILED,
+  STOPPED,
+  ABSENT
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/InvalidSegmentPathException.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/InvalidSegmentPathException.java
@@ -1,0 +1,8 @@
+package com.streamarr.transcode.engine.segment;
+
+public class InvalidSegmentPathException extends RuntimeException {
+
+  public InvalidSegmentPathException(String segment) {
+    super("Invalid segment path: " + segment);
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
@@ -1,0 +1,172 @@
+package com.streamarr.transcode.engine.segment;
+
+import com.streamarr.transcode.engine.error.TranscodeException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class LocalSegmentStorage {
+
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
+
+  private final Path baseDir;
+  private final ConcurrentHashMap<UUID, Path> sessionDirs = new ConcurrentHashMap<>();
+
+  public LocalSegmentStorage(Path baseDir) {
+    this.baseDir = baseDir;
+  }
+
+  public byte[] readSegment(UUID sessionId, String segmentName) {
+    var segmentPath = resolveSegmentPath(sessionId, segmentName);
+
+    try {
+      return Files.readAllBytes(segmentPath);
+    } catch (NoSuchFileException exception) {
+      throw new TranscodeException("Segment not found: " + segmentName, exception);
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to read segment: " + segmentName, exception);
+    }
+  }
+
+  public boolean waitForSegment(UUID sessionId, String segmentName, Duration timeout) {
+    var segmentPath = resolveSegmentPath(sessionId, segmentName);
+    var deadline = System.nanoTime() + timeout.toNanos();
+
+    while (System.nanoTime() < deadline) {
+      if (Files.exists(segmentPath)) {
+        return true;
+      }
+      try {
+        Thread.sleep(POLL_INTERVAL.toMillis());
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
+    return Files.exists(segmentPath);
+  }
+
+  public boolean segmentExists(UUID sessionId, String segmentName) {
+    try {
+      return Files.exists(resolveSegmentPath(sessionId, segmentName));
+    } catch (TranscodeException exception) {
+      return false;
+    }
+  }
+
+  public Path getOutputDirectory(UUID sessionId) {
+    return sessionDirs.computeIfAbsent(sessionId, this::createSessionDirectory);
+  }
+
+  public Path getOutputDirectory(UUID sessionId, String variantLabel) {
+    var sessionDir = getOutputDirectory(sessionId);
+    var variantDir = sessionDir.resolve(variantLabel);
+
+    try {
+      Files.createDirectories(variantDir);
+      return variantDir;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to create variant directory", exception);
+    }
+  }
+
+  public Set<UUID> snapshotStoredSessionIds() {
+    var sessionIds = new HashSet<UUID>();
+    try (var entries = Files.newDirectoryStream(baseDir)) {
+      for (var entry : entries) {
+        storedSessionId(entry).ifPresent(sessionIds::add);
+      }
+    } catch (NoSuchFileException _) {
+      return Set.of();
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to discover stored stream sessions", exception);
+    }
+    return Set.copyOf(sessionIds);
+  }
+
+  public void deleteSession(UUID sessionId) {
+    sessionDirs.remove(sessionId);
+    var dir = baseDir.resolve(sessionId.toString());
+    if (Files.exists(dir, LinkOption.NOFOLLOW_LINKS)) {
+      deleteDirectoryRecursively(dir);
+    }
+  }
+
+  public void shutdown() {
+    sessionDirs.clear();
+  }
+
+  private Path resolveSegmentPath(UUID sessionId, String segmentName) {
+    var dir = sessionDirs.get(sessionId);
+    if (dir == null) {
+      throw new TranscodeException("No output directory for session: " + sessionId);
+    }
+
+    var resolved = dir.resolve(segmentName).normalize();
+    if (!resolved.startsWith(dir)) {
+      throw new InvalidSegmentPathException(segmentName);
+    }
+
+    return resolved;
+  }
+
+  private Path createSessionDirectory(UUID sessionId) {
+    var dir = baseDir.resolve(sessionId.toString());
+
+    try {
+      Files.createDirectories(dir);
+      return dir;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to create session directory", exception);
+    }
+  }
+
+  private static Optional<UUID> storedSessionId(Path entry) {
+    var name = entry.getFileName().toString();
+    try {
+      var sessionId = UUID.fromString(name);
+      return sessionId.toString().equals(name) ? Optional.of(sessionId) : Optional.empty();
+    } catch (IllegalArgumentException _) {
+      return Optional.empty();
+    }
+  }
+
+  private void deleteDirectoryRecursively(Path dir) {
+    try {
+      Files.walkFileTree(
+          dir,
+          new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
+                throws IOException {
+              Files.deleteIfExists(file);
+              return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path directory, IOException exception)
+                throws IOException {
+              if (exception != null) {
+                throw exception;
+              }
+              Files.deleteIfExists(directory);
+              return FileVisitResult.CONTINUE;
+            }
+          });
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to clean up session directory: " + dir, exception);
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
@@ -1,6 +1,7 @@
 package com.streamarr.transcode.engine.segment;
 
 import com.streamarr.transcode.engine.error.TranscodeException;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileVisitResult;
@@ -11,41 +12,67 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LocalSegmentStorage {
 
   private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
+  private static final String STAGING_DIRECTORY = ".staging";
+
+  private record SegmentPublication(
+      TranscodeJobRef jobRef, Optional<Path> currentRoot, List<Path> historyRoots) {
+
+    private List<Path> searchRoots() {
+      if (currentRoot.isEmpty()) {
+        return List.of();
+      }
+      var searchRoots = new ArrayList<Path>();
+      searchRoots.add(currentRoot.orElseThrow());
+      searchRoots.addAll(historyRoots);
+      return List.copyOf(searchRoots);
+    }
+  }
+
+  private record SegmentPath(Path root, Path path) {}
 
   private final Path baseDir;
   private final ConcurrentHashMap<UUID, Path> sessionDirs = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<UUID, SegmentGeneration> currentCandidates =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<UUID, SegmentPublication> publishedGenerations =
+      new ConcurrentHashMap<>();
 
   public LocalSegmentStorage(Path baseDir) {
     this.baseDir = baseDir;
   }
 
   public byte[] readSegment(UUID sessionId, String segmentName) {
-    var segmentPath = resolveSegmentPath(sessionId, segmentName);
-
-    try {
-      return Files.readAllBytes(segmentPath);
-    } catch (NoSuchFileException exception) {
-      throw new TranscodeException("Segment not found: " + segmentName, exception);
-    } catch (IOException exception) {
-      throw new UncheckedIOException("Failed to read segment: " + segmentName, exception);
+    NoSuchFileException missing = null;
+    for (var segmentPath : resolveSegmentPaths(sessionId, segmentName)) {
+      try {
+        return Files.readAllBytes(verifiedSegmentPath(segmentPath, segmentName));
+      } catch (NoSuchFileException exception) {
+        missing = exception;
+      } catch (IOException exception) {
+        throw new UncheckedIOException("Failed to read segment: " + segmentName, exception);
+      }
     }
+    throw new TranscodeException("Segment not found: " + segmentName, missing);
   }
 
   public boolean waitForSegment(UUID sessionId, String segmentName, Duration timeout) {
-    var segmentPath = resolveSegmentPath(sessionId, segmentName);
+    resolveWithin(baseDir, segmentName);
     var deadline = System.nanoTime() + timeout.toNanos();
 
     while (System.nanoTime() < deadline) {
-      if (Files.exists(segmentPath)) {
+      if (segmentExists(sessionId, segmentName)) {
         return true;
       }
       try {
@@ -55,12 +82,12 @@ public class LocalSegmentStorage {
         return false;
       }
     }
-    return Files.exists(segmentPath);
+    return segmentExists(sessionId, segmentName);
   }
 
   public boolean segmentExists(UUID sessionId, String segmentName) {
     try {
-      return Files.exists(resolveSegmentPath(sessionId, segmentName));
+      return anyExists(resolveSegmentPaths(sessionId, segmentName));
     } catch (TranscodeException exception) {
       return false;
     }
@@ -82,14 +109,90 @@ public class LocalSegmentStorage {
     }
   }
 
+  public SegmentGeneration prepareGeneration(UUID sessionId, TranscodeJobRef jobRef) {
+    var outputDirectory =
+        baseDir
+            .resolve(STAGING_DIRECTORY)
+            .resolve(sessionId.toString())
+            .resolve(jobRef.jobId() + "-" + jobRef.generation());
+
+    try {
+      rejectResidualArtifacts(outputDirectory);
+      Files.createDirectories(outputDirectory);
+      var generation = new SegmentGeneration(sessionId, jobRef, outputDirectory);
+      currentCandidates.put(sessionId, generation);
+      return generation;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to prepare segment generation", exception);
+    }
+  }
+
+  public void publish(SegmentGeneration generation) {
+    currentCandidates.compute(
+        generation.sessionId(),
+        (sessionId, currentCandidate) -> {
+          if (currentCandidate != generation) {
+            throw new IllegalStateException("Segment generation is no longer current");
+          }
+          publishedGenerations.compute(
+              sessionId,
+              (_, currentPublication) ->
+                  new SegmentPublication(
+                      generation.jobRef(),
+                      Optional.of(generation.outputDirectory()),
+                      publicationHistory(currentPublication, sessionDirs.get(sessionId))));
+          return currentCandidate;
+        });
+  }
+
+  public void discard(SegmentGeneration generation) {
+    var discarded = new AtomicBoolean();
+    currentCandidates.computeIfPresent(
+        generation.sessionId(),
+        (_, currentCandidate) -> {
+          if (currentCandidate != generation) {
+            return currentCandidate;
+          }
+          var publication = publishedGenerations.get(generation.sessionId());
+          if (publication != null
+              && publication.jobRef().equals(generation.jobRef())
+              && publication
+                  .currentRoot()
+                  .filter(generation.outputDirectory()::equals)
+                  .isPresent()) {
+            return currentCandidate;
+          }
+          discarded.set(true);
+          return null;
+        });
+    if (!discarded.get()) {
+      throw new IllegalStateException("Segment generation is not owned by this storage");
+    }
+    var outputDirectory = generation.outputDirectory();
+    if (Files.exists(outputDirectory, LinkOption.NOFOLLOW_LINKS)) {
+      deleteDirectoryRecursively(outputDirectory);
+    }
+  }
+
+  public boolean withdraw(UUID sessionId, TranscodeJobRef jobRef) {
+    var withdrawn = new AtomicBoolean();
+    publishedGenerations.computeIfPresent(
+        sessionId,
+        (_, current) -> {
+          if (!current.jobRef().equals(jobRef)) {
+            return current;
+          }
+          withdrawn.set(true);
+          return new SegmentPublication(current.jobRef(), Optional.empty(), current.historyRoots());
+        });
+    return withdrawn.get();
+  }
+
   public Set<UUID> snapshotStoredSessionIds() {
     var sessionIds = new HashSet<UUID>();
-    try (var entries = Files.newDirectoryStream(baseDir)) {
-      for (var entry : entries) {
-        storedSessionId(entry).ifPresent(sessionIds::add);
-      }
-    } catch (NoSuchFileException _) {
-      return Set.of();
+    try {
+      addStoredSessionIds(baseDir, sessionIds);
+      addStoredSessionIds(baseDir.resolve(STAGING_DIRECTORY), sessionIds);
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to discover stored stream sessions", exception);
     }
@@ -97,29 +200,74 @@ public class LocalSegmentStorage {
   }
 
   public void deleteSession(UUID sessionId) {
+    currentCandidates.remove(sessionId);
+    publishedGenerations.remove(sessionId);
     sessionDirs.remove(sessionId);
-    var dir = baseDir.resolve(sessionId.toString());
-    if (Files.exists(dir, LinkOption.NOFOLLOW_LINKS)) {
-      deleteDirectoryRecursively(dir);
-    }
+    deleteIfExists(baseDir.resolve(sessionId.toString()));
+    deleteIfExists(baseDir.resolve(STAGING_DIRECTORY).resolve(sessionId.toString()));
   }
 
   public void shutdown() {
+    currentCandidates.clear();
+    publishedGenerations.clear();
     sessionDirs.clear();
   }
 
-  private Path resolveSegmentPath(UUID sessionId, String segmentName) {
-    var dir = sessionDirs.get(sessionId);
-    if (dir == null) {
+  private List<SegmentPath> resolveSegmentPaths(UUID sessionId, String segmentName) {
+    var publication = publishedGenerations.get(sessionId);
+    var searchRoots =
+        publication == null
+            ? Optional.ofNullable(sessionDirs.get(sessionId)).map(List::of).orElseGet(List::of)
+            : publication.searchRoots();
+    if (searchRoots.isEmpty()) {
       throw new TranscodeException("No output directory for session: " + sessionId);
     }
 
-    var resolved = dir.resolve(segmentName).normalize();
-    if (!resolved.startsWith(dir)) {
+    return searchRoots.stream()
+        .map(searchRoot -> new SegmentPath(searchRoot, resolveWithin(searchRoot, segmentName)))
+        .toList();
+  }
+
+  private static Path resolveWithin(Path searchRoot, String segmentName) {
+    var resolved = searchRoot.resolve(segmentName).normalize();
+    if (!resolved.startsWith(searchRoot)) {
       throw new InvalidSegmentPathException(segmentName);
     }
-
     return resolved;
+  }
+
+  private static boolean anyExists(List<SegmentPath> paths) {
+    for (var path : paths) {
+      try {
+        verifiedSegmentPath(path, path.path().getFileName().toString());
+        return true;
+      } catch (NoSuchFileException _) {
+        // Continue through older published roots.
+      } catch (IOException exception) {
+        throw new UncheckedIOException("Failed to inspect segment", exception);
+      }
+    }
+    return false;
+  }
+
+  private static Path verifiedSegmentPath(SegmentPath segmentPath, String segmentName)
+      throws IOException {
+    var realRoot = segmentPath.root().toRealPath();
+    var realSegment = segmentPath.path().toRealPath();
+    if (!realSegment.startsWith(realRoot) || !Files.isRegularFile(realSegment)) {
+      throw new InvalidSegmentPathException(segmentName);
+    }
+    return realSegment;
+  }
+
+  private static List<Path> publicationHistory(SegmentPublication current, Path legacyRoot) {
+    if (current == null) {
+      return legacyRoot == null ? List.of() : List.of(legacyRoot);
+    }
+    var historyRoots = new ArrayList<Path>();
+    current.currentRoot().ifPresent(historyRoots::add);
+    historyRoots.addAll(current.historyRoots());
+    return List.copyOf(historyRoots);
   }
 
   private Path createSessionDirectory(UUID sessionId) {
@@ -133,6 +281,20 @@ public class LocalSegmentStorage {
     }
   }
 
+  private static void rejectResidualArtifacts(Path outputDirectory) throws IOException {
+    if (!Files.exists(outputDirectory, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    if (!Files.isDirectory(outputDirectory, LinkOption.NOFOLLOW_LINKS)) {
+      throw new IllegalStateException("Segment generation path is not a directory");
+    }
+    try (var entries = Files.newDirectoryStream(outputDirectory)) {
+      if (entries.iterator().hasNext()) {
+        throw new IllegalStateException("Segment generation contains residual artifacts");
+      }
+    }
+  }
+
   private static Optional<UUID> storedSessionId(Path entry) {
     var name = entry.getFileName().toString();
     try {
@@ -140,6 +302,16 @@ public class LocalSegmentStorage {
       return sessionId.toString().equals(name) ? Optional.of(sessionId) : Optional.empty();
     } catch (IllegalArgumentException _) {
       return Optional.empty();
+    }
+  }
+
+  private static void addStoredSessionIds(Path directory, Set<UUID> sessionIds) throws IOException {
+    try (var entries = Files.newDirectoryStream(directory)) {
+      for (var entry : entries) {
+        storedSessionId(entry).ifPresent(sessionIds::add);
+      }
+    } catch (NoSuchFileException _) {
+      // A missing storage layout has no sessions to discover.
     }
   }
 
@@ -167,6 +339,12 @@ public class LocalSegmentStorage {
           });
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to clean up session directory: " + dir, exception);
+    }
+  }
+
+  private void deleteIfExists(Path path) {
+    if (Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+      deleteDirectoryRecursively(path);
     }
   }
 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
@@ -85,7 +85,7 @@ public class LocalSegmentStorage {
       }
       try {
         Thread.sleep(POLL_INTERVAL.toMillis());
-      } catch (InterruptedException exception) {
+      } catch (InterruptedException _) {
         Thread.currentThread().interrupt();
         return false;
       }
@@ -96,7 +96,7 @@ public class LocalSegmentStorage {
   public boolean segmentExists(UUID sessionId, String segmentName) {
     try {
       return anyExists(resolveSegmentPaths(sessionId, segmentName));
-    } catch (TranscodeException exception) {
+    } catch (TranscodeException _) {
       return false;
     }
   }
@@ -177,7 +177,7 @@ public class LocalSegmentStorage {
         }
         return Optional.of(contents);
       }
-    } catch (NoSuchFileException exception) {
+    } catch (NoSuchFileException _) {
       return Optional.empty();
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to read staged artifact", exception);
@@ -254,7 +254,7 @@ public class LocalSegmentStorage {
         (_, candidate) -> {
           publishedGenerations.computeIfPresent(
               sessionId,
-              (__, current) -> {
+              (_, current) -> {
                 if (!current.jobRef().equals(jobRef)) {
                   return current;
                 }

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/LocalSegmentStorage.java
@@ -25,6 +25,7 @@ public class LocalSegmentStorage {
 
   private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
   private static final String STAGING_DIRECTORY = ".staging";
+  private static final int MAX_STAGED_ARTIFACT_BYTES = 1_048_576;
 
   private record SegmentPublication(
       TranscodeJobRef jobRef, Optional<Path> currentRoot, List<Path> historyRoots) {
@@ -43,6 +44,7 @@ public class LocalSegmentStorage {
   private record SegmentPath(Path root, Path path) {}
 
   private final Path baseDir;
+  private final Path canonicalBaseDir;
   private final ConcurrentHashMap<UUID, Path> sessionDirs = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<UUID, SegmentGeneration> currentCandidates =
       new ConcurrentHashMap<>();
@@ -50,7 +52,13 @@ public class LocalSegmentStorage {
       new ConcurrentHashMap<>();
 
   public LocalSegmentStorage(Path baseDir) {
-    this.baseDir = baseDir;
+    this.baseDir = baseDir.toAbsolutePath().normalize();
+    try {
+      Files.createDirectories(this.baseDir);
+      canonicalBaseDir = this.baseDir.toRealPath();
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to initialize segment storage", exception);
+    }
   }
 
   public byte[] readSegment(UUID sessionId, String segmentName) {
@@ -94,15 +102,23 @@ public class LocalSegmentStorage {
   }
 
   public Path getOutputDirectory(UUID sessionId) {
-    return sessionDirs.computeIfAbsent(sessionId, this::createSessionDirectory);
+    var sessionDirectory = sessionDirs.computeIfAbsent(sessionId, this::createSessionDirectory);
+    try {
+      requireManagedPath(sessionDirectory, sessionId.toString());
+      return sessionDirectory;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to verify session directory", exception);
+    }
   }
 
   public Path getOutputDirectory(UUID sessionId, String variantLabel) {
     var sessionDir = getOutputDirectory(sessionId);
-    var variantDir = sessionDir.resolve(variantLabel);
+    var variantDir = resolveWithin(sessionDir, variantLabel);
 
     try {
+      requireManagedPath(variantDir, variantLabel);
       Files.createDirectories(variantDir);
+      requireManagedPath(variantDir, variantLabel);
       return variantDir;
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to create variant directory", exception);
@@ -117,13 +133,72 @@ public class LocalSegmentStorage {
             .resolve(jobRef.jobId() + "-" + jobRef.generation());
 
     try {
+      Files.createDirectories(baseDir);
+      requireManagedPath(outputDirectory, jobRef.jobId().toString());
       rejectResidualArtifacts(outputDirectory);
       Files.createDirectories(outputDirectory);
+      requireManagedPath(outputDirectory, jobRef.jobId().toString());
       var generation = new SegmentGeneration(sessionId, jobRef, outputDirectory);
       currentCandidates.put(sessionId, generation);
       return generation;
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to prepare segment generation", exception);
+    }
+  }
+
+  public Path prepareRenditionDirectory(SegmentGeneration generation, String label) {
+    requireCurrent(generation);
+    var outputDirectory = resolveWithin(generation.outputDirectory(), label);
+    try {
+      requireManagedPath(outputDirectory, label);
+      Files.createDirectories(outputDirectory);
+      requireManagedPath(outputDirectory, label);
+      return outputDirectory;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to prepare rendition directory", exception);
+    }
+  }
+
+  public Optional<byte[]> readStagedArtifact(SegmentGeneration generation, String relativeName) {
+    requireCurrent(generation);
+    var artifact = resolveWithin(generation.outputDirectory(), relativeName);
+    try {
+      requireManagedPath(artifact, relativeName);
+      if (!Files.exists(artifact, LinkOption.NOFOLLOW_LINKS)) {
+        return Optional.empty();
+      }
+      if (!Files.isRegularFile(artifact, LinkOption.NOFOLLOW_LINKS)) {
+        throw new InvalidSegmentPathException(relativeName);
+      }
+      try (var input = Files.newInputStream(artifact, LinkOption.NOFOLLOW_LINKS)) {
+        var contents = input.readNBytes(MAX_STAGED_ARTIFACT_BYTES + 1);
+        if (contents.length > MAX_STAGED_ARTIFACT_BYTES) {
+          throw new TranscodeException("Staged artifact exceeds inspection limit");
+        }
+        return Optional.of(contents);
+      }
+    } catch (NoSuchFileException exception) {
+      return Optional.empty();
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to read staged artifact", exception);
+    }
+  }
+
+  public boolean isStagedArtifactNonEmpty(SegmentGeneration generation, String relativeName) {
+    requireCurrent(generation);
+    var artifact = resolveWithin(generation.outputDirectory(), relativeName);
+    try {
+      requireManagedPath(artifact, relativeName);
+      var attributes =
+          Files.readAttributes(artifact, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+      if (!attributes.isRegularFile()) {
+        throw new InvalidSegmentPathException(relativeName);
+      }
+      return attributes.size() > 0;
+    } catch (NoSuchFileException _) {
+      return false;
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to inspect staged artifact", exception);
     }
   }
 
@@ -162,28 +237,35 @@ public class LocalSegmentStorage {
                   .isPresent()) {
             return currentCandidate;
           }
+          requireManagedGeneration(generation.outputDirectory());
+          deleteIfExists(generation.outputDirectory());
           discarded.set(true);
           return null;
         });
     if (!discarded.get()) {
       throw new IllegalStateException("Segment generation is not owned by this storage");
     }
-    var outputDirectory = generation.outputDirectory();
-    if (Files.exists(outputDirectory, LinkOption.NOFOLLOW_LINKS)) {
-      deleteDirectoryRecursively(outputDirectory);
-    }
   }
 
   public boolean withdraw(UUID sessionId, TranscodeJobRef jobRef) {
     var withdrawn = new AtomicBoolean();
-    publishedGenerations.computeIfPresent(
+    currentCandidates.compute(
         sessionId,
-        (_, current) -> {
-          if (!current.jobRef().equals(jobRef)) {
-            return current;
+        (_, candidate) -> {
+          publishedGenerations.computeIfPresent(
+              sessionId,
+              (__, current) -> {
+                if (!current.jobRef().equals(jobRef)) {
+                  return current;
+                }
+                withdrawn.set(true);
+                return new SegmentPublication(
+                    current.jobRef(), Optional.empty(), current.historyRoots());
+              });
+          if (withdrawn.get() && candidate != null && candidate.jobRef().equals(jobRef)) {
+            return null;
           }
-          withdrawn.set(true);
-          return new SegmentPublication(current.jobRef(), Optional.empty(), current.historyRoots());
+          return candidate;
         });
     return withdrawn.get();
   }
@@ -191,8 +273,11 @@ public class LocalSegmentStorage {
   public Set<UUID> snapshotStoredSessionIds() {
     var sessionIds = new HashSet<UUID>();
     try {
+      requireManagedPath(baseDir, "storage");
+      var stagingDirectory = baseDir.resolve(STAGING_DIRECTORY);
+      requireManagedPath(stagingDirectory, STAGING_DIRECTORY);
       addStoredSessionIds(baseDir, sessionIds);
-      addStoredSessionIds(baseDir.resolve(STAGING_DIRECTORY), sessionIds);
+      addStoredSessionIds(stagingDirectory, sessionIds);
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to discover stored stream sessions", exception);
     }
@@ -200,6 +285,13 @@ public class LocalSegmentStorage {
   }
 
   public void deleteSession(UUID sessionId) {
+    try {
+      requireSafeDeletionPath(baseDir.resolve(sessionId.toString()), sessionId.toString());
+      requireSafeDeletionPath(
+          baseDir.resolve(STAGING_DIRECTORY).resolve(sessionId.toString()), sessionId.toString());
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to verify session storage", exception);
+    }
     currentCandidates.remove(sessionId);
     publishedGenerations.remove(sessionId);
     sessionDirs.remove(sessionId);
@@ -236,7 +328,7 @@ public class LocalSegmentStorage {
     return resolved;
   }
 
-  private static boolean anyExists(List<SegmentPath> paths) {
+  private boolean anyExists(List<SegmentPath> paths) {
     for (var path : paths) {
       try {
         verifiedSegmentPath(path, path.path().getFileName().toString());
@@ -250,11 +342,19 @@ public class LocalSegmentStorage {
     return false;
   }
 
-  private static Path verifiedSegmentPath(SegmentPath segmentPath, String segmentName)
-      throws IOException {
+  private Path verifiedSegmentPath(SegmentPath segmentPath, String segmentName) throws IOException {
+    requireBaseIdentity(segmentName);
+    var lexicalBase = baseDir;
+    var lexicalRoot = segmentPath.root().toAbsolutePath().normalize();
+    if (!lexicalRoot.startsWith(lexicalBase)) {
+      throw new InvalidSegmentPathException(segmentName);
+    }
+    var expectedRoot = canonicalBaseDir.resolve(lexicalBase.relativize(lexicalRoot));
     var realRoot = segmentPath.root().toRealPath();
     var realSegment = segmentPath.path().toRealPath();
-    if (!realSegment.startsWith(realRoot) || !Files.isRegularFile(realSegment)) {
+    if (!realRoot.equals(expectedRoot)
+        || !realSegment.startsWith(realRoot)
+        || !Files.isRegularFile(realSegment)) {
       throw new InvalidSegmentPathException(segmentName);
     }
     return realSegment;
@@ -274,7 +374,10 @@ public class LocalSegmentStorage {
     var dir = baseDir.resolve(sessionId.toString());
 
     try {
+      Files.createDirectories(baseDir);
+      requireManagedPath(dir, sessionId.toString());
       Files.createDirectories(dir);
+      requireManagedPath(dir, sessionId.toString());
       return dir;
     } catch (IOException exception) {
       throw new UncheckedIOException("Failed to create session directory", exception);
@@ -292,6 +395,58 @@ public class LocalSegmentStorage {
       if (entries.iterator().hasNext()) {
         throw new IllegalStateException("Segment generation contains residual artifacts");
       }
+    }
+  }
+
+  private void requireManagedPath(Path path, String identifier) throws IOException {
+    requireBaseIdentity(identifier);
+    var lexicalBase = baseDir;
+    var lexicalPath = path.toAbsolutePath().normalize();
+    if (!lexicalPath.startsWith(lexicalBase)) {
+      throw new InvalidSegmentPathException(identifier);
+    }
+    var current = lexicalBase;
+    var expected = canonicalBaseDir;
+    for (var component : lexicalBase.relativize(lexicalPath)) {
+      current = current.resolve(component);
+      expected = expected.resolve(component);
+      if (!Files.exists(current, LinkOption.NOFOLLOW_LINKS)) {
+        return;
+      }
+      if (!current.toRealPath().equals(expected)) {
+        throw new InvalidSegmentPathException(identifier);
+      }
+    }
+  }
+
+  private void requireCurrent(SegmentGeneration generation) {
+    if (currentCandidates.get(generation.sessionId()) != generation) {
+      throw new IllegalStateException("Segment generation is no longer current");
+    }
+  }
+
+  private void requireManagedGeneration(Path outputDirectory) {
+    try {
+      requireManagedPath(outputDirectory, outputDirectory.getFileName().toString());
+    } catch (IOException exception) {
+      throw new UncheckedIOException("Failed to verify segment generation", exception);
+    }
+  }
+
+  private void requireSafeDeletionPath(Path path, String identifier) throws IOException {
+    var lexicalPath = path.toAbsolutePath().normalize();
+    if (!lexicalPath.startsWith(baseDir)) {
+      throw new InvalidSegmentPathException(identifier);
+    }
+    requireManagedPath(path.getParent(), identifier);
+    if (!Files.isSymbolicLink(path)) {
+      requireManagedPath(path, identifier);
+    }
+  }
+
+  private void requireBaseIdentity(String identifier) throws IOException {
+    if (!baseDir.toRealPath().equals(canonicalBaseDir)) {
+      throw new InvalidSegmentPathException(identifier);
     }
   }
 
@@ -317,6 +472,11 @@ public class LocalSegmentStorage {
 
   private void deleteDirectoryRecursively(Path dir) {
     try {
+      requireSafeDeletionPath(dir, dir.getFileName().toString());
+      if (Files.isSymbolicLink(dir)) {
+        Files.deleteIfExists(dir);
+        return;
+      }
       Files.walkFileTree(
           dir,
           new SimpleFileVisitor<>() {

--- a/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/SegmentGeneration.java
+++ b/streamarr-transcode-engine/src/main/java/com/streamarr/transcode/engine/segment/SegmentGeneration.java
@@ -1,0 +1,32 @@
+package com.streamarr.transcode.engine.segment;
+
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class SegmentGeneration {
+
+  private final UUID sessionId;
+  private final TranscodeJobRef jobRef;
+  private final Path outputDirectory;
+
+  SegmentGeneration(UUID sessionId, TranscodeJobRef jobRef, Path outputDirectory) {
+    this.sessionId = Objects.requireNonNull(sessionId, "sessionId must not be null");
+    this.jobRef = Objects.requireNonNull(jobRef, "jobRef must not be null");
+    this.outputDirectory =
+        Objects.requireNonNull(outputDirectory, "outputDirectory must not be null");
+  }
+
+  public UUID sessionId() {
+    return sessionId;
+  }
+
+  public TranscodeJobRef jobRef() {
+    return jobRef;
+  }
+
+  public Path outputDirectory() {
+    return outputDirectory;
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/fakes/FakeFfmpegProcessManager.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/fakes/FakeFfmpegProcessManager.java
@@ -188,6 +188,8 @@ public final class FakeFfmpegProcessManager implements FfmpegProcessManager {
     }
 
     @Override
-    public void destroy() {}
+    public void destroy() {
+      // The stub represents an already-completed process, so destruction has no further effect.
+    }
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/fakes/FakeFfmpegProcessManager.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/fakes/FakeFfmpegProcessManager.java
@@ -1,0 +1,193 @@
+package com.streamarr.transcode.engine.fakes;
+
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessObservation;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessState;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+public final class FakeFfmpegProcessManager implements FfmpegProcessManager {
+
+  @FunctionalInterface
+  public interface StartAction {
+
+    void accept(FfmpegProcessKey key, Path outputDirectory) throws IOException;
+  }
+
+  private final List<FfmpegProcessKey> startedKeys = new CopyOnWriteArrayList<>();
+  private final ConcurrentHashMap<FfmpegProcessKey, FfmpegProcessObservation> observations =
+      new ConcurrentHashMap<>();
+  private volatile StartAction startAction = (_, _) -> {};
+  private volatile Runnable stopAction = () -> {};
+  private volatile Consumer<FfmpegProcessKey> observeAction = _ -> {};
+  private volatile Consumer<FfmpegProcessKey> observedAction = _ -> {};
+  private final AtomicReference<RuntimeException> nextStopFailure = new AtomicReference<>();
+  private final AtomicReference<RuntimeException> nextForceStopFailure = new AtomicReference<>();
+  private final AtomicBoolean refuseNextRelease = new AtomicBoolean();
+
+  public void onStart(StartAction action) {
+    startAction = action;
+  }
+
+  public List<FfmpegProcessKey> startedKeys() {
+    return List.copyOf(startedKeys);
+  }
+
+  public void failProcess(FfmpegProcessKey key, int exitCode) {
+    observations.put(
+        key, FfmpegProcessObservation.withExitCode(FfmpegProcessState.FAILED, exitCode));
+  }
+
+  public void completeProcess(FfmpegProcessKey key) {
+    observations.put(key, FfmpegProcessObservation.withExitCode(FfmpegProcessState.COMPLETED, 0));
+  }
+
+  public void failNextStop(RuntimeException failure) {
+    nextStopFailure.set(failure);
+  }
+
+  public void failNextForceStop(RuntimeException failure) {
+    nextForceStopFailure.set(failure);
+  }
+
+  public void refuseNextRelease() {
+    refuseNextRelease.set(true);
+  }
+
+  public void onStop(Runnable action) {
+    stopAction = action;
+  }
+
+  public void onObserve(Consumer<FfmpegProcessKey> action) {
+    observeAction = action;
+  }
+
+  public void afterObserve(Consumer<FfmpegProcessKey> action) {
+    observedAction = action;
+  }
+
+  @Override
+  public Process startProcess(FfmpegProcessKey key, List<String> command, Path workingDir) {
+    startedKeys.add(key);
+    observations.put(key, FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.RUNNING));
+    try {
+      startAction.accept(key, workingDir);
+    } catch (IOException exception) {
+      startedKeys.remove(key);
+      observations.remove(key);
+      throw new UncheckedIOException(exception);
+    } catch (RuntimeException exception) {
+      startedKeys.remove(key);
+      observations.remove(key);
+      throw exception;
+    }
+    return new StubProcess();
+  }
+
+  @Override
+  public void stopProcess(FfmpegProcessKey key) {
+    observations.put(key, FfmpegProcessObservation.withExitCode(FfmpegProcessState.STOPPED, 0));
+  }
+
+  @Override
+  public void stopJob(TranscodeJobRef jobRef) {
+    var failure = nextStopFailure.getAndSet(null);
+    if (failure != null) {
+      throw failure;
+    }
+    stopAction.run();
+    observations.replaceAll(
+        (key, observation) -> key.jobRef().equals(jobRef) ? stoppedObservation() : observation);
+  }
+
+  @Override
+  public void forceStopAll() {
+    var failure = nextForceStopFailure.getAndSet(null);
+    if (failure != null) {
+      throw failure;
+    }
+    observations.replaceAll((_, _) -> stoppedObservation());
+  }
+
+  @Override
+  public boolean isRunning(TranscodeJobRef jobRef) {
+    return observations.entrySet().stream()
+        .anyMatch(
+            entry ->
+                entry.getKey().jobRef().equals(jobRef)
+                    && entry.getValue().state() == FfmpegProcessState.RUNNING);
+  }
+
+  @Override
+  public boolean isRunning(FfmpegProcessKey key) {
+    return observe(key).state() == FfmpegProcessState.RUNNING;
+  }
+
+  @Override
+  public FfmpegProcessObservation observe(FfmpegProcessKey key) {
+    observeAction.accept(key);
+    var observation =
+        observations.getOrDefault(
+            key, FfmpegProcessObservation.withoutExitCode(FfmpegProcessState.ABSENT));
+    observedAction.accept(key);
+    return observation;
+  }
+
+  @Override
+  public boolean releaseJobObservation(TranscodeJobRef jobRef) {
+    if (refuseNextRelease.getAndSet(false)) {
+      return false;
+    }
+    if (isRunning(jobRef)) {
+      return false;
+    }
+    observations.keySet().removeIf(key -> key.jobRef().equals(jobRef));
+    return true;
+  }
+
+  private static FfmpegProcessObservation stoppedObservation() {
+    return FfmpegProcessObservation.withExitCode(FfmpegProcessState.STOPPED, 0);
+  }
+
+  private static final class StubProcess extends Process {
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {}
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/FfmpegCommandBuilderTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/FfmpegCommandBuilderTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.streamarr.transcode.engine.model.AudioDecision;
 import com.streamarr.transcode.engine.model.AudioMode;
 import com.streamarr.transcode.engine.model.ContainerFormat;
+import com.streamarr.transcode.engine.model.RenditionJob;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import com.streamarr.transcode.engine.model.SubtitleDecision;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
-import com.streamarr.transcode.engine.model.TranscodeJob;
 import com.streamarr.transcode.engine.model.TranscodeMode;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -26,7 +26,7 @@ class FfmpegCommandBuilderTest {
 
   private final FfmpegCommandBuilder builder = new FfmpegCommandBuilder("ffmpeg");
 
-  private TranscodeJob job(
+  private RenditionJob job(
       TranscodeMode mode,
       String codecFamily,
       String audioCodec,
@@ -36,7 +36,7 @@ class FfmpegCommandBuilderTest {
     return job(mode, codecFamily, audioCodec, container, videoEncoder, needsKeyframeAlignment, 0);
   }
 
-  private TranscodeJob job(
+  private RenditionJob job(
       TranscodeMode mode,
       String codecFamily,
       String audioCodec,
@@ -57,7 +57,7 @@ class FfmpegCommandBuilderTest {
         5_000_000L);
   }
 
-  private TranscodeJob job(
+  private RenditionJob job(
       TranscodeMode mode,
       String codecFamily,
       String audioCodec,
@@ -69,9 +69,9 @@ class FfmpegCommandBuilderTest {
       int height,
       long bitrate) {
     var audio = audioDecisionFor(mode, audioCodec);
-    return TranscodeJob.builder()
+    return RenditionJob.builder()
         .request(
-            TranscodeRequest.builder()
+            RenditionRequest.builder()
                 .sessionId(UUID.randomUUID())
                 .sourcePath(Path.of("/media/movie.mkv"))
                 .seekPosition(seekPosition)
@@ -95,7 +95,7 @@ class FfmpegCommandBuilderTest {
         .build();
   }
 
-  private TranscodeJob jobWithStartNumber(
+  private RenditionJob jobWithStartNumber(
       TranscodeMode mode,
       String codecFamily,
       String audioCodec,
@@ -104,9 +104,9 @@ class FfmpegCommandBuilderTest {
       boolean needsKeyframeAlignment,
       int startNumber) {
     var audio = audioDecisionFor(mode, audioCodec);
-    return TranscodeJob.builder()
+    return RenditionJob.builder()
         .request(
-            TranscodeRequest.builder()
+            RenditionRequest.builder()
                 .sessionId(UUID.randomUUID())
                 .sourcePath(Path.of("/media/movie.mkv"))
                 .seekPosition(0)
@@ -138,15 +138,15 @@ class FfmpegCommandBuilderTest {
     };
   }
 
-  private TranscodeJob jobWithAudio(
+  private RenditionJob jobWithAudio(
       TranscodeMode mode,
       String codecFamily,
       AudioDecision audio,
       ContainerFormat container,
       String videoEncoder) {
-    return TranscodeJob.builder()
+    return RenditionJob.builder()
         .request(
-            TranscodeRequest.builder()
+            RenditionRequest.builder()
                 .sessionId(UUID.randomUUID())
                 .sourcePath(Path.of("/media/movie.mkv"))
                 .seekPosition(0)

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessKeyTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessKeyTest.java
@@ -1,0 +1,39 @@
+package com.streamarr.transcode.engine.ffmpeg;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("FFmpeg Process Key Tests")
+class FfmpegProcessKeyTest {
+
+  @ParameterizedTest
+  @MethodSource("invalidKeys")
+  @DisplayName("Should reject process key when exact job or rendition identity is invalid")
+  void shouldRejectProcessKeyWhenExactJobOrRenditionIdentityIsInvalid(
+      TranscodeJobRef jobRef, String renditionLabel) {
+    assertThatThrownBy(() -> new FfmpegProcessKey(jobRef, renditionLabel))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> invalidKeys() {
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
+    return Stream.of(
+        Arguments.of(null, "720p"),
+        Arguments.of(jobRef, null),
+        Arguments.of(jobRef, " "),
+        Arguments.of(jobRef, "."),
+        Arguments.of(jobRef, ".."),
+        Arguments.of(jobRef, "nested/720p"),
+        Arguments.of(jobRef, "nested\\720p"),
+        Arguments.of(jobRef, "720p\0escape"));
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessObservationTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/FfmpegProcessObservationTest.java
@@ -1,0 +1,36 @@
+package com.streamarr.transcode.engine.ffmpeg;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("FFmpeg Process Observation Tests")
+class FfmpegProcessObservationTest {
+
+  @ParameterizedTest
+  @MethodSource("contradictoryObservations")
+  @DisplayName("Should reject process observation when state contradicts exit code")
+  void shouldRejectProcessObservationWhenStateContradictsExitCode(
+      FfmpegProcessState state, OptionalInt exitCode) {
+    assertThatThrownBy(() -> new FfmpegProcessObservation(state, exitCode))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> contradictoryObservations() {
+    return Stream.of(
+        Arguments.of(null, OptionalInt.empty()),
+        Arguments.of(FfmpegProcessState.RUNNING, null),
+        Arguments.of(FfmpegProcessState.RUNNING, OptionalInt.of(0)),
+        Arguments.of(FfmpegProcessState.ABSENT, OptionalInt.of(0)),
+        Arguments.of(FfmpegProcessState.COMPLETED, OptionalInt.empty()),
+        Arguments.of(FfmpegProcessState.FAILED, OptionalInt.empty()),
+        Arguments.of(FfmpegProcessState.STOPPED, OptionalInt.empty()));
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManagerTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManagerTest.java
@@ -7,6 +7,7 @@ import static org.awaitility.Awaitility.await;
 
 import com.streamarr.transcode.engine.error.TranscodeException;
 import com.streamarr.transcode.engine.model.RenditionRequest;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -25,20 +26,44 @@ class LocalFfmpegProcessManagerTest {
 
   private final LocalFfmpegProcessManager manager = new LocalFfmpegProcessManager();
 
+  private static TranscodeJobRef jobRef(UUID sessionId) {
+    return new TranscodeJobRef(sessionId, 1L);
+  }
+
+  private static FfmpegProcessKey processKey(UUID sessionId, String renditionLabel) {
+    return new FfmpegProcessKey(jobRef(sessionId), renditionLabel);
+  }
+
+  private Process startProcess(
+      UUID sessionId, String renditionLabel, List<String> command, Path workingDir) {
+    return manager.startProcess(processKey(sessionId, renditionLabel), command, workingDir);
+  }
+
+  private void stopJob(UUID sessionId) {
+    manager.stopJob(jobRef(sessionId));
+  }
+
+  private boolean isRunning(UUID sessionId) {
+    return manager.isRunning(jobRef(sessionId));
+  }
+
+  private boolean isRunning(UUID sessionId, String renditionLabel) {
+    return manager.isRunning(processKey(sessionId, renditionLabel));
+  }
+
   @Test
   @DisplayName("Should report running when process is started")
   void shouldReportRunningWhenProcessIsStarted() {
     var sessionId = UUID.randomUUID();
 
     var process =
-        manager.startProcess(
-            sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
+        startProcess(sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
 
     assertThat(process).isNotNull();
     assertThat(process.isAlive()).isTrue();
-    assertThat(manager.isRunning(sessionId)).isTrue();
+    assertThat(isRunning(sessionId)).isTrue();
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
   }
 
   @Test
@@ -46,18 +71,103 @@ class LocalFfmpegProcessManagerTest {
   void shouldStopProcessGracefullyWhenRequested() {
     var sessionId = UUID.randomUUID();
 
-    manager.startProcess(
-        sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
 
-    assertThat(manager.isRunning(sessionId)).isFalse();
+    assertThat(isRunning(sessionId)).isFalse();
   }
 
   @Test
   @DisplayName("Should report not running when session is unknown")
   void shouldReportNotRunningWhenSessionIsUnknown() {
-    assertThat(manager.isRunning(UUID.randomUUID())).isFalse();
+    assertThat(isRunning(UUID.randomUUID())).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should observe an unknown process as absent")
+  void shouldObserveAnUnknownProcessAsAbsent() {
+    var observation = manager.observe(processKey(UUID.randomUUID(), "unknown"));
+
+    assertThat(observation.state()).isEqualTo(FfmpegProcessState.ABSENT);
+    assertThat(observation.exitCode()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should observe a live process as running")
+  void shouldObserveALiveProcessAsRunning() {
+    var sessionId = UUID.randomUUID();
+    var key = processKey(sessionId, "running");
+    manager.startProcess(key, List.of("bash", "-c", "read -r -n 1"), tempDir);
+
+    try {
+      var observation = manager.observe(key);
+
+      assertThat(observation.state()).isEqualTo(FfmpegProcessState.RUNNING);
+      assertThat(observation.exitCode()).isEmpty();
+    } finally {
+      stopJob(sessionId);
+    }
+  }
+
+  @Test
+  @DisplayName("Should retain a clean process completion with its exit code")
+  void shouldRetainACleanProcessCompletionWithItsExitCode() throws Exception {
+    var key = processKey(UUID.randomUUID(), "completed");
+    var process = manager.startProcess(key, List.of("true"), tempDir);
+    process.waitFor();
+
+    var observation = manager.observe(key);
+
+    assertThat(observation.state()).isEqualTo(FfmpegProcessState.COMPLETED);
+    assertThat(observation.exitCode()).hasValue(0);
+    assertThat(manager.observe(key)).isEqualTo(observation);
+  }
+
+  @Test
+  @DisplayName("Should retain a failed process with its nonzero exit code")
+  void shouldRetainAFailedProcessWithItsNonzeroExitCode() throws Exception {
+    var key = processKey(UUID.randomUUID(), "failed");
+    var process = manager.startProcess(key, List.of("bash", "-c", "exit 7"), tempDir);
+    process.waitFor();
+
+    var observation = manager.observe(key);
+
+    assertThat(observation.state()).isEqualTo(FfmpegProcessState.FAILED);
+    assertThat(observation.exitCode()).hasValue(7);
+    assertThat(manager.observe(key)).isEqualTo(observation);
+  }
+
+  @Test
+  @DisplayName("Should retain requested process stop separately from natural completion")
+  void shouldRetainRequestedProcessStopSeparatelyFromNaturalCompletion() {
+    var key = processKey(UUID.randomUUID(), "stopped");
+    manager.startProcess(key, List.of("bash", "-c", "read -r -n 1"), tempDir);
+
+    manager.stopProcess(key);
+    var observation = manager.observe(key);
+
+    assertThat(observation.state()).isEqualTo(FfmpegProcessState.STOPPED);
+    assertThat(observation.exitCode()).hasValue(0);
+    assertThat(manager.observe(key)).isEqualTo(observation);
+  }
+
+  @Test
+  @DisplayName("Should replace a terminal observation when the exact process restarts")
+  void shouldReplaceATerminalObservationWhenTheExactProcessRestarts() {
+    var key = processKey(UUID.randomUUID(), "restarted");
+    var gracefulCommand = List.of("bash", "-c", "read -r -n 1");
+    manager.startProcess(key, gracefulCommand, tempDir);
+    manager.stopProcess(key);
+    assertThat(manager.observe(key).state()).isEqualTo(FfmpegProcessState.STOPPED);
+
+    manager.startProcess(key, gracefulCommand, tempDir);
+
+    try {
+      assertThat(manager.observe(key).state()).isEqualTo(FfmpegProcessState.RUNNING);
+    } finally {
+      manager.stopProcess(key);
+    }
   }
 
   @Test
@@ -66,13 +176,12 @@ class LocalFfmpegProcessManagerTest {
     var sessionId = UUID.randomUUID();
 
     var process =
-        manager.startProcess(
-            sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("echo", "done"), tempDir);
+        startProcess(sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("echo", "done"), tempDir);
     process.waitFor();
 
     await().pollDelay(Duration.ofMillis(100)).until(() -> true);
 
-    assertThat(manager.isRunning(sessionId)).isFalse();
+    assertThat(isRunning(sessionId)).isFalse();
   }
 
   @Test
@@ -80,7 +189,7 @@ class LocalFfmpegProcessManagerTest {
   void shouldNotThrowWhenStoppingAlreadyStoppedSession() {
     var sessionId = UUID.randomUUID();
 
-    assertThatNoException().isThrownBy(() -> manager.stopProcess(sessionId));
+    assertThatNoException().isThrownBy(() -> stopJob(sessionId));
   }
 
   @Test
@@ -88,16 +197,38 @@ class LocalFfmpegProcessManagerTest {
   void shouldTrackMultipleVariantsPerSession() {
     var sessionId = UUID.randomUUID();
 
-    manager.startProcess(sessionId, "1080p", List.of("sleep", "30"), tempDir);
-    manager.startProcess(sessionId, "720p", List.of("sleep", "30"), tempDir);
-    manager.startProcess(sessionId, "480p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "1080p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "720p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "480p", List.of("sleep", "30"), tempDir);
 
-    assertThat(manager.isRunning(sessionId)).isTrue();
-    assertThat(manager.isRunning(sessionId, "1080p")).isTrue();
-    assertThat(manager.isRunning(sessionId, "720p")).isTrue();
-    assertThat(manager.isRunning(sessionId, "480p")).isTrue();
+    assertThat(isRunning(sessionId)).isTrue();
+    assertThat(isRunning(sessionId, "1080p")).isTrue();
+    assertThat(isRunning(sessionId, "720p")).isTrue();
+    assertThat(isRunning(sessionId, "480p")).isTrue();
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
+  }
+
+  @Test
+  @DisplayName("Should isolate the same rendition across exact job generations")
+  void shouldIsolateTheSameRenditionAcrossExactJobGenerations() {
+    var jobId = UUID.randomUUID();
+    var firstJob = new TranscodeJobRef(jobId, 1L);
+    var secondJob = new TranscodeJobRef(jobId, 2L);
+    var firstKey = new FfmpegProcessKey(firstJob, "720p");
+    var secondKey = new FfmpegProcessKey(secondJob, "720p");
+    var gracefulCommand = List.of("bash", "-c", "read -r -n 1");
+    manager.startProcess(firstKey, gracefulCommand, tempDir);
+    manager.startProcess(secondKey, gracefulCommand, tempDir);
+
+    try {
+      manager.stopJob(firstJob);
+
+      assertThat(manager.observe(firstKey).state()).isEqualTo(FfmpegProcessState.STOPPED);
+      assertThat(manager.observe(secondKey).state()).isEqualTo(FfmpegProcessState.RUNNING);
+    } finally {
+      manager.stopJob(secondJob);
+    }
   }
 
   @Test
@@ -106,15 +237,15 @@ class LocalFfmpegProcessManagerTest {
     var sessionId = UUID.randomUUID();
     var variant = RenditionRequest.DEFAULT_VARIANT;
     var command = List.of("sleep", "30");
-    var first = manager.startProcess(sessionId, variant, command, tempDir);
+    var first = startProcess(sessionId, variant, command, tempDir);
 
-    assertThatThrownBy(() -> manager.startProcess(sessionId, variant, command, tempDir))
+    assertThatThrownBy(() -> startProcess(sessionId, variant, command, tempDir))
         .isInstanceOf(TranscodeException.class)
         .hasMessage(TranscodeException.GENERIC_MESSAGE);
 
     assertThat(first.isAlive()).isTrue();
-    assertThat(manager.isRunning(sessionId, variant)).isTrue();
-    manager.stopProcess(sessionId);
+    assertThat(isRunning(sessionId, variant)).isTrue();
+    stopJob(sessionId);
     assertThat(first.isAlive()).isFalse();
   }
 
@@ -123,16 +254,16 @@ class LocalFfmpegProcessManagerTest {
   void shouldStopAllVariantsWhenStoppingSession() {
     var sessionId = UUID.randomUUID();
 
-    manager.startProcess(sessionId, "1080p", List.of("sleep", "30"), tempDir);
-    manager.startProcess(sessionId, "720p", List.of("sleep", "30"), tempDir);
-    manager.startProcess(sessionId, "480p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "1080p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "720p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "480p", List.of("sleep", "30"), tempDir);
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
 
-    assertThat(manager.isRunning(sessionId)).isFalse();
-    assertThat(manager.isRunning(sessionId, "1080p")).isFalse();
-    assertThat(manager.isRunning(sessionId, "720p")).isFalse();
-    assertThat(manager.isRunning(sessionId, "480p")).isFalse();
+    assertThat(isRunning(sessionId)).isFalse();
+    assertThat(isRunning(sessionId, "1080p")).isFalse();
+    assertThat(isRunning(sessionId, "720p")).isFalse();
+    assertThat(isRunning(sessionId, "480p")).isFalse();
   }
 
   @Test
@@ -141,10 +272,10 @@ class LocalFfmpegProcessManagerTest {
     var firstSessionId = UUID.randomUUID();
     var secondSessionId = UUID.randomUUID();
     var first =
-        manager.startProcess(
+        startProcess(
             firstSessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
     var second =
-        manager.startProcess(
+        startProcess(
             secondSessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
 
     try {
@@ -152,11 +283,11 @@ class LocalFfmpegProcessManagerTest {
 
       assertThat(first.isAlive()).isFalse();
       assertThat(second.isAlive()).isFalse();
-      assertThat(manager.isRunning(firstSessionId)).isFalse();
-      assertThat(manager.isRunning(secondSessionId)).isFalse();
+      assertThat(isRunning(firstSessionId)).isFalse();
+      assertThat(isRunning(secondSessionId)).isFalse();
     } finally {
-      manager.stopProcess(firstSessionId);
-      manager.stopProcess(secondSessionId);
+      stopJob(firstSessionId);
+      stopJob(secondSessionId);
     }
   }
 
@@ -164,12 +295,12 @@ class LocalFfmpegProcessManagerTest {
   @DisplayName("Should remove naturally completed process during final shutdown")
   void shouldRemoveNaturallyCompletedProcessDuringFinalShutdown() throws Exception {
     var sessionId = UUID.randomUUID();
-    var process = manager.startProcess(sessionId, "completed", List.of("true"), tempDir);
+    var process = startProcess(sessionId, "completed", List.of("true"), tempDir);
     process.waitFor();
 
     manager.forceStopAll();
 
-    assertThat(manager.isRunning(sessionId, "completed")).isFalse();
+    assertThat(isRunning(sessionId, "completed")).isFalse();
   }
 
   @Test
@@ -177,12 +308,12 @@ class LocalFfmpegProcessManagerTest {
   void shouldAcceptGracefulQuitResponseWhenStoppingProcess() {
     var sessionId = UUID.randomUUID();
     var process =
-        manager.startProcess(sessionId, "graceful", List.of("bash", "-c", "read -r -n 1"), tempDir);
+        startProcess(sessionId, "graceful", List.of("bash", "-c", "read -r -n 1"), tempDir);
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
 
     assertThat(process.isAlive()).isFalse();
-    assertThat(manager.isRunning(sessionId, "graceful")).isFalse();
+    assertThat(isRunning(sessionId, "graceful")).isFalse();
   }
 
   @Test
@@ -191,19 +322,19 @@ class LocalFfmpegProcessManagerTest {
   void shouldStopEveryVariantAndRestoreInterruptionWhenSessionStopIsInterrupted() {
     var sessionId = UUID.randomUUID();
     var gracefulCommand = List.of("bash", "-c", "read -r -n 1");
-    var first = manager.startProcess(sessionId, "first", gracefulCommand, tempDir);
-    var second = manager.startProcess(sessionId, "second", gracefulCommand, tempDir);
+    var first = startProcess(sessionId, "first", gracefulCommand, tempDir);
+    var second = startProcess(sessionId, "second", gracefulCommand, tempDir);
 
     try {
       Thread.currentThread().interrupt();
 
-      assertThatThrownBy(() -> manager.stopProcess(sessionId))
+      assertThatThrownBy(() -> stopJob(sessionId))
           .isInstanceOf(TranscodeException.class)
           .hasMessage(TranscodeException.GENERIC_MESSAGE);
       assertThat(Thread.currentThread().isInterrupted()).isTrue();
       assertThat(first.isAlive()).isFalse();
       assertThat(second.isAlive()).isFalse();
-      assertThat(manager.isRunning(sessionId)).isFalse();
+      assertThat(isRunning(sessionId)).isFalse();
     } finally {
       Thread.interrupted();
       manager.forceStopAll();
@@ -214,14 +345,14 @@ class LocalFfmpegProcessManagerTest {
   @DisplayName("Should finish cleanup when session stop is interrupted while waiting")
   void shouldFinishCleanupWhenSessionStopIsInterruptedWhileWaiting() {
     var sessionId = UUID.randomUUID();
-    var process = manager.startProcess(sessionId, "waiting", List.of("sleep", "30"), tempDir);
+    var process = startProcess(sessionId, "waiting", List.of("sleep", "30"), tempDir);
     var failure = new AtomicReference<RuntimeException>();
     var stopThread =
         Thread.ofVirtual()
             .start(
                 () -> {
                   try {
-                    manager.stopProcess(sessionId);
+                    stopJob(sessionId);
                   } catch (RuntimeException exception) {
                     failure.set(exception);
                   }
@@ -240,7 +371,7 @@ class LocalFfmpegProcessManagerTest {
       assertThat(failure.get()).isInstanceOf(TranscodeException.class);
       assertThat(stopThread.isInterrupted()).isTrue();
       assertThat(process.isAlive()).isFalse();
-      assertThat(manager.isRunning(sessionId)).isFalse();
+      assertThat(isRunning(sessionId)).isFalse();
     } finally {
       stopThread.interrupt();
       manager.forceStopAll();
@@ -252,12 +383,12 @@ class LocalFfmpegProcessManagerTest {
   void shouldReportRunningForSpecificVariant() {
     var sessionId = UUID.randomUUID();
 
-    manager.startProcess(sessionId, "720p", List.of("sleep", "30"), tempDir);
+    startProcess(sessionId, "720p", List.of("sleep", "30"), tempDir);
 
-    assertThat(manager.isRunning(sessionId, "720p")).isTrue();
-    assertThat(manager.isRunning(sessionId, "360p")).isFalse();
+    assertThat(isRunning(sessionId, "720p")).isTrue();
+    assertThat(isRunning(sessionId, "360p")).isFalse();
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
   }
 
   @Test
@@ -267,7 +398,7 @@ class LocalFfmpegProcessManagerTest {
 
     var command = List.of("/nonexistent-binary-12345");
 
-    assertThatThrownBy(() -> manager.startProcess(sessionId, "default", command, tempDir))
+    assertThatThrownBy(() -> startProcess(sessionId, "default", command, tempDir))
         .isInstanceOf(TranscodeException.class)
         .hasMessage(TranscodeException.GENERIC_MESSAGE);
   }
@@ -282,7 +413,7 @@ class LocalFfmpegProcessManagerTest {
     var script = "for i in $(seq 1 5000); do echo \"stderr line $i\" >&2; done; exit 0";
 
     var process =
-        manager.startProcess(
+        startProcess(
             sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("bash", "-c", script), tempDir);
 
     await()
@@ -293,7 +424,7 @@ class LocalFfmpegProcessManagerTest {
               assertThat(process.exitValue()).isZero();
             });
 
-    manager.stopProcess(sessionId);
+    stopJob(sessionId);
   }
 
   @Test
@@ -302,7 +433,7 @@ class LocalFfmpegProcessManagerTest {
     var sessionId = UUID.randomUUID();
 
     var process =
-        manager.startProcess(
+        startProcess(
             sessionId,
             RenditionRequest.DEFAULT_VARIANT,
             List.of("bash", "-c", "echo 'error output' >&2; exit 1"),
@@ -312,7 +443,7 @@ class LocalFfmpegProcessManagerTest {
     await().pollDelay(Duration.ofMillis(200)).until(() -> true);
 
     // isRunning triggers cleanup + logExitDetails — should not throw
-    assertThatNoException().isThrownBy(() -> manager.isRunning(sessionId));
-    assertThat(manager.isRunning(sessionId)).isFalse();
+    assertThatNoException().isThrownBy(() -> isRunning(sessionId));
+    assertThat(isRunning(sessionId)).isFalse();
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManagerTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManagerTest.java
@@ -125,6 +125,91 @@ class LocalFfmpegProcessManagerTest {
   }
 
   @Test
+  @DisplayName("Should release terminal observations for the exact job")
+  void shouldReleaseTerminalObservationsForTheExactJob() throws Exception {
+    var jobRef = jobRef(UUID.randomUUID());
+    var firstKey = new FfmpegProcessKey(jobRef, "completed-first");
+    var secondKey = new FfmpegProcessKey(jobRef, "completed-second");
+    var firstProcess = manager.startProcess(firstKey, List.of("true"), tempDir);
+    var secondProcess = manager.startProcess(secondKey, List.of("true"), tempDir);
+    firstProcess.waitFor();
+    secondProcess.waitFor();
+    assertThat(manager.observe(firstKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+    assertThat(manager.observe(secondKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+
+    var released = manager.releaseJobObservation(jobRef);
+
+    assertThat(released).isTrue();
+    assertThat(manager.observe(firstKey).state()).isEqualTo(FfmpegProcessState.ABSENT);
+    assertThat(manager.observe(secondKey).state()).isEqualTo(FfmpegProcessState.ABSENT);
+  }
+
+  @Test
+  @DisplayName("Should refuse observation release while any exact job process is running")
+  void shouldRefuseObservationReleaseWhileAnyExactJobProcessIsRunning() throws Exception {
+    var jobRef = jobRef(UUID.randomUUID());
+    var completedKey = new FfmpegProcessKey(jobRef, "completed");
+    var runningKey = new FfmpegProcessKey(jobRef, "running");
+    var completed = manager.startProcess(completedKey, List.of("true"), tempDir);
+    completed.waitFor();
+    assertThat(manager.observe(completedKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+    manager.startProcess(runningKey, List.of("bash", "-c", "read -r -n 1"), tempDir);
+
+    try {
+      var released = manager.releaseJobObservation(jobRef);
+
+      assertThat(released).isFalse();
+      assertThat(manager.observe(completedKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+      assertThat(manager.observe(runningKey).state()).isEqualTo(FfmpegProcessState.RUNNING);
+    } finally {
+      manager.stopJob(jobRef);
+    }
+  }
+
+  @Test
+  @DisplayName("Should not release a newer generation through a stale job reference")
+  void shouldNotReleaseANewerGenerationThroughAStaleJobReference() throws Exception {
+    var jobId = UUID.randomUUID();
+    var firstJob = new TranscodeJobRef(jobId, 1L);
+    var secondJob = new TranscodeJobRef(jobId, 2L);
+    var firstKey = new FfmpegProcessKey(firstJob, "720p");
+    var secondKey = new FfmpegProcessKey(secondJob, "720p");
+    var firstProcess = manager.startProcess(firstKey, List.of("true"), tempDir);
+    var secondProcess = manager.startProcess(secondKey, List.of("true"), tempDir);
+    firstProcess.waitFor();
+    secondProcess.waitFor();
+    assertThat(manager.observe(firstKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+    assertThat(manager.observe(secondKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+
+    assertThat(manager.releaseJobObservation(firstJob)).isTrue();
+
+    assertThat(manager.observe(firstKey).state()).isEqualTo(FfmpegProcessState.ABSENT);
+    assertThat(manager.observe(secondKey).state()).isEqualTo(FfmpegProcessState.COMPLETED);
+  }
+
+  @Test
+  @DisplayName("Should release an already absent job observation idempotently")
+  void shouldReleaseAnAlreadyAbsentJobObservationIdempotently() {
+    var jobRef = jobRef(UUID.randomUUID());
+
+    assertThat(manager.releaseJobObservation(jobRef)).isTrue();
+    assertThat(manager.releaseJobObservation(jobRef)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should release a terminal process before it has been observed")
+  void shouldReleaseATerminalProcessBeforeItHasBeenObserved() throws Exception {
+    var jobRef = jobRef(UUID.randomUUID());
+    var key = new FfmpegProcessKey(jobRef, "completed");
+    var process = manager.startProcess(key, List.of("true"), tempDir);
+    process.waitFor();
+
+    assertThat(manager.releaseJobObservation(jobRef)).isTrue();
+
+    assertThat(manager.observe(key).state()).isEqualTo(FfmpegProcessState.ABSENT);
+  }
+
+  @Test
   @DisplayName("Should retain a failed process with its nonzero exit code")
   void shouldRetainAFailedProcessWithItsNonzeroExitCode() throws Exception {
     var key = processKey(UUID.randomUUID(), "failed");

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManagerTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/ffmpeg/LocalFfmpegProcessManagerTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import com.streamarr.transcode.engine.error.TranscodeException;
-import com.streamarr.transcode.engine.model.TranscodeRequest;
+import com.streamarr.transcode.engine.model.RenditionRequest;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -32,7 +32,7 @@ class LocalFfmpegProcessManagerTest {
 
     var process =
         manager.startProcess(
-            sessionId, TranscodeRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
+            sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
 
     assertThat(process).isNotNull();
     assertThat(process.isAlive()).isTrue();
@@ -47,7 +47,7 @@ class LocalFfmpegProcessManagerTest {
     var sessionId = UUID.randomUUID();
 
     manager.startProcess(
-        sessionId, TranscodeRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
+        sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
 
     manager.stopProcess(sessionId);
 
@@ -67,7 +67,7 @@ class LocalFfmpegProcessManagerTest {
 
     var process =
         manager.startProcess(
-            sessionId, TranscodeRequest.DEFAULT_VARIANT, List.of("echo", "done"), tempDir);
+            sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("echo", "done"), tempDir);
     process.waitFor();
 
     await().pollDelay(Duration.ofMillis(100)).until(() -> true);
@@ -104,7 +104,7 @@ class LocalFfmpegProcessManagerTest {
   @DisplayName("Should reject duplicate variant without replacing its running process")
   void shouldRejectDuplicateVariantWithoutReplacingItsRunningProcess() {
     var sessionId = UUID.randomUUID();
-    var variant = TranscodeRequest.DEFAULT_VARIANT;
+    var variant = RenditionRequest.DEFAULT_VARIANT;
     var command = List.of("sleep", "30");
     var first = manager.startProcess(sessionId, variant, command, tempDir);
 
@@ -142,10 +142,10 @@ class LocalFfmpegProcessManagerTest {
     var secondSessionId = UUID.randomUUID();
     var first =
         manager.startProcess(
-            firstSessionId, TranscodeRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
+            firstSessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
     var second =
         manager.startProcess(
-            secondSessionId, TranscodeRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
+            secondSessionId, RenditionRequest.DEFAULT_VARIANT, List.of("sleep", "30"), tempDir);
 
     try {
       manager.forceStopAll();
@@ -283,7 +283,7 @@ class LocalFfmpegProcessManagerTest {
 
     var process =
         manager.startProcess(
-            sessionId, TranscodeRequest.DEFAULT_VARIANT, List.of("bash", "-c", script), tempDir);
+            sessionId, RenditionRequest.DEFAULT_VARIANT, List.of("bash", "-c", script), tempDir);
 
     await()
         .atMost(Duration.ofSeconds(10))
@@ -304,7 +304,7 @@ class LocalFfmpegProcessManagerTest {
     var process =
         manager.startProcess(
             sessionId,
-            TranscodeRequest.DEFAULT_VARIANT,
+            RenditionRequest.DEFAULT_VARIANT,
             List.of("bash", "-c", "echo 'error output' >&2; exit 1"),
             tempDir);
     process.waitFor();

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/job/LocalTranscodeEngineTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/job/LocalTranscodeEngineTest.java
@@ -543,6 +543,7 @@ class LocalTranscodeEngineTest {
     engine.start(nextJob, source);
 
     assertThat(engine.releaseObservation(original.jobRef())).isTrue();
+    assertThat(engine.releaseObservation(failedReplacement.jobRef())).isTrue();
   }
 
   @Test
@@ -609,6 +610,79 @@ class LocalTranscodeEngineTest {
     engine.shutdown();
 
     assertThat(segmentStorage.segmentExists(original.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should withdraw fallback when the current failed generation is stopped")
+  void shouldWithdrawFallbackWhenCurrentFailedGenerationIsStopped() throws IOException {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 1));
+    var failedTemplate = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var failedReplacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(jobId, 2),
+            original.source(),
+            original.decision(),
+            failedTemplate.execution(),
+            original.renditions());
+    var newest = withJobRef(original, new TranscodeJobRef(jobId, 3));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (!key.jobRef().equals(failedReplacement.jobRef())) {
+            writeStartupArtifacts(
+                outputDirectory, "generation-" + key.jobRef().generation(), ".ts");
+          }
+        });
+    engine.start(original, source);
+    assertThatThrownBy(() -> engine.start(failedReplacement, source))
+        .isInstanceOf(TranscodeException.class);
+
+    assertThat(engine.stop(failedReplacement.jobRef()).state())
+        .isEqualTo(TranscodeJobState.STOPPED);
+
+    assertThat(segmentStorage.segmentExists(original.sessionId(), "segment0.ts")).isFalse();
+    engine.start(newest, source);
+    assertThat(engine.stop(original.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+        .isEqualTo("generation-3".getBytes());
+    assertThat(engine.releaseObservation(original.jobRef())).isTrue();
+    assertThat(engine.releaseObservation(failedReplacement.jobRef())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should retain current stop authority while a fallback remains published")
+  void shouldRetainCurrentStopAuthorityWhileFallbackRemainsPublished() throws IOException {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 1));
+    var failedTemplate = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var failedReplacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(jobId, 2),
+            original.source(),
+            original.decision(),
+            failedTemplate.execution(),
+            original.renditions());
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (key.jobRef().equals(original.jobRef())) {
+            writeStartupArtifacts(outputDirectory, "fallback", ".ts");
+          }
+        });
+    engine.start(original, source);
+    assertThatThrownBy(() -> engine.start(failedReplacement, source))
+        .isInstanceOf(TranscodeException.class);
+
+    var released = engine.releaseObservation(failedReplacement.jobRef());
+    var stopState = engine.stop(failedReplacement.jobRef()).state();
+    var fallbackVisible = segmentStorage.segmentExists(original.sessionId(), "segment0.ts");
+
+    assertThat(released + ":" + stopState + ":" + fallbackVisible).isEqualTo("false:STOPPED:false");
   }
 
   @Test

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/job/LocalTranscodeEngineTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/job/LocalTranscodeEngineTest.java
@@ -1,0 +1,1486 @@
+package com.streamarr.transcode.engine.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.transcode.engine.error.TranscodeException;
+import com.streamarr.transcode.engine.fakes.FakeFfmpegProcessManager;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
+import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessState;
+import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
+import com.streamarr.transcode.engine.model.AudioDecision;
+import com.streamarr.transcode.engine.model.ContainerFormat;
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import com.streamarr.transcode.engine.model.RenditionObservation;
+import com.streamarr.transcode.engine.model.RenditionSpec;
+import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.SubtitleDecision;
+import com.streamarr.transcode.engine.model.SubtitleMode;
+import com.streamarr.transcode.engine.model.TranscodeDecision;
+import com.streamarr.transcode.engine.model.TranscodeExecutionParameters;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import com.streamarr.transcode.engine.model.TranscodeJobSpec;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
+import com.streamarr.transcode.engine.model.TranscodeMode;
+import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
+import com.streamarr.transcode.engine.segment.SegmentGeneration;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Tag("UnitTest")
+@DisplayName("Local Transcode Engine Tests")
+class LocalTranscodeEngineTest {
+
+  @TempDir Path tempDir;
+
+  private FakeFfmpegProcessManager processManager;
+  private LocalSegmentStorage segmentStorage;
+  private LocalTranscodeEngine engine;
+
+  @BeforeEach
+  void setUp() {
+    processManager = new FakeFfmpegProcessManager();
+    segmentStorage = new LocalSegmentStorage(tempDir.resolve("segments"));
+    var capabilities =
+        new TranscodeCapabilityService(
+            "ffmpeg",
+            _ -> {
+              throw new UnsupportedOperationException();
+            });
+    engine =
+        LocalTranscodeEngine.builder()
+            .commandBuilder(new FfmpegCommandBuilder("ffmpeg"))
+            .processManager(processManager)
+            .segmentStorage(segmentStorage)
+            .capabilityService(capabilities)
+            .build();
+  }
+
+  @Test
+  @DisplayName("Should publish a complete single-rendition job after startup artifacts are ready")
+  void shouldPublishCompleteSingleRenditionJobAfterStartupArtifactsAreReady() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> {
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n");
+          Files.writeString(outputDirectory.resolve("segment0.ts"), "segment-zero");
+        });
+
+    var observation = engine.start(specification, source);
+
+    assertThat(observation.jobRef()).isEqualTo(specification.jobRef());
+    assertThat(observation.state()).isEqualTo(TranscodeJobState.RUNNING);
+    assertThat(observation.renditions())
+        .extracting(RenditionObservation::state)
+        .containsExactly(RenditionState.RUNNING);
+    assertThat(processManager.startedKeys())
+        .containsExactly(new FfmpegProcessKey(specification.jobRef(), "default"));
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "segment0.ts"))
+        .isEqualTo("segment-zero".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should expose every rendition atomically when the complete ladder is ready")
+  void shouldExposeEveryRenditionAtomicallyWhenCompleteLadderIsReady() throws IOException {
+    var lowRendition = rendition("480p", 854, 480, 1_500_000L);
+    var highRendition = rendition("1080p", 1920, 1080, 5_000_000L);
+    var specification = jobSpecification(List.of(lowRendition, highRendition));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          writeStartupArtifacts(outputDirectory, "segment-" + key.renditionLabel(), ".ts");
+          if (key.renditionLabel().equals("480p")) {
+            assertThat(segmentStorage.segmentExists(specification.sessionId(), "480p/segment0.ts"))
+                .isFalse();
+          }
+        });
+
+    var observation = engine.start(specification, source);
+
+    assertThat(observation.renditions())
+        .extracting(RenditionObservation::state)
+        .containsExactly(RenditionState.RUNNING, RenditionState.RUNNING);
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "480p/segment0.ts"))
+        .isEqualTo("segment-480p".getBytes());
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "1080p/segment0.ts"))
+        .isEqualTo("segment-1080p".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should publish a single named rendition under its variant directory")
+  void shouldPublishSingleNamedRenditionUnderVariantDirectory() throws IOException {
+    var specification = jobSpecification(List.of(rendition("720p", 1280, 720, 2_500_000L)));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "named-segment", ".ts"));
+
+    engine.start(specification, source);
+
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "720p/segment0.ts"))
+        .isEqualTo("named-segment".getBytes());
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should fail the complete job immediately when a rendition process exits nonzero")
+  void shouldFailCompleteJobImmediatelyWhenRenditionProcessExitsNonzero() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(100));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart((key, _) -> processManager.failProcess(key, 23));
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessageContaining("failed");
+
+    assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject a rendition that fails immediately before publication")
+  void shouldRejectRenditionThatFailsImmediatelyBeforePublication() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var observations = new AtomicInteger();
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    processManager.onObserve(
+        key -> {
+          if (observations.incrementAndGet() == 2) {
+            processManager.failProcess(key, 23);
+          }
+        });
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.STARTUP_FAILED));
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should stop the complete job and discard staging when startup times out")
+  void shouldStopCompleteJobAndDiscardStagingWhenStartupTimesOut() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var generationRoot = new AtomicReference<Path>();
+    processManager.onStart((_, outputDirectory) -> generationRoot.set(outputDirectory));
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessageContaining("timed out");
+
+    assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+    assertThat(generationRoot.get()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should compensate an already-started rendition when a later spawn fails")
+  void shouldCompensateAlreadyStartedRenditionWhenLaterSpawnFails() throws IOException {
+    var low = rendition("480p", 854, 480, 1_500_000L);
+    var high = rendition("1080p", 1920, 1080, 5_000_000L);
+    var specification = jobSpecification(List.of(low, high));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var generationRoot = new AtomicReference<Path>();
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (key.renditionLabel().equals("1080p")) {
+            throw new TranscodeException("spawn failed");
+          }
+          generationRoot.set(outputDirectory.getParent());
+        });
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessage("spawn failed");
+
+    var firstKey = new FfmpegProcessKey(specification.jobRef(), "480p");
+    assertThat(processManager.observe(firstKey).state()).isEqualTo(FfmpegProcessState.STOPPED);
+    assertThat(generationRoot.get()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should compensate the complete job and preserve interruption during startup")
+  void shouldCompensateCompleteJobAndPreserveInterruptionDuringStartup() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var generationRoot = new AtomicReference<Path>();
+    processManager.onStart((_, outputDirectory) -> generationRoot.set(outputDirectory));
+
+    try {
+      Thread.currentThread().interrupt();
+
+      assertThatThrownBy(() -> engine.start(specification, source))
+          .isInstanceOf(TranscodeException.class)
+          .hasMessageContaining("interrupted");
+
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+      assertThat(generationRoot.get()).doesNotExist();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("Should inspect a running complete job by its exact generation")
+  void shouldInspectRunningCompleteJobByExactGeneration() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    var started = engine.start(specification, source);
+
+    var inspected = engine.inspect(specification.jobRef());
+
+    assertThat(inspected).isEqualTo(started);
+  }
+
+  @Test
+  @DisplayName("Should join an in-flight duplicate start for the same exact job")
+  void shouldJoinInFlightDuplicateStartForSameExactJob() throws Exception {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var processStarted = new CountDownLatch(1);
+    var allowReadiness = new CountDownLatch(1);
+    processManager.onStart(
+        (_, outputDirectory) -> {
+          processStarted.countDown();
+          await(allowReadiness);
+          writeStartupArtifacts(outputDirectory, "segment", ".ts");
+        });
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var original = executor.submit(() -> engine.start(specification, source));
+      assertThat(processStarted.await(1, TimeUnit.SECONDS)).isTrue();
+      var duplicate = executor.submit(() -> engine.start(specification, source));
+      allowReadiness.countDown();
+
+      assertThat(duplicate.get(2, TimeUnit.SECONDS)).isEqualTo(original.get(2, TimeUnit.SECONDS));
+    }
+    assertThat(processManager.startedKeys())
+        .containsExactly(new FfmpegProcessKey(specification.jobRef(), "default"));
+  }
+
+  @Test
+  @DisplayName("Should check segment readiness without loading segment contents")
+  void shouldCheckSegmentReadinessWithoutLoadingSegmentContents() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> {
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U");
+          try (var segment =
+              Files.newByteChannel(
+                  outputDirectory.resolve("segment0.ts"),
+                  StandardOpenOption.CREATE_NEW,
+                  StandardOpenOption.WRITE)) {
+            segment.position((long) Integer.MAX_VALUE);
+            segment.write(ByteBuffer.wrap(new byte[] {1}));
+          }
+        });
+
+    var observation = engine.start(specification, source);
+
+    assertThat(observation.state()).isEqualTo(TranscodeJobState.RUNNING);
+  }
+
+  @Test
+  @DisplayName("Should reject conflicting content for an existing exact job")
+  void shouldRejectConflictingContentForExistingExactJob() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var conflicting =
+        new TranscodeJobSpec(
+            specification.sessionId(),
+            specification.jobRef(),
+            specification.source(),
+            specification.decision(),
+            specification.execution(),
+            List.of(rendition("default", 1280, 720, 2_500_000L)));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+
+    assertThatThrownBy(() -> engine.start(conflicting, source))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessageContaining("conflicts");
+
+    assertThat(processManager.startedKeys()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("Should reject a lower generation after a newer generation is admitted")
+  void shouldRejectLowerGenerationAfterNewerGenerationIsAdmitted() throws IOException {
+    var jobId = UUID.randomUUID();
+    var template = jobSpecification(List.of(defaultRendition()));
+    var newer = withJobRef(template, new TranscodeJobRef(jobId, 2));
+    var older = withJobRef(template, new TranscodeJobRef(jobId, 1));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(newer, source);
+
+    assertThatThrownBy(() -> engine.start(older, source))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessageContaining("stale");
+
+    assertThat(processManager.startedKeys())
+        .containsExactly(new FfmpegProcessKey(newer.jobRef(), "default"));
+  }
+
+  @Test
+  @DisplayName("Should reject a different job that conflicts for the same session")
+  void shouldRejectDifferentJobThatConflictsForSameSession() throws IOException {
+    var first = jobSpecification(List.of(defaultRendition()));
+    var conflicting = withJobRef(first, new TranscodeJobRef(UUID.randomUUID(), 1));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(first, source);
+
+    assertThatThrownBy(() -> engine.start(conflicting, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.SESSION_CONFLICT));
+
+    assertThat(processManager.startedKeys()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("Should keep one job identity bound to its original session")
+  void shouldKeepOneJobIdentityBoundToItsOriginalSession() throws IOException {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 1));
+    var differentSession =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 2));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(original, source);
+
+    assertThatThrownBy(() -> engine.start(differentSession, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.JOB_CONFLICT));
+    assertThat(processManager.startedKeys()).hasSize(1);
+    engine.stop(original.jobRef());
+    engine.releaseObservation(original.jobRef());
+
+    assertThatThrownBy(() -> engine.start(differentSession, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.JOB_CONFLICT));
+  }
+
+  @Test
+  @DisplayName("Should fence the old process before starting a replacement generation")
+  void shouldFenceOldProcessBeforeStartingReplacementGeneration() throws IOException {
+    var jobId = UUID.randomUUID();
+    var template = jobSpecification(List.of(defaultRendition()));
+    var original = withJobRef(template, new TranscodeJobRef(jobId, 1));
+    var replacement = withJobRef(template, new TranscodeJobRef(jobId, 2));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var originalKey = new FfmpegProcessKey(original.jobRef(), "default");
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (key.jobRef().equals(replacement.jobRef())) {
+            assertThat(processManager.observe(originalKey).state())
+                .isEqualTo(FfmpegProcessState.STOPPED);
+          }
+          writeStartupArtifacts(outputDirectory, "generation-" + key.jobRef().generation(), ".ts");
+        });
+    engine.start(original, source);
+
+    engine.start(replacement, source);
+
+    assertThat(processManager.observe(originalKey).state()).isEqualTo(FfmpegProcessState.STOPPED);
+    assertThat(segmentStorage.readSegment(replacement.sessionId(), "segment0.ts"))
+        .isEqualTo("generation-2".getBytes());
+  }
+
+  @Test
+  @DisplayName(
+      "Should preserve fallback segments when a delayed old stop arrives during replacement")
+  void shouldPreserveFallbackSegmentsWhenDelayedOldStopArrivesDuringReplacement() throws Exception {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 1));
+    var execution = original.execution();
+    var replacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(jobId, 2),
+            original.source(),
+            original.decision(),
+            new TranscodeExecutionParameters(
+                execution.seekPosition(),
+                execution.segmentDuration(),
+                execution.framerate(),
+                1,
+                execution.startupTimeout()),
+            original.renditions());
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var replacementSpawned = new CountDownLatch(1);
+    var allowReplacement = new CountDownLatch(1);
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (key.jobRef().equals(original.jobRef())) {
+            writeStartupArtifacts(outputDirectory, "original-zero", ".ts");
+            return;
+          }
+          replacementSpawned.countDown();
+          await(allowReplacement);
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n");
+          Files.writeString(outputDirectory.resolve("segment1.ts"), "replacement-one");
+        });
+    engine.start(original, source);
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var replacing = executor.submit(() -> engine.start(replacement, source));
+      assertThat(replacementSpawned.await(1, TimeUnit.SECONDS)).isTrue();
+      try {
+        engine.stop(original.jobRef());
+
+        assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+            .isEqualTo("original-zero".getBytes());
+      } finally {
+        allowReplacement.countDown();
+      }
+      assertThat(replacing.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.RUNNING);
+    }
+    assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+        .isEqualTo("original-zero".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should release a superseded generation after its replacement is published")
+  void shouldReleaseSupersededGenerationAfterReplacementIsPublished() throws IOException {
+    var jobId = UUID.randomUUID();
+    var template = jobSpecification(List.of(defaultRendition()));
+    var original = withJobRef(template, new TranscodeJobRef(jobId, 1));
+    var replacement = withJobRef(template, new TranscodeJobRef(jobId, 2));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) ->
+            writeStartupArtifacts(
+                outputDirectory, "generation-" + key.jobRef().generation(), ".ts"));
+    engine.start(original, source);
+    engine.start(replacement, source);
+
+    assertThat(engine.inspect(original.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(engine.releaseObservation(original.jobRef())).isTrue();
+    assertThat(engine.inspect(original.jobRef()).state()).isEqualTo(TranscodeJobState.ABSENT);
+    assertThat(segmentStorage.readSegment(replacement.sessionId(), "segment0.ts"))
+        .isEqualTo("generation-2".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should release stopped fallback after a different job publishes for the session")
+  void shouldReleaseStoppedFallbackAfterDifferentJobPublishesForSession() throws IOException {
+    var original = jobSpecification(List.of(defaultRendition()));
+    var failedReplacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(original.jobRef().jobId(), 2),
+            original.source(),
+            original.decision(),
+            jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50)).execution(),
+            original.renditions());
+    var nextJob =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(UUID.randomUUID(), 1),
+            original.source(),
+            original.decision(),
+            original.execution(),
+            original.renditions());
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (!key.jobRef().equals(failedReplacement.jobRef())) {
+            writeStartupArtifacts(outputDirectory, key.jobRef().jobId().toString(), ".ts");
+          }
+        });
+    engine.start(original, source);
+    assertThatThrownBy(() -> engine.start(failedReplacement, source))
+        .isInstanceOf(TranscodeException.class);
+    engine.stop(failedReplacement.jobRef());
+
+    engine.start(nextJob, source);
+
+    assertThat(engine.releaseObservation(original.jobRef())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should report cleanup pending when a superseded process cannot be stopped")
+  void shouldReportCleanupPendingWhenSupersededProcessCannotBeStopped() throws IOException {
+    var jobId = UUID.randomUUID();
+    var template = jobSpecification(List.of(defaultRendition()));
+    var original = withJobRef(template, new TranscodeJobRef(jobId, 1));
+    var replacement = withJobRef(template, new TranscodeJobRef(jobId, 2));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "original", ".ts"));
+    engine.start(original, source);
+    processManager.failNextStop(new TranscodeException("stop failed"));
+
+    assertThatThrownBy(() -> engine.start(replacement, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+    assertThat(processManager.isRunning(original.jobRef())).isTrue();
+    assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+        .isEqualTo("original".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should preserve the prior published generation when replacement startup fails")
+  void shouldPreservePriorPublishedGenerationWhenReplacementStartupFails() throws IOException {
+    var jobId = UUID.randomUUID();
+    var template = jobSpecification(List.of(defaultRendition()));
+    var original = withJobRef(template, new TranscodeJobRef(jobId, 1));
+    var replacement =
+        withJobRef(
+            jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50)),
+            new TranscodeJobRef(jobId, 2));
+    replacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            replacement.jobRef(),
+            original.source(),
+            original.decision(),
+            replacement.execution(),
+            original.renditions());
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (key.jobRef().equals(original.jobRef())) {
+            writeStartupArtifacts(outputDirectory, "original", ".ts");
+          }
+        });
+    engine.start(original, source);
+
+    var failedReplacement = replacement;
+    assertThatThrownBy(() -> engine.start(failedReplacement, source))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessageContaining("timed out");
+
+    assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+        .isEqualTo("original".getBytes());
+
+    assertThat(engine.stop(original.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(segmentStorage.segmentExists(original.sessionId(), "segment0.ts")).isTrue();
+    engine.shutdown();
+
+    assertThat(segmentStorage.segmentExists(original.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should preserve fallback when supersession is admitted during failure cleanup")
+  void shouldPreserveFallbackWhenSupersessionIsAdmittedDuringFailureCleanup() throws Exception {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 1));
+    var replacementTemplate = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var replacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(jobId, 2),
+            original.source(),
+            original.decision(),
+            replacementTemplate.execution(),
+            original.renditions());
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          if (key.jobRef().equals(original.jobRef())) {
+            writeStartupArtifacts(outputDirectory, "original", ".ts");
+          }
+        });
+    engine.start(original, source);
+    processManager.failProcess(
+        new FfmpegProcessKey(original.jobRef(), defaultRendition().label()), 42);
+    var failureStopEntered = new CountDownLatch(1);
+    var releaseFailureStop = new CountDownLatch(1);
+    var stopCalls = new AtomicInteger();
+    processManager.onStop(
+        () -> {
+          if (stopCalls.incrementAndGet() == 1) {
+            failureStopEntered.countDown();
+            await(releaseFailureStop);
+          }
+        });
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var inspection = executor.submit(() -> engine.inspect(original.jobRef()));
+      assertThat(failureStopEntered.await(1, TimeUnit.SECONDS)).isTrue();
+      var replacementStart = executor.submit(() -> engine.start(replacement, source));
+      assertThat(awaitState(replacement.jobRef(), TranscodeJobState.ADMITTING)).isTrue();
+      releaseFailureStop.countDown();
+
+      inspection.get(2, TimeUnit.SECONDS);
+      assertThatThrownBy(() -> replacementStart.get(2, TimeUnit.SECONDS))
+          .hasCauseInstanceOf(TranscodeException.class);
+    }
+
+    assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+        .isEqualTo("original".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should discard retained unpublished staging before starting a newer generation")
+  void shouldDiscardRetainedUnpublishedStagingBeforeStartingNewerGeneration() throws IOException {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(
+            jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50)),
+            new TranscodeJobRef(jobId, 1));
+    var replacement = withJobRef(original, new TranscodeJobRef(jobId, 2));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var originalStaging = new AtomicReference<Path>();
+    processManager.onStart((_, outputDirectory) -> originalStaging.set(outputDirectory));
+    processManager.failNextStop(new TranscodeException("cleanup failed"));
+    assertThatThrownBy(() -> engine.start(original, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "replacement", ".ts"));
+
+    engine.start(replacement, source);
+
+    assertThat(originalStaging.get()).doesNotExist();
+    assertThat(segmentStorage.readSegment(replacement.sessionId(), "segment0.ts"))
+        .isEqualTo("replacement".getBytes());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(value = SubtitleMode.class, names = "EXCLUDE", mode = EnumSource.Mode.EXCLUDE)
+  @DisplayName("Should reject an unsupported subtitle mode before starting any process")
+  void shouldRejectUnsupportedSubtitleModeBeforeStartingAnyProcess(SubtitleMode subtitleMode)
+      throws IOException {
+    var template = jobSpecification(List.of(defaultRendition()));
+    var decision = template.decision();
+    var unsupportedSubtitle =
+        new SubtitleDecision(
+            subtitleMode, Optional.of("ass"), OptionalInt.of(0), Optional.of("eng"));
+    var unsupportedDecision =
+        new TranscodeDecision(
+            decision.transcodeMode(),
+            decision.videoCodecFamily(),
+            decision.audioDecision(),
+            unsupportedSubtitle,
+            decision.containerFormat(),
+            decision.needsKeyframeAlignment());
+    var specification = withDecision(template, unsupportedDecision);
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.INVALID_SPECIFICATION));
+
+    assertThat(processManager.startedKeys()).isEmpty();
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(
+      value = TranscodeMode.class,
+      names = {"REMUX", "AUDIO_TRANSCODE"})
+  @DisplayName("Should use the copy video path without probing an encoder")
+  void shouldUseCopyVideoPathWithoutProbingEncoder(TranscodeMode mode) throws IOException {
+    var specification = withMode(jobSpecification(List.of(defaultRendition())), mode);
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+
+    var observation = engine.start(specification, source);
+
+    assertThat(observation.state()).isEqualTo(TranscodeJobState.RUNNING);
+    assertThat(processManager.startedKeys())
+        .containsExactly(new FfmpegProcessKey(specification.jobRef(), "default"));
+  }
+
+  @Test
+  @DisplayName("Should reject a completed rendition whose playlist has no end marker")
+  void shouldRejectCompletedRenditionWhosePlaylistHasNoEndMarker() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          writeStartupArtifacts(outputDirectory, "segment", ".ts");
+          processManager.completeProcess(key);
+        });
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.STARTUP_FAILED));
+
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should fail and withdraw a job when completed playlist inspection fails")
+  void shouldFailAndWithdrawJobWhenCompletedPlaylistInspectionFails() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var outputDirectory = new AtomicReference<Path>();
+    processManager.onStart(
+        (_, output) -> {
+          outputDirectory.set(output);
+          writeStartupArtifacts(output, "segment", ".ts");
+        });
+    engine.start(specification, source);
+    Files.write(outputDirectory.get().resolve("stream.m3u8"), new byte[1_048_577]);
+    processManager.completeProcess(new FfmpegProcessKey(specification.jobRef(), "default"));
+
+    var failed = engine.inspect(specification.jobRef());
+
+    assertThat(failed.state()).isEqualTo(TranscodeJobState.FAILED);
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should publish a cleanly completed job only when every playlist has an end marker")
+  void shouldPublishCleanlyCompletedJobOnlyWhenEveryPlaylistHasEndMarker() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n#EXT-X-ENDLIST\n");
+          Files.writeString(outputDirectory.resolve("segment0.ts"), "segment");
+          processManager.completeProcess(key);
+        });
+
+    var observation = engine.start(specification, source);
+
+    assertThat(observation.state()).isEqualTo(TranscodeJobState.COMPLETED);
+    assertThat(observation.renditions())
+        .extracting(RenditionObservation::state)
+        .containsExactly(RenditionState.COMPLETED);
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "segment0.ts"))
+        .isEqualTo("segment".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should stop a complete job exactly and make repeated stop idempotent")
+  void shouldStopCompleteJobExactlyAndMakeRepeatedStopIdempotent() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+
+    var stopped = engine.stop(specification.jobRef());
+    var repeated = engine.stop(specification.jobRef());
+
+    assertThat(stopped.state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(stopped.renditions())
+        .extracting(RenditionObservation::state)
+        .containsExactly(RenditionState.STOPPED);
+    assertThat(repeated).isEqualTo(stopped);
+    assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should treat stop and release for an unknown exact job as already complete")
+  void shouldTreatStopAndReleaseForUnknownExactJobAsAlreadyComplete() {
+    var unknown = new TranscodeJobRef(UUID.randomUUID(), 1);
+
+    assertThat(engine.stop(unknown).state()).isEqualTo(TranscodeJobState.ABSENT);
+    assertThat(engine.releaseObservation(unknown)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should retain a published job when stop cleanup fails and complete on retry")
+  void shouldRetainPublishedJobWhenStopCleanupFailsAndCompleteOnRetry() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    processManager.failNextStop(new TranscodeException("stop failed"));
+
+    assertThatThrownBy(() -> engine.stop(specification.jobRef()))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "segment0.ts"))
+        .isEqualTo("segment".getBytes());
+    assertThat(engine.releaseObservation(specification.jobRef())).isFalse();
+
+    assertThat(engine.stop(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+    assertThat(engine.releaseObservation(specification.jobRef())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should fail and withdraw the whole job when one running rendition fails")
+  void shouldFailAndWithdrawWholeJobWhenOneRunningRenditionFails() throws IOException {
+    var specification =
+        jobSpecification(
+            List.of(
+                rendition("480p", 854, 480, 1_500_000L),
+                rendition("1080p", 1920, 1080, 5_000_000L)));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) ->
+            writeStartupArtifacts(outputDirectory, key.renditionLabel(), ".ts"));
+    engine.start(specification, source);
+    processManager.failProcess(new FfmpegProcessKey(specification.jobRef(), "1080p"), 42);
+
+    var failed = engine.inspect(specification.jobRef());
+
+    assertThat(failed.state()).isEqualTo(TranscodeJobState.FAILED);
+    assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "480p/segment0.ts"))
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("Should retain a failed publication when inspection cleanup fails and retry")
+  void shouldRetainFailedPublicationWhenInspectionCleanupFailsAndRetry() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var key = new FfmpegProcessKey(specification.jobRef(), "default");
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    processManager.failProcess(key, 42);
+    processManager.failNextStop(new TranscodeException("failure cleanup failed"));
+
+    assertThatThrownBy(() -> engine.inspect(specification.jobRef()))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "segment0.ts"))
+        .isEqualTo("segment".getBytes());
+    assertThat(engine.releaseObservation(specification.jobRef())).isFalse();
+
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.FAILED);
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+    assertThat(engine.releaseObservation(specification.jobRef())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should preserve stopped state when failure inspection races explicit stop")
+  void shouldPreserveStoppedStateWhenFailureInspectionRacesExplicitStop() throws Exception {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    processManager.failProcess(new FfmpegProcessKey(specification.jobRef(), "default"), 23);
+    var inspectStopEntered = new CountDownLatch(1);
+    var releaseInspect = new CountDownLatch(1);
+    var stopCalls = new AtomicInteger();
+    processManager.onStop(
+        () -> {
+          if (stopCalls.incrementAndGet() == 1) {
+            inspectStopEntered.countDown();
+            await(releaseInspect);
+          }
+        });
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var inspecting = executor.submit(() -> engine.inspect(specification.jobRef()));
+      assertThat(inspectStopEntered.await(1, TimeUnit.SECONDS)).isTrue();
+      var stopping = executor.submit(() -> engine.stop(specification.jobRef()));
+      assertThat(stopping.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+      releaseInspect.countDown();
+
+      assertThat(inspecting.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+    }
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+  }
+
+  @Test
+  @DisplayName("Should preserve stopped state when healthy inspection races explicit stop")
+  void shouldPreserveStoppedStateWhenHealthyInspectionRacesExplicitStop() throws Exception {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    var healthyObservationCaptured = new CountDownLatch(1);
+    var releaseInspection = new CountDownLatch(1);
+    var observations = new AtomicInteger();
+    processManager.afterObserve(
+        _ -> {
+          if (observations.incrementAndGet() == 2) {
+            healthyObservationCaptured.countDown();
+            await(releaseInspection);
+          }
+        });
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var inspecting = executor.submit(() -> engine.inspect(specification.jobRef()));
+      assertThat(healthyObservationCaptured.await(1, TimeUnit.SECONDS)).isTrue();
+      assertThat(engine.stop(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+      releaseInspection.countDown();
+
+      assertThat(inspecting.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+    }
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+  }
+
+  @Test
+  @DisplayName("Should preserve published fallback when stale inspection finishes after fencing")
+  void shouldPreservePublishedFallbackWhenStaleInspectionFinishesAfterFencing() throws Exception {
+    var jobId = UUID.randomUUID();
+    var original =
+        withJobRef(jobSpecification(List.of(defaultRendition())), new TranscodeJobRef(jobId, 1));
+    var replacementTemplate = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var replacement =
+        new TranscodeJobSpec(
+            original.sessionId(),
+            new TranscodeJobRef(jobId, 2),
+            original.source(),
+            original.decision(),
+            replacementTemplate.execution(),
+            original.renditions());
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "original", ".ts"));
+    engine.start(original, source);
+    var inspectionEntered = new CountDownLatch(1);
+    var releaseInspection = new CountDownLatch(1);
+    var replacementSpawned = new CountDownLatch(1);
+    var releaseReplacement = new CountDownLatch(1);
+    var blockInspection = new AtomicBoolean(true);
+    processManager.onObserve(
+        key -> {
+          if (key.jobRef().equals(original.jobRef()) && blockInspection.getAndSet(false)) {
+            inspectionEntered.countDown();
+            await(releaseInspection);
+          }
+        });
+    processManager.onStart(
+        (key, _) -> {
+          if (key.jobRef().equals(replacement.jobRef())) {
+            replacementSpawned.countDown();
+            await(releaseReplacement);
+          }
+        });
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var inspection = executor.submit(() -> engine.inspect(original.jobRef()));
+      assertThat(inspectionEntered.await(1, TimeUnit.SECONDS)).isTrue();
+      var replacementStart = executor.submit(() -> engine.start(replacement, source));
+      assertThat(replacementSpawned.await(1, TimeUnit.SECONDS)).isTrue();
+      releaseInspection.countDown();
+      assertThat(inspection.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+      releaseReplacement.countDown();
+      assertThatThrownBy(() -> replacementStart.get(2, TimeUnit.SECONDS))
+          .hasCauseInstanceOf(TranscodeException.class);
+    }
+
+    assertThat(segmentStorage.readSegment(original.sessionId(), "segment0.ts"))
+        .isEqualTo("original".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should release only terminal observations while retaining generation high-water")
+  void shouldReleaseOnlyTerminalObservationsWhileRetainingGenerationHighWater() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+
+    assertThat(engine.releaseObservation(specification.jobRef())).isFalse();
+    engine.stop(specification.jobRef());
+    assertThat(engine.releaseObservation(specification.jobRef())).isTrue();
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.ABSENT);
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.STALE_GENERATION));
+  }
+
+  @Test
+  @DisplayName("Should retain a terminal observation when process release is refused and retry")
+  void shouldRetainTerminalObservationWhenProcessReleaseIsRefusedAndRetry() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    engine.stop(specification.jobRef());
+    processManager.refuseNextRelease();
+
+    assertThat(engine.releaseObservation(specification.jobRef())).isFalse();
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(engine.releaseObservation(specification.jobRef())).isTrue();
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.ABSENT);
+  }
+
+  @Test
+  @DisplayName("Should stop every job and reject new admission after shutdown")
+  void shouldStopEveryJobAndRejectNewAdmissionAfterShutdown() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+
+    engine.shutdown();
+
+    assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.SHUTTING_DOWN));
+  }
+
+  @Test
+  @DisplayName("Should retain jobs when force-stop fails during shutdown and complete on retry")
+  void shouldRetainJobsWhenForceStopFailsDuringShutdownAndCompleteOnRetry() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    processManager.failNextForceStop(new TranscodeException("force-stop failed"));
+
+    assertThatThrownBy(engine::shutdown)
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+    assertThat(processManager.isRunning(specification.jobRef())).isTrue();
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "segment0.ts"))
+        .isEqualTo("segment".getBytes());
+
+    engine.shutdown();
+
+    assertThat(processManager.isRunning(specification.jobRef())).isFalse();
+    assertThat(engine.inspect(specification.jobRef()).state()).isEqualTo(TranscodeJobState.STOPPED);
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should retain a completed observation until its publication is withdrawn")
+  void shouldRetainCompletedObservationUntilPublicationIsWithdrawn() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (key, outputDirectory) -> {
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n#EXT-X-ENDLIST\n");
+          Files.writeString(outputDirectory.resolve("segment0.ts"), "segment");
+          processManager.completeProcess(key);
+        });
+    engine.start(specification, source);
+
+    assertThat(engine.releaseObservation(specification.jobRef())).isFalse();
+    assertThat(segmentStorage.segmentExists(specification.sessionId(), "segment0.ts")).isTrue();
+    engine.stop(specification.jobRef());
+    assertThat(engine.releaseObservation(specification.jobRef())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should retain and retry staged cleanup after startup compensation fails")
+  void shouldRetainAndRetryStagedCleanupAfterStartupCompensationFails() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var stagingDirectory = new AtomicReference<Path>();
+    processManager.onStart((_, outputDirectory) -> stagingDirectory.set(outputDirectory));
+    processManager.failNextStop(new TranscodeException("cleanup failed"));
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+    assertThat(engine.releaseObservation(specification.jobRef())).isFalse();
+
+    engine.stop(specification.jobRef());
+
+    assertThat(stagingDirectory.get()).doesNotExist();
+    assertThat(engine.releaseObservation(specification.jobRef())).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should make concurrent stops idempotent for retained staging")
+  void shouldMakeConcurrentStopsIdempotentForRetainedStaging() throws Exception {
+    var blockingStorage = new BlockingDiscardStorage(tempDir.resolve("blocking-segments"));
+    segmentStorage = blockingStorage;
+    engine =
+        LocalTranscodeEngine.builder()
+            .commandBuilder(new FfmpegCommandBuilder("ffmpeg"))
+            .processManager(processManager)
+            .segmentStorage(segmentStorage)
+            .capabilityService(
+                new TranscodeCapabilityService(
+                    "ffmpeg",
+                    _ -> {
+                      throw new UnsupportedOperationException();
+                    }))
+            .build();
+    var specification = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.failNextStop(new TranscodeException("cleanup failed"));
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOf(TranscodeEngineException.class);
+    blockingStorage.blockDiscards();
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var first = executor.submit(() -> engine.stop(specification.jobRef()));
+      var second = executor.submit(() -> engine.stop(specification.jobRef()));
+      try {
+        assertThat(blockingStorage.awaitBothDiscards()).isFalse();
+      } finally {
+        blockingStorage.releaseDiscards();
+      }
+
+      assertThat(first.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+      assertThat(second.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+    }
+  }
+
+  @Test
+  @DisplayName("Should discard retained staging when engine shuts down after cleanup failure")
+  void shouldDiscardRetainedStagingWhenEngineShutsDownAfterCleanupFailure() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var stagingDirectory = new AtomicReference<Path>();
+    processManager.onStart((_, outputDirectory) -> stagingDirectory.set(outputDirectory));
+    processManager.failNextStop(new TranscodeException("cleanup failed"));
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.CLEANUP_PENDING));
+
+    engine.shutdown();
+
+    assertThat(stagingDirectory.get()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should prevent late rendition spawn when stop races startup")
+  void shouldPreventLateRenditionSpawnWhenStopRacesStartup() throws Exception {
+    var specification =
+        jobSpecification(
+            List.of(
+                rendition("480p", 854, 480, 1_500_000L),
+                rendition("1080p", 1920, 1080, 5_000_000L)));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    var firstSpawned = new CountDownLatch(1);
+    var stopEntered = new CountDownLatch(1);
+    var releaseSpawn = new CountDownLatch(1);
+    processManager.onStop(stopEntered::countDown);
+    processManager.onStart(
+        (key, _) -> {
+          if (key.renditionLabel().equals("480p")) {
+            firstSpawned.countDown();
+            await(releaseSpawn);
+          }
+        });
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var starting = executor.submit(() -> engine.start(specification, source));
+      assertThat(firstSpawned.await(1, TimeUnit.SECONDS)).isTrue();
+      var stopping = executor.submit(() -> engine.stop(specification.jobRef()));
+      assertThat(stopEntered.await(1, TimeUnit.SECONDS)).isTrue();
+      releaseSpawn.countDown();
+
+      assertThat(stopping.get(2, TimeUnit.SECONDS).state()).isEqualTo(TranscodeJobState.STOPPED);
+      assertThatThrownBy(() -> starting.get(2, TimeUnit.SECONDS))
+          .hasCauseInstanceOf(TranscodeEngineException.class);
+    }
+    assertThat(processManager.startedKeys())
+        .containsExactly(new FfmpegProcessKey(specification.jobRef(), "480p"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(strings = {"stream.m3u8", "segment7.m4s", "init.mp4"})
+  @DisplayName("Should require every nonempty FMP4 startup artifact")
+  void shouldRequireEveryNonemptyFmp4StartupArtifact(String emptyArtifact) throws IOException {
+    var specification = fmp4Specification(Duration.ofMillis(50));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> {
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n");
+          Files.writeString(outputDirectory.resolve("segment7.m4s"), "segment-seven");
+          Files.writeString(outputDirectory.resolve("init.mp4"), "init");
+          Files.write(outputDirectory.resolve(emptyArtifact), new byte[0]);
+        });
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.STARTUP_FAILED));
+  }
+
+  @Test
+  @DisplayName("Should publish FMP4 after its init and first requested segment are ready")
+  void shouldPublishFmp4AfterInitAndFirstRequestedSegmentAreReady() throws IOException {
+    var specification = fmp4Specification(Duration.ofSeconds(1));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> {
+          Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n");
+          Files.writeString(outputDirectory.resolve("segment7.m4s"), "segment-seven");
+          Files.writeString(outputDirectory.resolve("init.mp4"), "init");
+        });
+
+    engine.start(specification, source);
+
+    assertThat(segmentStorage.readSegment(specification.sessionId(), "segment7.m4s"))
+        .isEqualTo("segment-seven".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should return the retained terminal result for a duplicate exact start")
+  void shouldReturnRetainedTerminalResultForDuplicateExactStart() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+    processManager.onStart(
+        (_, outputDirectory) -> writeStartupArtifacts(outputDirectory, "segment", ".ts"));
+    engine.start(specification, source);
+    var stopped = engine.stop(specification.jobRef());
+
+    var duplicate = engine.start(specification, source);
+
+    assertThat(duplicate).isEqualTo(stopped);
+    assertThat(processManager.startedKeys()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("Should repeat the original failure for a duplicate exact start")
+  void shouldRepeatOriginalFailureForDuplicateExactStart() throws IOException {
+    var specification = jobSpecification(List.of(defaultRendition()), Duration.ofMillis(50));
+    var source = Files.createFile(tempDir.resolve("movie.mkv"));
+
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.STARTUP_FAILED));
+    assertThatThrownBy(() -> engine.start(specification, source))
+        .isInstanceOfSatisfying(
+            TranscodeEngineException.class,
+            exception ->
+                assertThat(exception.reason())
+                    .isEqualTo(TranscodeEngineException.Reason.STARTUP_FAILED));
+    assertThat(processManager.startedKeys()).hasSize(1);
+  }
+
+  private static TranscodeJobSpec jobSpecification(List<RenditionSpec> renditions) {
+    return jobSpecification(renditions, Duration.ofSeconds(1));
+  }
+
+  private static TranscodeJobSpec jobSpecification(
+      List<RenditionSpec> renditions, Duration startupTimeout) {
+    return TranscodeJobSpec.builder()
+        .sessionId(UUID.randomUUID())
+        .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
+        .source(new MediaSourceRef(UUID.randomUUID(), "Movies/movie.mkv"))
+        .decision(
+            TranscodeDecision.builder()
+                .transcodeMode(TranscodeMode.FULL_TRANSCODE)
+                .videoCodecFamily("h264")
+                .audioDecision(AudioDecision.stereoAac())
+                .subtitleDecision(SubtitleDecision.exclude())
+                .containerFormat(ContainerFormat.MPEGTS)
+                .build())
+        .execution(
+            TranscodeExecutionParameters.builder()
+                .segmentDuration(6)
+                .framerate(23.976)
+                .startupTimeout(startupTimeout)
+                .build())
+        .renditions(renditions)
+        .build();
+  }
+
+  private static TranscodeJobSpec fmp4Specification(Duration startupTimeout) {
+    var template = jobSpecification(List.of(defaultRendition()), startupTimeout);
+    var decision = template.decision();
+    var execution = template.execution();
+    return new TranscodeJobSpec(
+        template.sessionId(),
+        template.jobRef(),
+        template.source(),
+        new TranscodeDecision(
+            decision.transcodeMode(),
+            decision.videoCodecFamily(),
+            decision.audioDecision(),
+            decision.subtitleDecision(),
+            ContainerFormat.FMP4,
+            decision.needsKeyframeAlignment()),
+        new TranscodeExecutionParameters(
+            execution.seekPosition(),
+            execution.segmentDuration(),
+            execution.framerate(),
+            7,
+            startupTimeout),
+        template.renditions());
+  }
+
+  private static RenditionSpec defaultRendition() {
+    return rendition("default", 1920, 1080, 5_000_000L);
+  }
+
+  private static TranscodeJobSpec withJobRef(
+      TranscodeJobSpec specification, TranscodeJobRef jobRef) {
+    return new TranscodeJobSpec(
+        specification.sessionId(),
+        jobRef,
+        specification.source(),
+        specification.decision(),
+        specification.execution(),
+        specification.renditions());
+  }
+
+  private static TranscodeJobSpec withDecision(
+      TranscodeJobSpec specification, TranscodeDecision decision) {
+    return new TranscodeJobSpec(
+        specification.sessionId(),
+        specification.jobRef(),
+        specification.source(),
+        decision,
+        specification.execution(),
+        specification.renditions());
+  }
+
+  private static TranscodeJobSpec withMode(TranscodeJobSpec specification, TranscodeMode mode) {
+    var decision = specification.decision();
+    return withDecision(
+        specification,
+        new TranscodeDecision(
+            mode,
+            decision.videoCodecFamily(),
+            decision.audioDecision(),
+            decision.subtitleDecision(),
+            decision.containerFormat(),
+            decision.needsKeyframeAlignment()));
+  }
+
+  private static RenditionSpec rendition(String label, int width, int height, long bitrate) {
+    return RenditionSpec.builder()
+        .label(label)
+        .width(width)
+        .height(height)
+        .videoBitrate(bitrate)
+        .build();
+  }
+
+  private static void writeStartupArtifacts(Path outputDirectory, String contents, String extension)
+      throws IOException {
+    Files.writeString(outputDirectory.resolve("stream.m3u8"), "#EXTM3U\n");
+    Files.writeString(outputDirectory.resolve("segment0" + extension), contents);
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new TranscodeException("Test interrupted", exception);
+    }
+  }
+
+  private boolean awaitState(TranscodeJobRef jobRef, TranscodeJobState expected) {
+    var deadline = System.nanoTime() + Duration.ofSeconds(1).toNanos();
+    while (System.nanoTime() < deadline) {
+      if (engine.inspect(jobRef).state() == expected) {
+        return true;
+      }
+      Thread.yield();
+    }
+    return false;
+  }
+
+  private static final class BlockingDiscardStorage extends LocalSegmentStorage {
+    private final CountDownLatch bothDiscards = new CountDownLatch(2);
+    private final CountDownLatch releaseDiscards = new CountDownLatch(1);
+    private volatile boolean blocking;
+
+    private BlockingDiscardStorage(Path baseDir) {
+      super(baseDir);
+    }
+
+    private void blockDiscards() {
+      blocking = true;
+    }
+
+    private boolean awaitBothDiscards() throws InterruptedException {
+      return bothDiscards.await(1, TimeUnit.SECONDS);
+    }
+
+    private void releaseDiscards() {
+      releaseDiscards.countDown();
+    }
+
+    @Override
+    public void discard(SegmentGeneration generation) {
+      if (blocking) {
+        bothDiscards.countDown();
+        await(releaseDiscards);
+      }
+      super.discard(generation);
+    }
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/AudioDecisionTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/AudioDecisionTest.java
@@ -1,12 +1,16 @@
 package com.streamarr.transcode.engine.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("UnitTest")
 @DisplayName("Audio Decision Tests")
@@ -63,6 +67,23 @@ class AudioDecisionTest {
   }
 
   @Test
+  @DisplayName("Should preserve unknown bitrate when copy decision created")
+  void shouldPreserveUnknownBitrateWhenCopyDecisionCreated() {
+    var decision = AudioDecision.copy("ac3", 6, 0L);
+
+    assertThat(decision.bitrate()).isZero();
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidAudioDecisions")
+  @DisplayName("Should reject audio decision when values are invalid for mode")
+  void shouldRejectAudioDecisionWhenValuesAreInvalidForMode(
+      AudioMode mode, String codec, int channels, long bitrate) {
+    assertThatThrownBy(() -> new AudioDecision(mode, codec, channels, bitrate))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   @DisplayName("Should return AAC codec string when codec is unrecognized")
   void shouldReturnAacCodecStringWhenCodecIsUnrecognized() {
     var decision = new AudioDecision(AudioMode.COPY, "opus", 2, 128_000L);
@@ -79,5 +100,24 @@ class AudioDecisionTest {
     assertThat(decision.codec()).isNull();
     assertThat(decision.channels()).isZero();
     assertThat(decision.bitrate()).isZero();
+  }
+
+  static Stream<Arguments> invalidAudioDecisions() {
+    var excessiveBitrate = Long.MAX_VALUE / 2 + 1;
+    return Stream.of(
+        Arguments.of(null, "aac", 2, 128_000L),
+        Arguments.of(AudioMode.COPY, null, 2, 0L),
+        Arguments.of(AudioMode.COPY, " ", 2, 0L),
+        Arguments.of(AudioMode.COPY, "aac", 0, 0L),
+        Arguments.of(AudioMode.COPY, "aac", 2, -1L),
+        Arguments.of(AudioMode.COPY, "aac", 2, excessiveBitrate),
+        Arguments.of(AudioMode.TRANSCODE, null, 2, 128_000L),
+        Arguments.of(AudioMode.TRANSCODE, " ", 2, 128_000L),
+        Arguments.of(AudioMode.TRANSCODE, "aac", 0, 128_000L),
+        Arguments.of(AudioMode.TRANSCODE, "aac", 2, 0L),
+        Arguments.of(AudioMode.TRANSCODE, "aac", 2, excessiveBitrate),
+        Arguments.of(AudioMode.NONE, "aac", 0, 0L),
+        Arguments.of(AudioMode.NONE, null, 1, 0L),
+        Arguments.of(AudioMode.NONE, null, 0, 1L));
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/MediaSourceRefTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/MediaSourceRefTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @Tag("UnitTest")
@@ -25,6 +26,7 @@ class MediaSourceRefTest {
   }
 
   @ParameterizedTest
+  @NullSource
   @ValueSource(
       strings = {
         "",

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/MediaSourceRefTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/MediaSourceRefTest.java
@@ -1,0 +1,58 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Tag("UnitTest")
+@DisplayName("Media Source Reference Tests")
+class MediaSourceRefTest {
+
+  @Test
+  @DisplayName("Should preserve namespace and relative key when source reference is portable")
+  void shouldPreserveNamespaceAndRelativeKeyWhenSourceReferenceIsPortable() {
+    var namespaceId = UUID.randomUUID();
+
+    var source = new MediaSourceRef(namespaceId, "Movies/Amélie.mkv");
+
+    assertThat(source.namespaceId()).isEqualTo(namespaceId);
+    assertThat(source.relativeKey()).isEqualTo("Movies/Amélie.mkv");
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
+        "/absolute.mkv",
+        "C:/movie.mkv",
+        "Movies\\movie.mkv",
+        "Movies//movie.mkv",
+        "Movies/movie.mkv/",
+        ".",
+        "..",
+        "Movies/./movie.mkv",
+        "Movies/../movie.mkv",
+        "Movies/\0movie.mkv"
+      })
+  @DisplayName("Should reject source reference when relative key is not portable")
+  void shouldRejectSourceReferenceWhenRelativeKeyIsNotPortable(String relativeKey) {
+    var namespaceId = UUID.randomUUID();
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> new MediaSourceRef(namespaceId, relativeKey))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject source reference when namespace is absent")
+  void shouldRejectSourceReferenceWhenNamespaceIsAbsent() {
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> new MediaSourceRef(null, "Movies/movie.mkv"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionObservationTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionObservationTest.java
@@ -6,6 +6,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @Tag("UnitTest")
 @DisplayName("Rendition Observation Tests")
@@ -28,6 +30,14 @@ class RenditionObservationTest {
     assertThatThrownBy(() -> new RenditionObservation(" ", RenditionState.RUNNING))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> new RenditionObservation("720p", null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"720/p", "720\\p", ".", "..", "720\0p"})
+  @DisplayName("Should reject rendition observation when label is not one portable segment")
+  void shouldRejectRenditionObservationWhenLabelIsNotOnePortableSegment(String label) {
+    assertThatThrownBy(() -> new RenditionObservation(label, RenditionState.RUNNING))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionObservationTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionObservationTest.java
@@ -1,0 +1,33 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Rendition Observation Tests")
+class RenditionObservationTest {
+
+  @Test
+  @DisplayName("Should preserve rendition state when observation is valid")
+  void shouldPreserveRenditionStateWhenObservationIsValid() {
+    var observation = new RenditionObservation("720p", RenditionState.RUNNING);
+
+    assertThat(observation.label()).isEqualTo("720p");
+    assertThat(observation.state()).isEqualTo(RenditionState.RUNNING);
+  }
+
+  @Test
+  @DisplayName("Should reject rendition observation when identity or state is absent")
+  void shouldRejectRenditionObservationWhenIdentityOrStateIsAbsent() {
+    assertThatThrownBy(() -> new RenditionObservation(null, RenditionState.RUNNING))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new RenditionObservation(" ", RenditionState.RUNNING))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new RenditionObservation("720p", null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionRequestTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionRequestTest.java
@@ -7,21 +7,21 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("UnitTest")
-@DisplayName("Transcode Request Tests")
-class TranscodeRequestTest {
+@DisplayName("Rendition Request Tests")
+class RenditionRequestTest {
 
   @Test
   @DisplayName("Should use default variant when label is absent")
   void shouldUseDefaultVariantWhenLabelIsAbsent() {
-    var request = TranscodeRequest.builder().build();
+    var request = RenditionRequest.builder().build();
 
-    assertThat(request.variantLabel()).isEqualTo(TranscodeRequest.DEFAULT_VARIANT);
+    assertThat(request.variantLabel()).isEqualTo(RenditionRequest.DEFAULT_VARIANT);
   }
 
   @Test
   @DisplayName("Should preserve explicit variant label")
   void shouldPreserveExplicitVariantLabel() {
-    var request = TranscodeRequest.builder().variantLabel("720p").build();
+    var request = RenditionRequest.builder().variantLabel("720p").build();
 
     assertThat(request.variantLabel()).isEqualTo("720p");
   }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionSpecTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionSpecTest.java
@@ -49,7 +49,8 @@ class RenditionSpecTest {
         Arguments.of(" ", 1280, 720, 3_000_000L),
         Arguments.of("720p", 0, 720, 3_000_000L),
         Arguments.of("720p", 1280, 0, 3_000_000L),
-        Arguments.of("720p", 1280, 720, 0L));
+        Arguments.of("720p", 1280, 720, 0L),
+        Arguments.of("720p", 1280, 720, Long.MAX_VALUE / 2 + 1));
   }
 
   static Stream<String> unsafePortableLabels() {

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionSpecTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/RenditionSpecTest.java
@@ -1,0 +1,58 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("Rendition Specification Tests")
+class RenditionSpecTest {
+
+  @Test
+  @DisplayName("Should preserve rendition intent when values are valid")
+  void shouldPreserveRenditionIntentWhenValuesAreValid() {
+    var rendition = new RenditionSpec("720p", 1280, 720, 3_000_000L);
+
+    assertThat(rendition.label()).isEqualTo("720p");
+    assertThat(rendition.width()).isEqualTo(1280);
+    assertThat(rendition.height()).isEqualTo(720);
+    assertThat(rendition.videoBitrate()).isEqualTo(3_000_000L);
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidRenditions")
+  @DisplayName("Should reject rendition specification when values are invalid")
+  void shouldRejectRenditionSpecificationWhenValuesAreInvalid(
+      String label, int width, int height, long videoBitrate) {
+    assertThatThrownBy(() -> new RenditionSpec(label, width, height, videoBitrate))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("unsafePortableLabels")
+  @DisplayName("Should reject rendition specification when label is not one portable segment")
+  void shouldRejectRenditionSpecificationWhenLabelIsNotOnePortableSegment(String label) {
+    assertThatThrownBy(() -> new RenditionSpec(label, 1280, 720, 3_000_000L))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> invalidRenditions() {
+    return Stream.of(
+        Arguments.of(null, 1280, 720, 3_000_000L),
+        Arguments.of(" ", 1280, 720, 3_000_000L),
+        Arguments.of("720p", 0, 720, 3_000_000L),
+        Arguments.of("720p", 1280, 0, 3_000_000L),
+        Arguments.of("720p", 1280, 720, 0L));
+  }
+
+  static Stream<String> unsafePortableLabels() {
+    return Stream.of("720/p", "720\\p", ".", "..", "720\0p");
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/SubtitleDecisionTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/SubtitleDecisionTest.java
@@ -1,0 +1,46 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("Subtitle Decision Tests")
+class SubtitleDecisionTest {
+
+  @ParameterizedTest
+  @MethodSource("invalidSubtitleDecisions")
+  @DisplayName("Should reject subtitle decision when values are structurally invalid")
+  void shouldRejectSubtitleDecisionWhenValuesAreStructurallyInvalid(
+      SubtitleMode mode,
+      Optional<String> codec,
+      OptionalInt streamIndex,
+      Optional<String> language) {
+    assertThatThrownBy(() -> new SubtitleDecision(mode, codec, streamIndex, language))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> invalidSubtitleDecisions() {
+    return Stream.of(
+        Arguments.of(null, Optional.empty(), OptionalInt.empty(), Optional.empty()),
+        Arguments.of(SubtitleMode.EXCLUDE, null, OptionalInt.empty(), Optional.empty()),
+        Arguments.of(SubtitleMode.EXCLUDE, Optional.empty(), null, Optional.empty()),
+        Arguments.of(SubtitleMode.EXCLUDE, Optional.empty(), OptionalInt.empty(), null),
+        Arguments.of(
+            SubtitleMode.EXCLUDE, Optional.of("webvtt"), OptionalInt.empty(), Optional.empty()),
+        Arguments.of(SubtitleMode.EXCLUDE, Optional.empty(), OptionalInt.of(0), Optional.empty()),
+        Arguments.of(
+            SubtitleMode.EXCLUDE, Optional.empty(), OptionalInt.empty(), Optional.of("eng")),
+        Arguments.of(SubtitleMode.HLS, Optional.of(" "), OptionalInt.of(0), Optional.of("eng")),
+        Arguments.of(
+            SubtitleMode.HLS, Optional.of("webvtt"), OptionalInt.of(-1), Optional.of("eng")),
+        Arguments.of(SubtitleMode.HLS, Optional.of("webvtt"), OptionalInt.of(0), Optional.of(" ")));
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeDecisionTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeDecisionTest.java
@@ -1,0 +1,55 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("Transcode Decision Tests")
+class TranscodeDecisionTest {
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("incompleteDecisions")
+  @DisplayName("Should reject transcode decision when a required value is absent")
+  void shouldRejectTranscodeDecisionWhenRequiredValueIsAbsent(
+      String scenario, Supplier<TranscodeDecision> decision) {
+    assertThatThrownBy(decision::get).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> incompleteDecisions() {
+    return Stream.of(
+        Arguments.of(
+            "transcode mode",
+            (Supplier<TranscodeDecision>) () -> validBuilder().transcodeMode(null).build()),
+        Arguments.of(
+            "video codec",
+            (Supplier<TranscodeDecision>) () -> validBuilder().videoCodecFamily(null).build()),
+        Arguments.of(
+            "blank video codec",
+            (Supplier<TranscodeDecision>) () -> validBuilder().videoCodecFamily(" ").build()),
+        Arguments.of(
+            "audio decision",
+            (Supplier<TranscodeDecision>) () -> validBuilder().audioDecision(null).build()),
+        Arguments.of(
+            "subtitle decision",
+            (Supplier<TranscodeDecision>) () -> validBuilder().subtitleDecision(null).build()),
+        Arguments.of(
+            "container format",
+            (Supplier<TranscodeDecision>) () -> validBuilder().containerFormat(null).build()));
+  }
+
+  private static TranscodeDecision.TranscodeDecisionBuilder validBuilder() {
+    return TranscodeDecision.builder()
+        .transcodeMode(TranscodeMode.FULL_TRANSCODE)
+        .videoCodecFamily("h264")
+        .audioDecision(AudioDecision.stereoAac())
+        .subtitleDecision(SubtitleDecision.exclude())
+        .containerFormat(ContainerFormat.MPEGTS);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeExecutionParametersTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeExecutionParametersTest.java
@@ -54,6 +54,7 @@ class TranscodeExecutionParametersTest {
         Arguments.of(0, 6, 23.976, -1, Duration.ofSeconds(45)),
         Arguments.of(0, 6, 23.976, 0, null),
         Arguments.of(0, 6, 23.976, 0, Duration.ZERO),
-        Arguments.of(0, 6, 23.976, 0, Duration.ofSeconds(-1)));
+        Arguments.of(0, 6, 23.976, 0, Duration.ofSeconds(-1)),
+        Arguments.of(0, 6, 23.976, 0, Duration.ofSeconds(Long.MAX_VALUE)));
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeExecutionParametersTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeExecutionParametersTest.java
@@ -1,0 +1,59 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("Transcode Execution Parameters Tests")
+class TranscodeExecutionParametersTest {
+
+  @Test
+  @DisplayName("Should preserve execution parameters when values are valid")
+  void shouldPreserveExecutionParametersWhenValuesAreValid() {
+    var parameters = new TranscodeExecutionParameters(30, 6, 23.976, 5, Duration.ofSeconds(45));
+
+    assertThat(parameters.seekPosition()).isEqualTo(30);
+    assertThat(parameters.segmentDuration()).isEqualTo(6);
+    assertThat(parameters.framerate()).isEqualTo(23.976);
+    assertThat(parameters.startNumber()).isEqualTo(5);
+    assertThat(parameters.startupTimeout()).isEqualTo(Duration.ofSeconds(45));
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidParameters")
+  @DisplayName("Should reject execution parameters when values are invalid")
+  void shouldRejectExecutionParametersWhenValuesAreInvalid(
+      int seekPosition,
+      int segmentDuration,
+      double framerate,
+      int startNumber,
+      Duration startupTimeout) {
+    assertThatThrownBy(
+            () ->
+                new TranscodeExecutionParameters(
+                    seekPosition, segmentDuration, framerate, startNumber, startupTimeout))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> invalidParameters() {
+    return Stream.of(
+        Arguments.of(-1, 6, 23.976, 0, Duration.ofSeconds(45)),
+        Arguments.of(0, 0, 23.976, 0, Duration.ofSeconds(45)),
+        Arguments.of(0, 6, 0.0, 0, Duration.ofSeconds(45)),
+        Arguments.of(0, 6, Double.NaN, 0, Duration.ofSeconds(45)),
+        Arguments.of(0, 6, Double.POSITIVE_INFINITY, 0, Duration.ofSeconds(45)),
+        Arguments.of(0, 6, 23.976, -1, Duration.ofSeconds(45)),
+        Arguments.of(0, 6, 23.976, 0, null),
+        Arguments.of(0, 6, 23.976, 0, Duration.ZERO),
+        Arguments.of(0, 6, 23.976, 0, Duration.ofSeconds(-1)));
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobObservationTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobObservationTest.java
@@ -1,0 +1,73 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Transcode Job Observation Tests")
+class TranscodeJobObservationTest {
+
+  @Test
+  @DisplayName("Should preserve an immutable rendition snapshot when job observation is valid")
+  void shouldPreserveImmutableRenditionSnapshotWhenJobObservationIsValid() {
+    var renditions =
+        new ArrayList<>(List.of(new RenditionObservation("720p", RenditionState.RUNNING)));
+
+    var observation =
+        TranscodeJobObservation.builder()
+            .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
+            .state(TranscodeJobState.RUNNING)
+            .renditions(renditions)
+            .build();
+    renditions.add(new RenditionObservation("480p", RenditionState.STARTING));
+
+    assertThat(observation.renditions())
+        .extracting(RenditionObservation::label)
+        .containsExactly("720p");
+    assertThatThrownBy(
+            () ->
+                observation
+                    .renditions()
+                    .add(new RenditionObservation("360p", RenditionState.STARTING)))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject job observation when a required value is absent")
+  void shouldRejectJobObservationWhenRequiredValueIsAbsent() {
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
+    var renditions = List.of(new RenditionObservation("720p", RenditionState.RUNNING));
+
+    assertThatThrownBy(
+            () -> new TranscodeJobObservation(null, TranscodeJobState.RUNNING, renditions))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new TranscodeJobObservation(jobRef, null, renditions))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> new TranscodeJobObservation(jobRef, TranscodeJobState.RUNNING, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject job observation when rendition labels are duplicated")
+  void shouldRejectJobObservationWhenRenditionLabelsAreDuplicated() {
+    var duplicateRenditions =
+        List.of(
+            new RenditionObservation("720p", RenditionState.RUNNING),
+            new RenditionObservation("720p", RenditionState.FAILED));
+
+    assertThatThrownBy(
+            () ->
+                new TranscodeJobObservation(
+                    new TranscodeJobRef(UUID.randomUUID(), 1),
+                    TranscodeJobState.FAILED,
+                    duplicateRenditions))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobObservationTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobObservationTest.java
@@ -35,11 +35,10 @@ class TranscodeJobObservationTest {
     assertThat(observation.renditions())
         .extracting(RenditionObservation::label)
         .containsExactly("720p");
-    assertThatThrownBy(
-            () ->
-                observation
-                    .renditions()
-                    .add(new RenditionObservation("360p", RenditionState.STARTING)))
+    var snapshot = observation.renditions();
+    var addedRendition = new RenditionObservation("360p", RenditionState.STARTING);
+
+    assertThatThrownBy(() -> snapshot.add(addedRendition))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -61,12 +60,11 @@ class TranscodeJobObservationTest {
   @Test
   @DisplayName("Should reject job observation when a rendition entry is absent")
   void shouldRejectJobObservationWhenRenditionEntryIsAbsent() {
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
+    var renditions = java.util.Collections.<RenditionObservation>singletonList(null);
+
     assertThatThrownBy(
-            () ->
-                new TranscodeJobObservation(
-                    new TranscodeJobRef(UUID.randomUUID(), 1),
-                    TranscodeJobState.RUNNING,
-                    java.util.Collections.singletonList(null)))
+            () -> new TranscodeJobObservation(jobRef, TranscodeJobState.RUNNING, renditions))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Transcode job observation values are required");
   }
@@ -78,13 +76,11 @@ class TranscodeJobObservationTest {
         List.of(
             new RenditionObservation("720p", RenditionState.STOPPED),
             new RenditionObservation("720p", RenditionState.FAILED));
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
 
     assertThatThrownBy(
             () ->
-                new TranscodeJobObservation(
-                    new TranscodeJobRef(UUID.randomUUID(), 1),
-                    TranscodeJobState.FAILED,
-                    duplicateRenditions))
+                new TranscodeJobObservation(jobRef, TranscodeJobState.FAILED, duplicateRenditions))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -95,13 +91,11 @@ class TranscodeJobObservationTest {
         List.of(
             new RenditionObservation("720p", RenditionState.STOPPED),
             new RenditionObservation("720P", RenditionState.FAILED));
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
 
     assertThatThrownBy(
             () ->
-                new TranscodeJobObservation(
-                    new TranscodeJobRef(UUID.randomUUID(), 1),
-                    TranscodeJobState.FAILED,
-                    collidingRenditions))
+                new TranscodeJobObservation(jobRef, TranscodeJobState.FAILED, collidingRenditions))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -110,11 +104,22 @@ class TranscodeJobObservationTest {
   @DisplayName("Should reject job observation when state contradicts rendition snapshot")
   void shouldRejectJobObservationWhenStateContradictsRenditionSnapshot(
       TranscodeJobState state, List<RenditionObservation> renditions) {
-    assertThatThrownBy(
-            () ->
-                new TranscodeJobObservation(
-                    new TranscodeJobRef(UUID.randomUUID(), 1), state, renditions))
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
+
+    assertThatThrownBy(() -> new TranscodeJobObservation(jobRef, state, renditions))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("validMixedStates")
+  @DisplayName("Should accept job observation when mixed rendition states agree")
+  void shouldAcceptJobObservationWhenMixedRenditionStatesAgree(
+      TranscodeJobState state, List<RenditionObservation> renditions) {
+    var observation =
+        new TranscodeJobObservation(new TranscodeJobRef(UUID.randomUUID(), 1), state, renditions);
+
+    assertThat(observation.state()).isEqualTo(state);
+    assertThat(observation.renditions()).containsExactlyElementsOf(renditions);
   }
 
   static Stream<Arguments> contradictoryStates() {
@@ -133,6 +138,16 @@ class TranscodeJobObservationTest {
             TranscodeJobState.RUNNING,
             List.of(new RenditionObservation("720p", RenditionState.COMPLETED))),
         Arguments.of(
+            TranscodeJobState.RUNNING,
+            List.of(
+                new RenditionObservation("720p", RenditionState.RUNNING),
+                new RenditionObservation("480p", RenditionState.FAILED))),
+        Arguments.of(
+            TranscodeJobState.RUNNING,
+            List.of(
+                new RenditionObservation("720p", RenditionState.RUNNING),
+                new RenditionObservation("480p", RenditionState.STARTING))),
+        Arguments.of(
             TranscodeJobState.COMPLETED,
             List.of(new RenditionObservation("720p", RenditionState.RUNNING))),
         Arguments.of(
@@ -144,7 +159,26 @@ class TranscodeJobObservationTest {
                 new RenditionObservation("720p", RenditionState.FAILED),
                 new RenditionObservation("480p", RenditionState.RUNNING))),
         Arguments.of(
+            TranscodeJobState.FAILED,
+            List.of(
+                new RenditionObservation("720p", RenditionState.FAILED),
+                new RenditionObservation("480p", RenditionState.STARTING))),
+        Arguments.of(
             TranscodeJobState.STOPPED,
             List.of(new RenditionObservation("720p", RenditionState.RUNNING))));
+  }
+
+  static Stream<Arguments> validMixedStates() {
+    return Stream.of(
+        Arguments.of(
+            TranscodeJobState.RUNNING,
+            List.of(
+                new RenditionObservation("720p", RenditionState.RUNNING),
+                new RenditionObservation("480p", RenditionState.COMPLETED))),
+        Arguments.of(
+            TranscodeJobState.FAILED,
+            List.of(
+                new RenditionObservation("720p", RenditionState.FAILED),
+                new RenditionObservation("480p", RenditionState.COMPLETED))));
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobObservationTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobObservationTest.java
@@ -6,9 +6,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("UnitTest")
 @DisplayName("Transcode Job Observation Tests")
@@ -55,11 +59,24 @@ class TranscodeJobObservationTest {
   }
 
   @Test
+  @DisplayName("Should reject job observation when a rendition entry is absent")
+  void shouldRejectJobObservationWhenRenditionEntryIsAbsent() {
+    assertThatThrownBy(
+            () ->
+                new TranscodeJobObservation(
+                    new TranscodeJobRef(UUID.randomUUID(), 1),
+                    TranscodeJobState.RUNNING,
+                    java.util.Collections.singletonList(null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Transcode job observation values are required");
+  }
+
+  @Test
   @DisplayName("Should reject job observation when rendition labels are duplicated")
   void shouldRejectJobObservationWhenRenditionLabelsAreDuplicated() {
     var duplicateRenditions =
         List.of(
-            new RenditionObservation("720p", RenditionState.RUNNING),
+            new RenditionObservation("720p", RenditionState.STOPPED),
             new RenditionObservation("720p", RenditionState.FAILED));
 
     assertThatThrownBy(
@@ -69,5 +86,65 @@ class TranscodeJobObservationTest {
                     TranscodeJobState.FAILED,
                     duplicateRenditions))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject observation labels that collide on case-insensitive storage")
+  void shouldRejectObservationLabelsThatCollideOnCaseInsensitiveStorage() {
+    var collidingRenditions =
+        List.of(
+            new RenditionObservation("720p", RenditionState.STOPPED),
+            new RenditionObservation("720P", RenditionState.FAILED));
+
+    assertThatThrownBy(
+            () ->
+                new TranscodeJobObservation(
+                    new TranscodeJobRef(UUID.randomUUID(), 1),
+                    TranscodeJobState.FAILED,
+                    collidingRenditions))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("contradictoryStates")
+  @DisplayName("Should reject job observation when state contradicts rendition snapshot")
+  void shouldRejectJobObservationWhenStateContradictsRenditionSnapshot(
+      TranscodeJobState state, List<RenditionObservation> renditions) {
+    assertThatThrownBy(
+            () ->
+                new TranscodeJobObservation(
+                    new TranscodeJobRef(UUID.randomUUID(), 1), state, renditions))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> contradictoryStates() {
+    return Stream.of(
+        Arguments.of(
+            TranscodeJobState.ABSENT,
+            List.of(new RenditionObservation("720p", RenditionState.STOPPED))),
+        Arguments.of(
+            TranscodeJobState.ADMITTING,
+            List.of(new RenditionObservation("720p", RenditionState.RUNNING))),
+        Arguments.of(TranscodeJobState.RUNNING, List.of()),
+        Arguments.of(
+            TranscodeJobState.RUNNING,
+            List.of(new RenditionObservation("720p", RenditionState.FAILED))),
+        Arguments.of(
+            TranscodeJobState.RUNNING,
+            List.of(new RenditionObservation("720p", RenditionState.COMPLETED))),
+        Arguments.of(
+            TranscodeJobState.COMPLETED,
+            List.of(new RenditionObservation("720p", RenditionState.RUNNING))),
+        Arguments.of(
+            TranscodeJobState.FAILED,
+            List.of(new RenditionObservation("720p", RenditionState.STOPPED))),
+        Arguments.of(
+            TranscodeJobState.FAILED,
+            List.of(
+                new RenditionObservation("720p", RenditionState.FAILED),
+                new RenditionObservation("480p", RenditionState.RUNNING))),
+        Arguments.of(
+            TranscodeJobState.STOPPED,
+            List.of(new RenditionObservation("720p", RenditionState.RUNNING))));
   }
 }

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobRefTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobRefTest.java
@@ -17,7 +17,9 @@ class TranscodeJobRefTest {
   @ValueSource(longs = {0, -1})
   @DisplayName("Should reject job reference when generation is not positive")
   void shouldRejectJobReferenceWhenGenerationIsNotPositive(long generation) {
-    assertThatThrownBy(() -> new TranscodeJobRef(UUID.randomUUID(), generation))
+    var jobId = UUID.randomUUID();
+
+    assertThatThrownBy(() -> new TranscodeJobRef(jobId, generation))
         .isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobRefTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobRefTest.java
@@ -1,0 +1,30 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Tag("UnitTest")
+@DisplayName("Transcode Job Reference Tests")
+class TranscodeJobRefTest {
+
+  @ParameterizedTest
+  @ValueSource(longs = {0, -1})
+  @DisplayName("Should reject job reference when generation is not positive")
+  void shouldRejectJobReferenceWhenGenerationIsNotPositive(long generation) {
+    assertThatThrownBy(() -> new TranscodeJobRef(UUID.randomUUID(), generation))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject job reference when job identity is absent")
+  void shouldRejectJobReferenceWhenJobIdentityIsAbsent() {
+    assertThatThrownBy(() -> new TranscodeJobRef(null, 1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobSpecTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobSpecTest.java
@@ -39,9 +39,23 @@ class TranscodeJobSpecTest {
   }
 
   @Test
+  @DisplayName("Should reject job specification when rendition ladder contains an absent value")
+  void shouldRejectJobSpecificationWhenRenditionLadderContainsAbsentValue() {
+    assertThatThrownBy(() -> specification(java.util.Arrays.asList(rendition("720p"), null)))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   @DisplayName("Should reject job specification when rendition labels are duplicated")
   void shouldRejectJobSpecificationWhenRenditionLabelsAreDuplicated() {
     assertThatThrownBy(() -> specification(List.of(rendition("720p"), rendition("720p"))))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject rendition labels that collide on case-insensitive storage")
+  void shouldRejectRenditionLabelsThatCollideOnCaseInsensitiveStorage() {
+    assertThatThrownBy(() -> specification(List.of(rendition("720p"), rendition("720P"))))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -88,9 +102,18 @@ class TranscodeJobSpecTest {
         .sessionId(UUID.randomUUID())
         .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
         .source(new MediaSourceRef(UUID.randomUUID(), "Movies/movie.mkv"))
-        .decision(TranscodeDecision.builder().build())
+        .decision(validDecision().build())
         .execution(new TranscodeExecutionParameters(0, 6, 23.976, 0, Duration.ofSeconds(45)))
         .renditions(List.of(rendition("720p")));
+  }
+
+  private static TranscodeDecision.TranscodeDecisionBuilder validDecision() {
+    return TranscodeDecision.builder()
+        .transcodeMode(TranscodeMode.FULL_TRANSCODE)
+        .videoCodecFamily("h264")
+        .audioDecision(AudioDecision.stereoAac())
+        .subtitleDecision(SubtitleDecision.exclude())
+        .containerFormat(ContainerFormat.MPEGTS);
   }
 
   private static RenditionSpec rendition(String label) {

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobSpecTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobSpecTest.java
@@ -41,21 +41,27 @@ class TranscodeJobSpecTest {
   @Test
   @DisplayName("Should reject job specification when rendition ladder contains an absent value")
   void shouldRejectJobSpecificationWhenRenditionLadderContainsAbsentValue() {
-    assertThatThrownBy(() -> specification(java.util.Arrays.asList(rendition("720p"), null)))
+    var renditions = java.util.Arrays.asList(rendition("720p"), null);
+
+    assertThatThrownBy(() -> specification(renditions))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   @DisplayName("Should reject job specification when rendition labels are duplicated")
   void shouldRejectJobSpecificationWhenRenditionLabelsAreDuplicated() {
-    assertThatThrownBy(() -> specification(List.of(rendition("720p"), rendition("720p"))))
+    var renditions = List.of(rendition("720p"), rendition("720p"));
+
+    assertThatThrownBy(() -> specification(renditions))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   @DisplayName("Should reject rendition labels that collide on case-insensitive storage")
   void shouldRejectRenditionLabelsThatCollideOnCaseInsensitiveStorage() {
-    assertThatThrownBy(() -> specification(List.of(rendition("720p"), rendition("720P"))))
+    var renditions = List.of(rendition("720p"), rendition("720P"));
+
+    assertThatThrownBy(() -> specification(renditions))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -89,7 +95,9 @@ class TranscodeJobSpecTest {
   }
 
   private static void assertThatThrownByUnsupportedMutation(List<RenditionSpec> renditions) {
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> renditions.add(rendition("360p")))
+    var addedRendition = rendition("360p");
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> renditions.add(addedRendition))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobSpecTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/model/TranscodeJobSpecTest.java
@@ -1,0 +1,99 @@
+package com.streamarr.transcode.engine.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Tag("UnitTest")
+@DisplayName("Transcode Job Specification Tests")
+class TranscodeJobSpecTest {
+
+  @Test
+  @DisplayName("Should preserve an immutable rendition ladder when job specification is valid")
+  void shouldPreserveImmutableRenditionLadderWhenJobSpecificationIsValid() {
+    var renditions = new ArrayList<>(List.of(rendition("720p")));
+
+    var specification = specification(renditions);
+    renditions.add(rendition("480p"));
+
+    assertThat(specification.renditions()).extracting(RenditionSpec::label).containsExactly("720p");
+    assertThatThrownByUnsupportedMutation(specification.renditions());
+  }
+
+  @Test
+  @DisplayName("Should reject job specification when rendition ladder is empty")
+  void shouldRejectJobSpecificationWhenRenditionLadderIsEmpty() {
+    assertThatThrownBy(() -> specification(List.of())).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject job specification when rendition labels are duplicated")
+  void shouldRejectJobSpecificationWhenRenditionLabelsAreDuplicated() {
+    assertThatThrownBy(() -> specification(List.of(rendition("720p"), rendition("720p"))))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("missingRequiredValues")
+  @DisplayName("Should reject job specification when a required value is absent")
+  void shouldRejectJobSpecificationWhenRequiredValueIsAbsent(
+      String scenario, Supplier<TranscodeJobSpec> specification) {
+    assertThatThrownBy(specification::get).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  static Stream<Arguments> missingRequiredValues() {
+    return Stream.of(
+        Arguments.of(
+            "session identity",
+            (Supplier<TranscodeJobSpec>) () -> validBuilder().sessionId(null).build()),
+        Arguments.of(
+            "job reference",
+            (Supplier<TranscodeJobSpec>) () -> validBuilder().jobRef(null).build()),
+        Arguments.of(
+            "media source", (Supplier<TranscodeJobSpec>) () -> validBuilder().source(null).build()),
+        Arguments.of(
+            "stream decision",
+            (Supplier<TranscodeJobSpec>) () -> validBuilder().decision(null).build()),
+        Arguments.of(
+            "execution parameters",
+            (Supplier<TranscodeJobSpec>) () -> validBuilder().execution(null).build()),
+        Arguments.of(
+            "rendition ladder",
+            (Supplier<TranscodeJobSpec>) () -> validBuilder().renditions(null).build()));
+  }
+
+  private static void assertThatThrownByUnsupportedMutation(List<RenditionSpec> renditions) {
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> renditions.add(rendition("360p")))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private static TranscodeJobSpec specification(List<RenditionSpec> renditions) {
+    return validBuilder().renditions(renditions).build();
+  }
+
+  private static TranscodeJobSpec.TranscodeJobSpecBuilder validBuilder() {
+    return TranscodeJobSpec.builder()
+        .sessionId(UUID.randomUUID())
+        .jobRef(new TranscodeJobRef(UUID.randomUUID(), 1))
+        .source(new MediaSourceRef(UUID.randomUUID(), "Movies/movie.mkv"))
+        .decision(TranscodeDecision.builder().build())
+        .execution(new TranscodeExecutionParameters(0, 6, 23.976, 0, Duration.ofSeconds(45)))
+        .renditions(List.of(rendition("720p")));
+  }
+
+  private static RenditionSpec rendition(String label) {
+    return new RenditionSpec(label, 1280, 720, 3_000_000L);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
@@ -1,0 +1,348 @@
+package com.streamarr.transcode.engine.segment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.transcode.engine.error.TranscodeException;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+@DisplayName("Local Segment Storage Tests")
+class LocalSegmentStorageTest {
+
+  @TempDir Path tempDir;
+  @TempDir Path externalDir;
+
+  private LocalSegmentStorage storage;
+
+  @BeforeEach
+  void setUp() {
+    storage = new LocalSegmentStorage(tempDir);
+  }
+
+  @Test
+  @DisplayName("Should hide generation artifacts until the generation is published")
+  void shouldHideGenerationArtifactsUntilGenerationIsPublished() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    var renditionDirectory = Files.createDirectories(generation.outputDirectory().resolve("720p"));
+    Files.writeString(renditionDirectory.resolve("segment0.ts"), "staged");
+
+    assertThat(storage.segmentExists(sessionId, "720p/segment0.ts")).isFalse();
+    assertThatThrownBy(() -> storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isInstanceOf(TranscodeException.class);
+  }
+
+  @Test
+  @DisplayName("Should expose every generation artifact when the generation is published")
+  void shouldExposeEveryGenerationArtifactWhenGenerationIsPublished() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    var lowRendition = Files.createDirectories(generation.outputDirectory().resolve("480p"));
+    var highRendition = Files.createDirectories(generation.outputDirectory().resolve("1080p"));
+    Files.writeString(lowRendition.resolve("segment0.ts"), "low");
+    Files.writeString(highRendition.resolve("segment0.ts"), "high");
+
+    storage.publish(generation);
+
+    assertThat(storage.readSegment(sessionId, "480p/segment0.ts")).isEqualTo("low".getBytes());
+    assertThat(storage.readSegment(sessionId, "1080p/segment0.ts")).isEqualTo("high".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should preserve the published generation when its replacement is discarded")
+  void shouldPreservePublishedGenerationWhenReplacementIsDiscarded() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var published = writeGeneration(sessionId, new TranscodeJobRef(jobId, 1), "published");
+    storage.publish(published);
+    var replacement = writeGeneration(sessionId, new TranscodeJobRef(jobId, 2), "replacement");
+
+    storage.discard(replacement);
+
+    assertThat(storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isEqualTo("published".getBytes());
+    assertThat(replacement.outputDirectory()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should prefer a replacement while retaining earlier timeline segments")
+  void shouldPreferReplacementWhileRetainingEarlierTimelineSegments() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var original = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 1));
+    var originalDirectory = Files.createDirectories(original.outputDirectory().resolve("720p"));
+    Files.writeString(originalDirectory.resolve("segment0.ts"), "original-zero");
+    Files.writeString(originalDirectory.resolve("segment1.ts"), "original-one");
+    storage.publish(original);
+    var replacement = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 2));
+    var replacementDirectory =
+        Files.createDirectories(replacement.outputDirectory().resolve("720p"));
+    Files.writeString(replacementDirectory.resolve("segment1.ts"), "replacement-one");
+
+    storage.publish(replacement);
+
+    assertThat(storage.readSegment(sessionId, "720p/segment1.ts"))
+        .isEqualTo("replacement-one".getBytes());
+    assertThat(storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isEqualTo("original-zero".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should reject publication of a superseded prepared generation")
+  void shouldRejectPublicationOfSupersededPreparedGeneration() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var superseded = writeGeneration(sessionId, new TranscodeJobRef(jobId, 1), "superseded");
+    var current = writeGeneration(sessionId, new TranscodeJobRef(jobId, 2), "current");
+    storage.publish(current);
+
+    assertThatThrownBy(() -> storage.publish(superseded)).isInstanceOf(IllegalStateException.class);
+    assertThat(storage.readSegment(sessionId, "720p/segment0.ts")).isEqualTo("current".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should ignore withdrawal for an older generation")
+  void shouldIgnoreWithdrawalForOlderGeneration() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var original = writeGeneration(sessionId, new TranscodeJobRef(jobId, 1), "original");
+    storage.publish(original);
+    var replacement = writeGeneration(sessionId, new TranscodeJobRef(jobId, 2), "replacement");
+    storage.publish(replacement);
+
+    var withdrawn = storage.withdraw(sessionId, original.jobRef());
+
+    assertThat(withdrawn).isFalse();
+    assertThat(storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isEqualTo("replacement".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should hide the complete timeline when the current generation is withdrawn")
+  void shouldHideCompleteTimelineWhenCurrentGenerationIsWithdrawn() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var original = writeGeneration(sessionId, new TranscodeJobRef(jobId, 1), "original");
+    storage.publish(original);
+    var replacement = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 2));
+    var replacementDirectory =
+        Files.createDirectories(replacement.outputDirectory().resolve("720p"));
+    Files.writeString(replacementDirectory.resolve("segment1.ts"), "replacement");
+    storage.publish(replacement);
+
+    var withdrawn = storage.withdraw(sessionId, replacement.jobRef());
+
+    assertThat(withdrawn).isTrue();
+    assertThat(storage.segmentExists(sessionId, "720p/segment0.ts")).isFalse();
+    assertThat(storage.segmentExists(sessionId, "720p/segment1.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should exclude a failed generation while retaining safe history on recovery")
+  void shouldExcludeFailedGenerationWhileRetainingSafeHistoryOnRecovery() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var original = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 1));
+    writeSegment(original, "segment0.ts", "safe-history");
+    storage.publish(original);
+    var failed = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 2));
+    writeSegment(failed, "segment1.ts", "failed-generation");
+    storage.publish(failed);
+    storage.withdraw(sessionId, failed.jobRef());
+    var recovered = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 3));
+    writeSegment(recovered, "segment2.ts", "recovered");
+
+    storage.publish(recovered);
+
+    assertThat(storage.readSegment(sessionId, "720p/segment2.ts"))
+        .isEqualTo("recovered".getBytes());
+    assertThat(storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isEqualTo("safe-history".getBytes());
+    assertThat(storage.segmentExists(sessionId, "720p/segment1.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should invalidate and delete a prepared generation when its session is deleted")
+  void shouldInvalidateAndDeletePreparedGenerationWhenSessionIsDeleted() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        writeGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1), "prepared-segment");
+
+    storage.deleteSession(sessionId);
+
+    assertThat(generation.outputDirectory()).doesNotExist();
+    assertThatThrownBy(() -> storage.publish(generation)).isInstanceOf(IllegalStateException.class);
+    assertThat(storage.segmentExists(sessionId, "720p/segment0.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should observe a generation published after waiting begins")
+  void shouldObserveGenerationPublishedAfterWaitingBegins() throws Exception {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        writeGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1), "published-later");
+    var entered = new CountDownLatch(1);
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var waiting =
+          executor.submit(
+              () -> {
+                entered.countDown();
+                return storage.waitForSegment(
+                    sessionId, "720p/segment0.ts", java.time.Duration.ofSeconds(2));
+              });
+      assertThat(entered.await(1, TimeUnit.SECONDS)).isTrue();
+      Thread.sleep(150);
+      assertThat(waiting.isDone()).isFalse();
+
+      storage.publish(generation);
+
+      assertThat(waiting.get(1, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  @Test
+  @DisplayName("Should stop observing a generation withdrawn while waiting")
+  void shouldStopObservingGenerationWithdrawnWhileWaiting() throws Exception {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    Files.createDirectories(generation.outputDirectory().resolve("720p"));
+    storage.publish(generation);
+    var entered = new CountDownLatch(1);
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var waiting =
+          executor.submit(
+              () -> {
+                entered.countDown();
+                return storage.waitForSegment(
+                    sessionId, "720p/segment1.ts", java.time.Duration.ofMillis(400));
+              });
+      assertThat(entered.await(1, TimeUnit.SECONDS)).isTrue();
+      Thread.sleep(150);
+
+      storage.withdraw(sessionId, generation.jobRef());
+      writeSegment(generation, "segment1.ts", "too-late");
+
+      assertThat(waiting.get(1, TimeUnit.SECONDS)).isFalse();
+    }
+  }
+
+  @Test
+  @DisplayName("Should discover a generated session after storage restarts")
+  void shouldDiscoverGeneratedSessionAfterStorageRestarts() {
+    var sessionId = UUID.randomUUID();
+    storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    storage = new LocalSegmentStorage(tempDir);
+
+    var storedSessionIds = storage.snapshotStoredSessionIds();
+
+    assertThat(storedSessionIds).containsExactly(sessionId);
+  }
+
+  @Test
+  @DisplayName("Should delete a generated session after storage restarts")
+  void shouldDeleteGeneratedSessionAfterStorageRestarts() {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    storage = new LocalSegmentStorage(tempDir);
+
+    storage.deleteSession(sessionId);
+
+    assertThat(generation.outputDirectory()).doesNotExist();
+    assertThat(storage.snapshotStoredSessionIds()).doesNotContain(sessionId);
+  }
+
+  @Test
+  @DisplayName("Should reject discarding a generation owned by another storage instance")
+  void shouldRejectDiscardingGenerationOwnedByAnotherStorageInstance() throws IOException {
+    var generation =
+        writeGeneration(
+            UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1), "owned-segment");
+    var otherStorage = new LocalSegmentStorage(tempDir);
+
+    assertThatThrownBy(() -> otherStorage.discard(generation))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(generation.outputDirectory()).exists();
+  }
+
+  @Test
+  @DisplayName("Should reject publishing a generation owned by another storage instance")
+  void shouldRejectPublishingGenerationOwnedByAnotherStorageInstance() throws IOException {
+    var generation =
+        writeGeneration(
+            UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1), "owned-segment");
+    var otherStorage = new LocalSegmentStorage(tempDir);
+
+    assertThatThrownBy(() -> otherStorage.publish(generation))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject discarding a generation after it is published")
+  void shouldRejectDiscardingGenerationAfterItIsPublished() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        writeGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1), "published-segment");
+    storage.publish(generation);
+
+    assertThatThrownBy(() -> storage.discard(generation)).isInstanceOf(IllegalStateException.class);
+    assertThat(storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isEqualTo("published-segment".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should reject a segment symlink outside the published generation")
+  void shouldRejectSegmentSymlinkOutsidePublishedGeneration() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    var renditionDirectory = Files.createDirectories(generation.outputDirectory().resolve("720p"));
+    var externalFile = Files.writeString(externalDir.resolve("secret.ts"), "external-secret");
+    Files.createSymbolicLink(renditionDirectory.resolve("segment0.ts"), externalFile);
+    storage.publish(generation);
+
+    assertThatThrownBy(() -> storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject reusing residual artifacts for the same generation after restart")
+  void shouldRejectReusingResidualArtifactsForSameGenerationAfterRestart() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
+    writeGeneration(sessionId, jobRef, "residual-segment");
+    storage = new LocalSegmentStorage(tempDir);
+
+    assertThatThrownBy(() -> storage.prepareGeneration(sessionId, jobRef))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private SegmentGeneration writeGeneration(
+      UUID sessionId, TranscodeJobRef jobRef, String segmentContents) throws IOException {
+    var generation = storage.prepareGeneration(sessionId, jobRef);
+    writeSegment(generation, "segment0.ts", segmentContents);
+    return generation;
+  }
+
+  private static void writeSegment(
+      SegmentGeneration generation, String segmentName, String segmentContents) throws IOException {
+    var renditionDirectory = Files.createDirectories(generation.outputDirectory().resolve("720p"));
+    Files.writeString(renditionDirectory.resolve(segmentName), segmentContents);
+  }
+}

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
@@ -6,8 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.streamarr.transcode.engine.error.TranscodeException;
 import com.streamarr.transcode.engine.model.TranscodeJobRef;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -47,6 +49,38 @@ class LocalSegmentStorageTest {
   }
 
   @Test
+  @DisplayName("Should prepare a generation when the managed base directory is missing")
+  void shouldPrepareGenerationWhenManagedBaseDirectoryIsMissing() {
+    var missingBase = tempDir.resolve("missing/base");
+    storage = new LocalSegmentStorage(missingBase);
+
+    var generation =
+        storage.prepareGeneration(UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1));
+
+    assertThat(generation.outputDirectory()).exists().isDirectory();
+  }
+
+  @Test
+  @DisplayName("Should reject a regular file as the configured storage base")
+  void shouldRejectRegularFileAsConfiguredStorageBase() throws IOException {
+    var configuredBase = Files.createFile(tempDir.resolve("segments.file"));
+
+    assertThatThrownBy(() -> new LocalSegmentStorage(configuredBase))
+        .isInstanceOf(UncheckedIOException.class);
+  }
+
+  @Test
+  @DisplayName("Should create a legacy rendition output directory inside its session")
+  void shouldCreateLegacyRenditionOutputDirectoryInsideItsSession() {
+    var sessionId = UUID.randomUUID();
+
+    var renditionDirectory = storage.getOutputDirectory(sessionId, "720p");
+
+    assertThat(renditionDirectory).isDirectory();
+    assertThat(renditionDirectory.getParent()).isEqualTo(storage.getOutputDirectory(sessionId));
+  }
+
+  @Test
   @DisplayName("Should expose every generation artifact when the generation is published")
   void shouldExposeEveryGenerationArtifactWhenGenerationIsPublished() throws IOException {
     var sessionId = UUID.randomUUID();
@@ -61,6 +95,35 @@ class LocalSegmentStorageTest {
 
     assertThat(storage.readSegment(sessionId, "480p/segment0.ts")).isEqualTo("low".getBytes());
     assertThat(storage.readSegment(sessionId, "1080p/segment0.ts")).isEqualTo("high".getBytes());
+  }
+
+  @Test
+  @DisplayName("Should report a missing segment after searching the published timeline")
+  void shouldReportMissingSegmentAfterSearchingPublishedTimeline() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    Files.writeString(generation.outputDirectory().resolve("stream.m3u8"), "#EXTM3U");
+    storage.publish(generation);
+
+    assertThatThrownBy(() -> storage.readSegment(sessionId, "segment0.ts"))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessage("Segment not found: segment0.ts");
+  }
+
+  @Test
+  @DisplayName("Should preserve interruption while waiting for a segment")
+  void shouldPreserveInterruptionWhileWaitingForSegment() {
+    var sessionId = UUID.randomUUID();
+    storage.getOutputDirectory(sessionId);
+    Thread.currentThread().interrupt();
+
+    try {
+      assertThat(storage.waitForSegment(sessionId, "segment0.ts", Duration.ofSeconds(1))).isFalse();
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      Thread.interrupted();
+    }
   }
 
   @Test
@@ -150,6 +213,19 @@ class LocalSegmentStorageTest {
     assertThat(withdrawn).isTrue();
     assertThat(storage.segmentExists(sessionId, "720p/segment0.ts")).isFalse();
     assertThat(storage.segmentExists(sessionId, "720p/segment1.ts")).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject republishing a withdrawn generation")
+  void shouldRejectRepublishingWithdrawnGeneration() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        writeGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1), "withdrawn-segment");
+    storage.publish(generation);
+    storage.withdraw(sessionId, generation.jobRef());
+
+    assertThatThrownBy(() -> storage.publish(generation)).isInstanceOf(IllegalStateException.class);
+    assertThat(storage.segmentExists(sessionId, "720p/segment0.ts")).isFalse();
   }
 
   @Test
@@ -322,6 +398,211 @@ class LocalSegmentStorageTest {
   }
 
   @Test
+  @DisplayName("Should reject a generation root replaced by an external symlink")
+  void shouldRejectGenerationRootReplacedByExternalSymlink() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var generation =
+        storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
+    Files.delete(generation.outputDirectory());
+    var externalGeneration = Files.createDirectories(externalDir.resolve("generation/720p"));
+    Files.writeString(externalGeneration.resolve("segment0.ts"), "external-secret");
+    Files.createSymbolicLink(
+        generation.outputDirectory(), externalGeneration.getParent().toAbsolutePath());
+    storage.publish(generation);
+
+    assertThatThrownBy(() -> storage.readSegment(sessionId, "720p/segment0.ts"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a staging directory symlink outside managed storage")
+  void shouldRejectStagingDirectorySymlinkOutsideManagedStorage() throws IOException {
+    var sessionId = UUID.randomUUID();
+    Files.createSymbolicLink(tempDir.resolve(".staging"), externalDir.toAbsolutePath());
+
+    assertThatThrownBy(
+            () -> storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1)))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThat(externalDir.resolve(sessionId.toString())).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should reject a legacy session directory symlink outside managed storage")
+  void shouldRejectLegacySessionDirectorySymlinkOutsideManagedStorage() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var externalSession = Files.createDirectories(externalDir.resolve(sessionId.toString()));
+    Files.createSymbolicLink(
+        tempDir.resolve(sessionId.toString()), externalSession.toAbsolutePath());
+
+    assertThatThrownBy(() -> storage.getOutputDirectory(sessionId, "720p"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThat(externalSession.resolve("720p")).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should delete a legacy session symlink without following its target")
+  void shouldDeleteLegacySessionSymlinkWithoutFollowingItsTarget() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var externalSession = Files.createDirectories(externalDir.resolve(sessionId.toString()));
+    var externalSegment = Files.writeString(externalSession.resolve("segment0.ts"), "external");
+    var sessionLink = tempDir.resolve(sessionId.toString());
+    Files.createSymbolicLink(sessionLink, externalSession.toAbsolutePath());
+
+    storage.deleteSession(sessionId);
+
+    assertThat(Files.exists(sessionLink, java.nio.file.LinkOption.NOFOLLOW_LINKS)).isFalse();
+    assertThat(externalSegment).exists().hasContent("external");
+  }
+
+  @Test
+  @DisplayName("Should reject deletion after managed base is replaced by an external symlink")
+  void shouldRejectDeletionAfterManagedBaseIsReplacedByExternalSymlink() throws IOException {
+    var managedBase = Files.createDirectories(tempDir.resolve("managed"));
+    storage = new LocalSegmentStorage(managedBase);
+    var sessionId = UUID.randomUUID();
+    var externalSession = Files.createDirectories(externalDir.resolve(sessionId.toString()));
+    var externalSegment = Files.writeString(externalSession.resolve("segment0.ts"), "external");
+    Files.delete(managedBase);
+    Files.createSymbolicLink(managedBase, externalDir.toAbsolutePath());
+
+    assertThatThrownBy(() -> storage.deleteSession(sessionId))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThat(externalSegment).exists();
+  }
+
+  @Test
+  @DisplayName("Should accept a configured base symlink when storage is initialized")
+  void shouldAcceptConfiguredBaseSymlinkWhenStorageIsInitialized() throws IOException {
+    var configuredTarget = Files.createDirectories(externalDir.resolve("configured-storage"));
+    var configuredBase = tempDir.resolve("configured-storage");
+    Files.createSymbolicLink(configuredBase, configuredTarget.toAbsolutePath());
+    storage = new LocalSegmentStorage(configuredBase);
+
+    var outputDirectory = storage.getOutputDirectory(UUID.randomUUID());
+
+    assertThat(outputDirectory.toRealPath()).startsWith(configuredTarget.toRealPath());
+  }
+
+  @Test
+  @DisplayName("Should retry generation discard after configured base identity is restored")
+  void shouldRetryGenerationDiscardAfterConfiguredBaseIdentityIsRestored() throws IOException {
+    var configuredTarget = Files.createDirectories(externalDir.resolve("configured-storage"));
+    var replacementTarget = Files.createDirectories(externalDir.resolve("replacement-storage"));
+    var configuredBase = tempDir.resolve("configured-storage");
+    Files.createSymbolicLink(configuredBase, configuredTarget.toAbsolutePath());
+    storage = new LocalSegmentStorage(configuredBase);
+    var generation =
+        writeGeneration(
+            UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1), "staged-segment");
+    var generationRelativePath = configuredBase.relativize(generation.outputDirectory());
+    Files.createDirectories(replacementTarget.resolve(generationRelativePath));
+    Files.delete(configuredBase);
+    Files.createSymbolicLink(configuredBase, replacementTarget.toAbsolutePath());
+
+    assertThatThrownBy(() -> storage.discard(generation))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    Files.delete(configuredBase);
+    Files.createSymbolicLink(configuredBase, configuredTarget.toAbsolutePath());
+
+    storage.discard(generation);
+
+    assertThat(generation.outputDirectory()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should reject session discovery through an external staging symlink")
+  void shouldRejectSessionDiscoveryThroughExternalStagingSymlink() throws IOException {
+    Files.createDirectories(externalDir.resolve(UUID.randomUUID().toString()));
+    Files.createSymbolicLink(tempDir.resolve(".staging"), externalDir.toAbsolutePath());
+
+    assertThatThrownBy(storage::snapshotStoredSessionIds)
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject deletion of a session symlink below an escaped staging parent")
+  void shouldRejectDeletionOfSessionSymlinkBelowEscapedStagingParent() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var externalStaging = Files.createDirectories(externalDir.resolve("staging"));
+    var externalTarget = Files.createDirectories(externalDir.resolve("target"));
+    var externalSessionLink = externalStaging.resolve(sessionId.toString());
+    Files.createSymbolicLink(externalSessionLink, externalTarget.toAbsolutePath());
+    Files.createSymbolicLink(tempDir.resolve(".staging"), externalStaging.toAbsolutePath());
+
+    assertThatThrownBy(() -> storage.deleteSession(sessionId))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThat(Files.exists(externalSessionLink, java.nio.file.LinkOption.NOFOLLOW_LINKS)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should reject a rendition directory symlink outside managed storage")
+  void shouldRejectRenditionDirectorySymlinkOutsideManagedStorage() throws IOException {
+    var generation =
+        storage.prepareGeneration(UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1));
+    var externalRendition = Files.createDirectories(externalDir.resolve("720p"));
+    Files.createSymbolicLink(
+        generation.outputDirectory().resolve("720p"), externalRendition.toAbsolutePath());
+
+    assertThatThrownBy(() -> storage.prepareRenditionDirectory(generation, "720p"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a staged artifact symlink outside managed storage")
+  void shouldRejectStagedArtifactSymlinkOutsideManagedStorage() throws IOException {
+    var generation =
+        storage.prepareGeneration(UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1));
+    var renditionDirectory = storage.prepareRenditionDirectory(generation, "720p");
+    var externalManifest = Files.writeString(externalDir.resolve("stream.m3u8"), "external");
+    Files.createSymbolicLink(
+        renditionDirectory.resolve("stream.m3u8"), externalManifest.toAbsolutePath());
+
+    assertThatThrownBy(() -> storage.readStagedArtifact(generation, "720p/stream.m3u8"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThatThrownBy(() -> storage.isStagedArtifactNonEmpty(generation, "720p/stream.m3u8"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a staged directory as an artifact")
+  void shouldRejectStagedDirectoryAsArtifact() {
+    var generation =
+        storage.prepareGeneration(UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1));
+    storage.prepareRenditionDirectory(generation, "720p");
+
+    assertThatThrownBy(() -> storage.readStagedArtifact(generation, "720p"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+    assertThatThrownBy(() -> storage.isStagedArtifactNonEmpty(generation, "720p"))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a staged artifact that exceeds the inspection limit")
+  void shouldRejectStagedArtifactThatExceedsInspectionLimit() throws IOException {
+    var generation =
+        storage.prepareGeneration(UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1));
+    Files.write(generation.outputDirectory().resolve("stream.m3u8"), new byte[1_048_577]);
+
+    assertThatThrownBy(() -> storage.readStagedArtifact(generation, "stream.m3u8"))
+        .isInstanceOf(TranscodeException.class)
+        .hasMessage("Staged artifact exceeds inspection limit");
+  }
+
+  @Test
+  @DisplayName("Should reject cleanup and reads through a superseded prepared generation")
+  void shouldRejectCleanupAndReadsThroughSupersededPreparedGeneration() {
+    var sessionId = UUID.randomUUID();
+    var jobId = UUID.randomUUID();
+    var superseded = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 1));
+    var current = storage.prepareGeneration(sessionId, new TranscodeJobRef(jobId, 2));
+
+    assertThatThrownBy(() -> storage.discard(superseded)).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> storage.readStagedArtifact(superseded, "stream.m3u8"))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(current.outputDirectory()).exists();
+  }
+
+  @Test
   @DisplayName("Should reject reusing residual artifacts for the same generation after restart")
   void shouldRejectReusingResidualArtifactsForSameGenerationAfterRestart() throws IOException {
     var sessionId = UUID.randomUUID();
@@ -331,6 +612,116 @@ class LocalSegmentStorageTest {
 
     assertThatThrownBy(() -> storage.prepareGeneration(sessionId, jobRef))
         .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a regular file at the generation root")
+  void shouldRejectRegularFileAtGenerationRoot() throws IOException {
+    var sessionId = UUID.randomUUID();
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
+    var generationRoot =
+        tempDir
+            .resolve(".staging")
+            .resolve(sessionId.toString())
+            .resolve(jobRef.jobId() + "-" + jobRef.generation());
+    Files.createDirectories(generationRoot.getParent());
+    Files.createFile(generationRoot);
+
+    assertThatThrownBy(() -> storage.prepareGeneration(sessionId, jobRef))
+        .isInstanceOf(IllegalStateException.class);
+    assertThat(generationRoot).isRegularFile();
+  }
+
+  @Test
+  @DisplayName("Should report no stored sessions before the staging layout exists")
+  void shouldReportNoStoredSessionsBeforeStagingLayoutExists() {
+    assertThat(storage.snapshotStoredSessionIds()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should reject traversal while waiting for a segment")
+  void shouldRejectTraversalWhileWaitingForSegment() {
+    assertThatThrownBy(
+            () -> storage.waitForSegment(UUID.randomUUID(), "../segment0.ts", Duration.ofMillis(1)))
+        .isInstanceOf(InvalidSegmentPathException.class);
+  }
+
+  @Test
+  @DisplayName("Should report cached session verification failure when base disappears")
+  void shouldReportCachedSessionVerificationFailureWhenBaseDisappears() throws IOException {
+    var managedBase = Files.createDirectory(tempDir.resolve("managed"));
+    storage = new LocalSegmentStorage(managedBase);
+    var sessionId = UUID.randomUUID();
+    Files.delete(storage.getOutputDirectory(sessionId));
+    Files.delete(managedBase);
+
+    assertThatThrownBy(() -> storage.getOutputDirectory(sessionId))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Failed to verify session directory");
+  }
+
+  @Test
+  @DisplayName("Should report legacy rendition creation failure when its path is a file")
+  void shouldReportLegacyRenditionCreationFailureWhenItsPathIsFile() throws IOException {
+    var sessionId = UUID.randomUUID();
+    Files.createFile(storage.getOutputDirectory(sessionId).resolve("720p"));
+
+    assertThatThrownBy(() -> storage.getOutputDirectory(sessionId, "720p"))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Failed to create variant directory");
+  }
+
+  @Test
+  @DisplayName("Should report generation preparation failure when base becomes a file")
+  void shouldReportGenerationPreparationFailureWhenBaseBecomesFile() throws IOException {
+    var managedBase = Files.createDirectory(tempDir.resolve("managed"));
+    storage = new LocalSegmentStorage(managedBase);
+    Files.delete(managedBase);
+    Files.createFile(managedBase);
+
+    assertThatThrownBy(
+            () ->
+                storage.prepareGeneration(
+                    UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1)))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Failed to prepare segment generation");
+  }
+
+  @Test
+  @DisplayName("Should report rendition preparation failure when its path is a file")
+  void shouldReportRenditionPreparationFailureWhenItsPathIsFile() throws IOException {
+    var generation =
+        storage.prepareGeneration(UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1));
+    Files.createFile(generation.outputDirectory().resolve("720p"));
+
+    assertThatThrownBy(() -> storage.prepareRenditionDirectory(generation, "720p"))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Failed to prepare rendition directory");
+  }
+
+  @Test
+  @DisplayName("Should report stored session discovery failure when base becomes a file")
+  void shouldReportStoredSessionDiscoveryFailureWhenBaseBecomesFile() throws IOException {
+    var managedBase = Files.createDirectory(tempDir.resolve("managed"));
+    storage = new LocalSegmentStorage(managedBase);
+    Files.delete(managedBase);
+    Files.createFile(managedBase);
+
+    assertThatThrownBy(storage::snapshotStoredSessionIds)
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Failed to discover stored stream sessions");
+  }
+
+  @Test
+  @DisplayName("Should report session deletion verification failure when base disappears")
+  void shouldReportSessionDeletionVerificationFailureWhenBaseDisappears() throws IOException {
+    var managedBase = Files.createDirectory(tempDir.resolve("managed"));
+    storage = new LocalSegmentStorage(managedBase);
+    Files.delete(managedBase);
+
+    assertThatThrownBy(() -> storage.deleteSession(UUID.randomUUID()))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessage("Failed to verify session storage");
   }
 
   private SegmentGeneration writeGeneration(

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
@@ -77,8 +77,7 @@ class LocalSegmentStorageTest {
     var renditionDirectory = storage.getOutputDirectory(sessionId, "720p");
     var sessionDirectory = storage.getOutputDirectory(sessionId);
 
-    assertThat(renditionDirectory).isDirectory();
-    assertThat(renditionDirectory).hasParent(sessionDirectory);
+    assertThat(renditionDirectory).isDirectory().hasParent(sessionDirectory);
   }
 
   @Test

--- a/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
+++ b/streamarr-transcode-engine/src/test/java/com/streamarr/transcode/engine/segment/LocalSegmentStorageTest.java
@@ -75,9 +75,10 @@ class LocalSegmentStorageTest {
     var sessionId = UUID.randomUUID();
 
     var renditionDirectory = storage.getOutputDirectory(sessionId, "720p");
+    var sessionDirectory = storage.getOutputDirectory(sessionId);
 
     assertThat(renditionDirectory).isDirectory();
-    assertThat(renditionDirectory.getParent()).isEqualTo(storage.getOutputDirectory(sessionId));
+    assertThat(renditionDirectory).hasParent(sessionDirectory);
   }
 
   @Test
@@ -269,6 +270,8 @@ class LocalSegmentStorageTest {
   @Test
   @DisplayName("Should observe a generation published after waiting begins")
   void shouldObserveGenerationPublishedAfterWaitingBegins() throws Exception {
+    var observedStorage = new ObservableSegmentStorage(tempDir);
+    storage = observedStorage;
     var sessionId = UUID.randomUUID();
     var generation =
         writeGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1), "published-later");
@@ -282,10 +285,11 @@ class LocalSegmentStorageTest {
                     sessionId, "720p/segment0.ts", java.time.Duration.ofSeconds(2));
               });
       assertThat(entered.await(1, TimeUnit.SECONDS)).isTrue();
-      Thread.sleep(150);
+      assertThat(observedStorage.awaitFirstSegmentCheck()).isTrue();
       assertThat(waiting.isDone()).isFalse();
 
       storage.publish(generation);
+      observedStorage.allowSegmentChecks();
 
       assertThat(waiting.get(1, TimeUnit.SECONDS)).isTrue();
     }
@@ -294,6 +298,8 @@ class LocalSegmentStorageTest {
   @Test
   @DisplayName("Should stop observing a generation withdrawn while waiting")
   void shouldStopObservingGenerationWithdrawnWhileWaiting() throws Exception {
+    var observedStorage = new ObservableSegmentStorage(tempDir);
+    storage = observedStorage;
     var sessionId = UUID.randomUUID();
     var generation =
         storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1));
@@ -309,10 +315,11 @@ class LocalSegmentStorageTest {
                     sessionId, "720p/segment1.ts", java.time.Duration.ofMillis(400));
               });
       assertThat(entered.await(1, TimeUnit.SECONDS)).isTrue();
-      Thread.sleep(150);
+      assertThat(observedStorage.awaitFirstSegmentCheck()).isTrue();
 
       storage.withdraw(sessionId, generation.jobRef());
       writeSegment(generation, "segment1.ts", "too-late");
+      observedStorage.allowSegmentChecks();
 
       assertThat(waiting.get(1, TimeUnit.SECONDS)).isFalse();
     }
@@ -418,10 +425,10 @@ class LocalSegmentStorageTest {
   @DisplayName("Should reject a staging directory symlink outside managed storage")
   void shouldRejectStagingDirectorySymlinkOutsideManagedStorage() throws IOException {
     var sessionId = UUID.randomUUID();
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
     Files.createSymbolicLink(tempDir.resolve(".staging"), externalDir.toAbsolutePath());
 
-    assertThatThrownBy(
-            () -> storage.prepareGeneration(sessionId, new TranscodeJobRef(UUID.randomUUID(), 1)))
+    assertThatThrownBy(() -> storage.prepareGeneration(sessionId, jobRef))
         .isInstanceOf(InvalidSegmentPathException.class);
     assertThat(externalDir.resolve(sessionId.toString())).doesNotExist();
   }
@@ -641,8 +648,10 @@ class LocalSegmentStorageTest {
   @Test
   @DisplayName("Should reject traversal while waiting for a segment")
   void shouldRejectTraversalWhileWaitingForSegment() {
-    assertThatThrownBy(
-            () -> storage.waitForSegment(UUID.randomUUID(), "../segment0.ts", Duration.ofMillis(1)))
+    var sessionId = UUID.randomUUID();
+    var timeout = Duration.ofMillis(1);
+
+    assertThatThrownBy(() -> storage.waitForSegment(sessionId, "../segment0.ts", timeout))
         .isInstanceOf(InvalidSegmentPathException.class);
   }
 
@@ -676,13 +685,12 @@ class LocalSegmentStorageTest {
   void shouldReportGenerationPreparationFailureWhenBaseBecomesFile() throws IOException {
     var managedBase = Files.createDirectory(tempDir.resolve("managed"));
     storage = new LocalSegmentStorage(managedBase);
+    var sessionId = UUID.randomUUID();
+    var jobRef = new TranscodeJobRef(UUID.randomUUID(), 1);
     Files.delete(managedBase);
     Files.createFile(managedBase);
 
-    assertThatThrownBy(
-            () ->
-                storage.prepareGeneration(
-                    UUID.randomUUID(), new TranscodeJobRef(UUID.randomUUID(), 1)))
+    assertThatThrownBy(() -> storage.prepareGeneration(sessionId, jobRef))
         .isInstanceOf(UncheckedIOException.class)
         .hasMessage("Failed to prepare segment generation");
   }
@@ -717,9 +725,10 @@ class LocalSegmentStorageTest {
   void shouldReportSessionDeletionVerificationFailureWhenBaseDisappears() throws IOException {
     var managedBase = Files.createDirectory(tempDir.resolve("managed"));
     storage = new LocalSegmentStorage(managedBase);
+    var sessionId = UUID.randomUUID();
     Files.delete(managedBase);
 
-    assertThatThrownBy(() -> storage.deleteSession(UUID.randomUUID()))
+    assertThatThrownBy(() -> storage.deleteSession(sessionId))
         .isInstanceOf(UncheckedIOException.class)
         .hasMessage("Failed to verify session storage");
   }
@@ -735,5 +744,42 @@ class LocalSegmentStorageTest {
       SegmentGeneration generation, String segmentName, String segmentContents) throws IOException {
     var renditionDirectory = Files.createDirectories(generation.outputDirectory().resolve("720p"));
     Files.writeString(renditionDirectory.resolve(segmentName), segmentContents);
+  }
+
+  private static final class ObservableSegmentStorage extends LocalSegmentStorage {
+
+    private final CountDownLatch firstSegmentCheck = new CountDownLatch(1);
+    private final CountDownLatch segmentChecksAllowed = new CountDownLatch(1);
+
+    private ObservableSegmentStorage(Path baseDir) {
+      super(baseDir);
+    }
+
+    @Override
+    public boolean segmentExists(UUID sessionId, String segmentName) {
+      var exists = super.segmentExists(sessionId, segmentName);
+      firstSegmentCheck.countDown();
+      awaitSegmentChecksAllowed();
+      return exists;
+    }
+
+    private boolean awaitFirstSegmentCheck() throws InterruptedException {
+      return firstSegmentCheck.await(1, TimeUnit.SECONDS);
+    }
+
+    private void allowSegmentChecks() {
+      segmentChecksAllowed.countDown();
+    }
+
+    private void awaitSegmentChecksAllowed() {
+      try {
+        if (!segmentChecksAllowed.await(1, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("Segment checks were not released");
+        }
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("Interrupted while awaiting segment checks", exception);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add a local job engine that starts, inspects, stops, and releases an entire rendition ladder under one exact job and generation fence.
- Stage complete output generations and publish them atomically only after every rendition is ready, while retaining the prior generation as fallback until replacement succeeds.
- Harden process observations, lifecycle idempotency, model invariants, segment-path confinement, bounded playlist inspection, and retryable cleanup.
- Introduce a trusted library media-source catalog that converts authoritative files into portable source references and resolves them back inside their library roots.
- Keep distributed execution disabled; this remains a behavior-preserving local foundation for the later worker adapter.

This is the P5-A1c complete local-ladder slice and targets the P5-A1b engine extraction.

## Validation

- Clean full-reactor verification, including PostgreSQL integration tests, formatting, static checks, packaging, and aggregate coverage.
- Deterministic concurrency and failure tests for stale generations, delayed stops, stale inspections, overlapping cleanup, partial startup, fallback replacement, and shutdown recovery.
- Filesystem tests for traversal, symbolic-link escape, publication races, cleanup retry, and oversized artifacts.
- Independent final review with new-code coverage above the project gate and no remaining validated findings.

Refs #76
