### PR TITLE
Cut playback over to whole-job transcodes

### DIFF
--- a/streamarr-server/src/main/java/com/streamarr/server/config/StreamingConfig.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/config/StreamingConfig.java
@@ -2,15 +2,17 @@ package com.streamarr.server.config;
 
 import com.streamarr.server.repositories.media.MediaFileRepository;
 import com.streamarr.server.services.auth.PlaybackTokenIssuer;
-import com.streamarr.server.services.concurrency.MutexFactoryProvider;
+import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.streaming.DefaultPlaybackSessionAccessService;
 import com.streamarr.server.services.streaming.DefaultPlaybackSessionCreationService;
 import com.streamarr.server.services.streaming.DefaultPlaybackSessionTerminationService;
+import com.streamarr.server.services.streaming.DefaultPlaybackTranscodeJobService;
 import com.streamarr.server.services.streaming.FfprobeService;
 import com.streamarr.server.services.streaming.HlsStreamingService;
 import com.streamarr.server.services.streaming.PlaybackSessionAccessService;
 import com.streamarr.server.services.streaming.PlaybackSessionCreationService;
 import com.streamarr.server.services.streaming.PlaybackSessionTerminationService;
+import com.streamarr.server.services.streaming.PlaybackTranscodeJobService;
 import com.streamarr.server.services.streaming.QualityLadderService;
 import com.streamarr.server.services.streaming.RuntimeStreamSessionRegistry;
 import com.streamarr.server.services.streaming.SegmentStore;
@@ -19,20 +21,24 @@ import com.streamarr.server.services.streaming.StreamSessionLifecycleTransaction
 import com.streamarr.server.services.streaming.StreamSessionTransactionRetry;
 import com.streamarr.server.services.streaming.StreamingService;
 import com.streamarr.server.services.streaming.TranscodeDecisionService;
-import com.streamarr.server.services.streaming.TranscodeExecutor;
 import com.streamarr.server.services.streaming.ffmpeg.LocalFfprobeService;
-import com.streamarr.server.services.streaming.ffmpeg.LocalTranscodeExecutor;
 import com.streamarr.server.services.streaming.local.InMemoryStreamSessionRepository;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
+import com.streamarr.server.services.streaming.worker.TranscodeWorkerPort;
+import com.streamarr.server.services.streaming.worker.WorkerTarget;
+import com.streamarr.server.services.streaming.worker.local.LocalTranscodeWorkerAdapter;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.LocalFfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
+import com.streamarr.transcode.engine.job.LocalTranscodeEngine;
 import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.util.UUID;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import tools.jackson.databind.ObjectMapper;
@@ -40,12 +46,15 @@ import tools.jackson.databind.ObjectMapper;
 @Configuration
 public class StreamingConfig {
 
-  @Bean
+  /** Reserved stable identity for the in-process worker across application boots. */
+  static final UUID LOCAL_WORKER_ID = UUID.fromString("00000000-0000-4000-8000-000000000001");
+
+  @Bean(destroyMethod = "")
   public LocalSegmentStorage localSegmentStorage(StreamingProperties properties) {
     return new LocalSegmentStorage(Path.of(properties.segmentBasePath()));
   }
 
-  @Bean
+  @Bean(destroyMethod = "")
   public LocalSegmentStore segmentStore(LocalSegmentStorage storage) {
     return new LocalSegmentStore(storage);
   }
@@ -98,14 +107,32 @@ public class StreamingConfig {
         });
   }
 
-  @Bean
-  public TranscodeExecutor transcodeExecutor(
+  @Bean(destroyMethod = "shutdown")
+  public LocalTranscodeEngine localTranscodeEngine(
       FfmpegCommandBuilder commandBuilder,
       FfmpegProcessManager processManager,
-      LocalSegmentStore segmentStore,
+      LocalSegmentStorage segmentStorage,
       TranscodeCapabilityService capabilityService) {
-    return new LocalTranscodeExecutor(
-        commandBuilder, processManager, segmentStore, capabilityService);
+    return LocalTranscodeEngine.builder()
+        .commandBuilder(commandBuilder)
+        .processManager(processManager)
+        .segmentStorage(segmentStorage)
+        .capabilityService(capabilityService)
+        .build();
+  }
+
+  @Bean
+  public WorkerTarget localWorkerTarget() {
+    return new WorkerTarget(LOCAL_WORKER_ID, UUID.randomUUID());
+  }
+
+  @Bean
+  public TranscodeWorkerPort transcodeWorkerPort(
+      WorkerTarget localWorkerTarget,
+      MediaSourceCatalog mediaSourceCatalog,
+      LocalTranscodeEngine localTranscodeEngine) {
+    return new LocalTranscodeWorkerAdapter(
+        localWorkerTarget, mediaSourceCatalog, localTranscodeEngine);
   }
 
   @Bean
@@ -114,26 +141,47 @@ public class StreamingConfig {
   }
 
   @Bean
+  public MutexFactory<UUID> streamingLifecycleMutexFactory() {
+    return new MutexFactory<>();
+  }
+
+  @Bean
+  public PlaybackTranscodeJobService playbackTranscodeJobService(
+      TranscodeWorkerPort worker,
+      WorkerTarget workerTarget,
+      RuntimeStreamSessionRegistry runtimeRegistry,
+      MutexFactory<UUID> streamingLifecycleMutexFactory) {
+    return DefaultPlaybackTranscodeJobService.builder()
+        .worker(worker)
+        .workerTarget(workerTarget)
+        .runtimeRegistry(runtimeRegistry)
+        .sessionMutexes(streamingLifecycleMutexFactory)
+        .build();
+  }
+
+  @Bean
   public StreamingService streamingService(
       MediaFileRepository mediaFileRepository,
-      TranscodeExecutor transcodeExecutor,
       SegmentStore segmentStore,
       FfprobeService ffprobeService,
       TranscodeDecisionService transcodeDecisionService,
       QualityLadderService qualityLadderService,
       StreamingProperties properties,
       RuntimeStreamSessionRegistry streamSessionRepository,
-      MutexFactoryProvider mutexFactoryProvider) {
+      MutexFactory<UUID> streamingLifecycleMutexFactory,
+      PlaybackTranscodeJobService playbackTranscodeJobService,
+      MediaSourceCatalog mediaSourceCatalog) {
     return new HlsStreamingService(
         mediaFileRepository,
-        transcodeExecutor,
         segmentStore,
         ffprobeService,
         transcodeDecisionService,
         qualityLadderService,
         properties,
         streamSessionRepository,
-        mutexFactoryProvider.getMutexFactory());
+        streamingLifecycleMutexFactory,
+        playbackTranscodeJobService,
+        mediaSourceCatalog);
   }
 
   @Bean

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -4,16 +4,19 @@ import com.streamarr.server.config.StreamingProperties;
 import com.streamarr.server.domain.streaming.MediaProbe;
 import com.streamarr.server.domain.streaming.StreamSession;
 import com.streamarr.server.domain.streaming.StreamingOptions;
-import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.exceptions.MaxConcurrentTranscodesException;
 import com.streamarr.server.exceptions.MediaFileNotFoundException;
 import com.streamarr.server.repositories.media.MediaFileRepository;
 import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.library.FilepathCodec;
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
 import com.streamarr.transcode.engine.model.QualityVariant;
 import com.streamarr.transcode.engine.model.RenditionRequest;
+import com.streamarr.transcode.engine.model.RenditionSpec;
 import com.streamarr.transcode.engine.model.TranscodeDecision;
+import com.streamarr.transcode.engine.model.TranscodeExecutionParameters;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
 import com.streamarr.transcode.engine.model.TranscodeMode;
 import java.time.Duration;
 import java.time.Instant;
@@ -36,7 +39,6 @@ public class HlsStreamingService implements StreamingService {
   private static final Duration FORWARD_RELOCATION_GAP = Duration.ofSeconds(24);
 
   private final MediaFileRepository mediaFileRepository;
-  private final TranscodeExecutor transcodeExecutor;
   private final SegmentStore segmentStore;
   private final FfprobeService ffprobeService;
   private final TranscodeDecisionService transcodeDecisionService;
@@ -44,6 +46,8 @@ public class HlsStreamingService implements StreamingService {
   private final StreamingProperties properties;
   private final RuntimeStreamSessionRegistry sessionRepository;
   private final MutexFactory<UUID> resumeMutex;
+  private final PlaybackTranscodeJobService playbackTranscodeJobService;
+  private final MediaSourceCatalog mediaSourceCatalog;
 
   @Override
   public StreamSession createSession(CreateRuntimeStreamSessionCommand command) {
@@ -107,8 +111,10 @@ public class HlsStreamingService implements StreamingService {
   @Override
   public boolean terminateRuntime(UUID sessionId) {
     sessionRepository.terminalize(sessionId);
-    transcodeExecutor.stop(sessionId);
-    sessionRepository.markRuntimeStopped(sessionId);
+    if (playbackTranscodeJobService.cleanupTerminal(sessionId) == RuntimeTranscodeCleanup.PENDING) {
+      log.warn("Cleanup remains pending for streaming session {}", sessionId);
+      return false;
+    }
     segmentStore.deleteSession(sessionId);
     var quiescent = sessionRepository.releaseTerminal(sessionId);
     log.info("Destroyed streaming session {}", sessionId);
@@ -118,20 +124,15 @@ public class HlsStreamingService implements StreamingService {
   @Override
   public void shutdownRuntime() {
     var sessionIds = sessionRepository.fenceAll();
-    sessionIds.forEach(this::stopForShutdown);
     for (var sessionId : sessionIds) {
-      sessionRepository.awaitTranscodeStarts(sessionId);
-      stopForShutdown(sessionId);
-    }
-    transcodeExecutor.forceStopAll();
-  }
-
-  private void stopForShutdown(UUID sessionId) {
-    try {
-      transcodeExecutor.stop(sessionId);
-      sessionRepository.markRuntimeStopped(sessionId);
-    } catch (RuntimeException exception) {
-      log.warn("Failed to stop stream session {} during shutdown", sessionId, exception);
+      try {
+        if (playbackTranscodeJobService.cleanupTerminal(sessionId)
+            == RuntimeTranscodeCleanup.PENDING) {
+          log.warn("Cleanup remains pending for stream session {} during shutdown", sessionId);
+        }
+      } catch (RuntimeException exception) {
+        log.warn("Failed to clean stream session {} during shutdown", sessionId, exception);
+      }
     }
   }
 
@@ -167,35 +168,45 @@ public class HlsStreamingService implements StreamingService {
 
   @Override
   public void resumeSessionIfNeeded(UUID sessionId, String segmentName) {
-    var session = sessionRepository.findById(sessionId).orElse(null);
-    if (session == null) {
-      return;
-    }
-
-    if (segmentStore.segmentExists(sessionId, segmentName)) {
-      return;
-    }
-
-    if (session.isSuspended()) {
-      resumeWithLock(sessionId, segmentName);
-      return;
-    }
-
-    if (!requiresRelocation(session, segmentName)) {
-      return;
-    }
-
-    relocateWithLock(sessionId, segmentName);
-  }
-
-  private void resumeWithLock(UUID sessionId, String segmentName) {
     var lock = resumeMutex.getMutex(sessionId);
     lock.lock();
-
     try {
-      doResume(sessionId, segmentName);
+      resumeOrRelocate(sessionId, segmentName);
     } finally {
       lock.unlock();
+    }
+  }
+
+  private void resumeOrRelocate(UUID sessionId, String segmentName) {
+    var session = sessionRepository.findById(sessionId).orElse(null);
+    if (session == null || segmentStore.segmentExists(sessionId, segmentName)) {
+      return;
+    }
+
+    switch (playbackTranscodeJobService.inspectActive(sessionId)) {
+      case ActiveTranscodeJobInspection.None _ -> startAtRequestedSegment(session, segmentName);
+      case ActiveTranscodeJobInspection.Unavailable(var jobRef) ->
+          log.warn(
+              "Active transcode inspection unavailable for session {} job {}", sessionId, jobRef);
+      case ActiveTranscodeJobInspection.Observed(var observation, var startNumber) ->
+          resumeObserved(session, segmentName, observation.state(), startNumber);
+    }
+  }
+
+  private void resumeObserved(
+      StreamSession session, String segmentName, TranscodeJobState state, int startNumber) {
+    switch (state) {
+      case ADMITTING, RUNNING -> {
+        if (requiresRelocation(session.getSessionId(), segmentName, startNumber)) {
+          startAtRequestedSegment(session, segmentName);
+        }
+      }
+      case COMPLETED, STOPPED, ABSENT -> startAtRequestedSegment(session, segmentName);
+      case FAILED -> {
+        log.warn(
+            "Transcode failed for session {}; replacing missing output", session.getSessionId());
+        startAtRequestedSegment(session, segmentName);
+      }
     }
   }
 
@@ -204,9 +215,8 @@ public class HlsStreamingService implements StreamingService {
    * needs the encoder relocated when it lies behind that start (it will never be produced) or so
    * far ahead of produced output that waiting would stall the player longer than restarting.
    */
-  private boolean requiresRelocation(StreamSession session, String segmentName) {
+  private boolean requiresRelocation(UUID sessionId, String segmentName, int startNumber) {
     var requestedIndex = parseSegmentIndex(segmentName);
-    var startNumber = activeStartNumber(session);
     if (requestedIndex < startNumber) {
       return true;
     }
@@ -216,42 +226,7 @@ public class HlsStreamingService implements StreamingService {
       return false;
     }
 
-    return !segmentStore.segmentExists(
-        session.getSessionId(), siblingSegmentName(segmentName, probeIndex));
-  }
-
-  private void relocateWithLock(UUID sessionId, String segmentName) {
-    var lock = resumeMutex.getMutex(sessionId);
-    lock.lock();
-
-    try {
-      doRelocate(sessionId, segmentName);
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  private void doRelocate(UUID sessionId, String segmentName) {
-    var session = sessionRepository.findById(sessionId).orElse(null);
-    if (session == null || !requiresRelocation(session, segmentName)) {
-      return;
-    }
-
-    if (segmentStore.segmentExists(sessionId, segmentName)) {
-      return;
-    }
-
-    var segmentIndex = parseSegmentIndex(segmentName);
-    transcodeExecutor.stop(sessionId);
-    startTranscodes(session, segmentIndex * segmentDurationSeconds(), segmentIndex);
-    log.info("Relocated transcode for session {} to segment {}", sessionId, segmentIndex);
-  }
-
-  private int activeStartNumber(StreamSession session) {
-    return session.getVariantHandles().values().stream()
-        .mapToInt(TranscodeHandle::startNumber)
-        .max()
-        .orElse(0);
+    return !segmentStore.segmentExists(sessionId, siblingSegmentName(segmentName, probeIndex));
   }
 
   private int forwardGapSegments() {
@@ -267,19 +242,14 @@ public class HlsStreamingService implements StreamingService {
     return SEGMENT_INDEX_PATTERN.matcher(segmentName).replaceFirst("segment" + index);
   }
 
-  private void doResume(UUID sessionId, String segmentName) {
-    var session = sessionRepository.findById(sessionId).orElse(null);
-    if (session == null || !session.isSuspended()) {
-      return;
-    }
-
+  private void startAtRequestedSegment(StreamSession session, String segmentName) {
     var segmentIndex = parseSegmentIndex(segmentName);
-    var resumeSeek = segmentIndex * (int) properties.segmentDuration().toSeconds();
+    var resumeSeek = segmentIndex * segmentDurationSeconds();
 
     startTranscodes(session, resumeSeek, segmentIndex);
     log.info(
-        "Resumed suspended session {} at segment {} (seek {}s)",
-        sessionId,
+        "Started replacement transcode for session {} at segment {} (seek {}s)",
+        session.getSessionId(),
         segmentIndex,
         resumeSeek);
   }
@@ -330,11 +300,21 @@ public class HlsStreamingService implements StreamingService {
   private int availableTranscodeSlots() {
     var activeTranscodes =
         sessionRepository.findAll().stream()
-            .filter(s -> !s.isSuspended())
             .filter(s -> requiresTranscode(s.getTranscodeDecision().transcodeMode()))
+            .filter(this::consumesTranscodeCapacity)
             .mapToInt(s -> Math.max(1, s.getVariants().size()))
             .sum();
     return properties.maxConcurrentTranscodes() - activeTranscodes;
+  }
+
+  private boolean consumesTranscodeCapacity(StreamSession session) {
+    return switch (playbackTranscodeJobService.inspectActive(session.getSessionId())) {
+      case ActiveTranscodeJobInspection.None _ -> false;
+      case ActiveTranscodeJobInspection.Unavailable _ -> true;
+      case ActiveTranscodeJobInspection.Observed(var observation, _) ->
+          observation.state() == TranscodeJobState.ADMITTING
+              || observation.state() == TranscodeJobState.RUNNING;
+    };
   }
 
   private boolean requiresTranscode(TranscodeMode mode) {
@@ -348,88 +328,57 @@ public class HlsStreamingService implements StreamingService {
   }
 
   private void startTranscodes(StreamSession session, int seekPosition, int startNumber) {
-    if (session.getVariants().isEmpty()) {
-      startSingleTranscode(session, seekPosition, startNumber);
-      return;
-    }
-
-    startVariantTranscodes(session, session.getVariants(), seekPosition, startNumber);
-  }
-
-  private void startSingleTranscode(StreamSession session, int seekPosition, int startNumber) {
     var probe = session.getMediaProbe();
-    var request =
-        RenditionRequest.builder()
+    playbackTranscodeJobService.start(
+        StartPlaybackTranscodeJobCommand.builder()
             .sessionId(session.getSessionId())
-            .sourcePath(session.getSourcePath())
-            .seekPosition(seekPosition)
-            .segmentDuration((int) properties.segmentDuration().toSeconds())
-            .framerate(probe.framerate())
-            .transcodeDecision(session.getTranscodeDecision())
-            .width(probe.width())
-            .height(probe.height())
-            .bitrate(probe.bitrate())
-            .variantLabel(RenditionRequest.DEFAULT_VARIANT)
-            .startNumber(startNumber)
-            .build();
-    var handle = startTranscode(request);
-
-    session.setHandle(handle);
+            .source(mediaSourceCatalog.referenceFor(session.getMediaFileId()))
+            .decision(session.getTranscodeDecision())
+            .execution(
+                TranscodeExecutionParameters.builder()
+                    .seekPosition(seekPosition)
+                    .segmentDuration(segmentDurationSeconds())
+                    .framerate(executionFramerate(session))
+                    .startNumber(startNumber)
+                    .startupTimeout(properties.transcodeStartupTimeout())
+                    .build())
+            .renditions(renditions(session))
+            .build());
   }
 
-  private void startVariantTranscodes(
-      StreamSession session, List<QualityVariant> variants, int seekPosition, int startNumber) {
-    for (var variant : variants) {
-      var request =
-          RenditionRequest.builder()
-              .sessionId(session.getSessionId())
-              .sourcePath(session.getSourcePath())
-              .seekPosition(seekPosition)
-              .segmentDuration((int) properties.segmentDuration().toSeconds())
-              .framerate(session.getMediaProbe().framerate())
-              .transcodeDecision(session.getTranscodeDecision())
-              .width(variant.width())
-              .height(variant.height())
-              .bitrate(variant.videoBitrate())
-              .variantLabel(variant.label())
-              .startNumber(startNumber)
-              .build();
-      var handle = startTranscode(request);
-
-      session.setVariantHandle(variant.label(), handle);
+  private List<RenditionSpec> renditions(StreamSession session) {
+    if (session.getVariants().isEmpty()) {
+      var probe = session.getMediaProbe();
+      return List.of(
+          new RenditionSpec(
+              RenditionRequest.DEFAULT_VARIANT,
+              probe.width(),
+              probe.height(),
+              defaultRenditionBitrate(session)));
     }
+    return session.getVariants().stream()
+        .map(
+            variant ->
+                new RenditionSpec(
+                    variant.label(), variant.width(), variant.height(), variant.videoBitrate()))
+        .toList();
   }
 
-  private TranscodeHandle startTranscode(RenditionRequest request) {
-    var start =
-        sessionRepository
-            .beginTranscodeStart(request.sessionId())
-            .orElseThrow(
-                () ->
-                    new com.streamarr.server.exceptions.SessionNotFoundException(
-                        request.sessionId()));
-    TranscodeHandle handle;
-    try {
-      handle = transcodeExecutor.start(request);
-    } catch (RuntimeException exception) {
-      sessionRepository.abortTranscodeStart(start);
-      throw exception;
+  private double executionFramerate(StreamSession session) {
+    var framerate = session.getMediaProbe().framerate();
+    if (requiresVideoTranscode(session.getTranscodeDecision().transcodeMode())
+        || (Double.isFinite(framerate) && framerate > 0)) {
+      return framerate;
     }
-    if (sessionRepository.completeTranscodeStart(start)) {
-      return handle;
-    }
-    finishRejectedStart(start);
-    throw new com.streamarr.server.exceptions.SessionNotFoundException(request.sessionId());
+    return 1.0;
   }
 
-  private void finishRejectedStart(RuntimeTranscodeStart start) {
-    try {
-      transcodeExecutor.stop(start.sessionId());
-      sessionRepository.finishRejectedTranscodeStart(start, true);
-    } catch (RuntimeException exception) {
-      sessionRepository.finishRejectedTranscodeStart(start, false);
-      throw exception;
+  private long defaultRenditionBitrate(StreamSession session) {
+    var bitrate = session.getMediaProbe().bitrate();
+    if (requiresVideoTranscode(session.getTranscodeDecision().transcodeMode()) || bitrate > 0) {
+      return bitrate;
     }
+    return 1;
   }
 
   private static int parseSegmentIndex(String segmentName) {

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/HlsStreamingService.java
@@ -195,19 +195,19 @@ public class HlsStreamingService implements StreamingService {
 
   private void resumeObserved(
       StreamSession session, String segmentName, TranscodeJobState state, int startNumber) {
-    switch (state) {
-      case ADMITTING, RUNNING -> {
-        if (requiresRelocation(session.getSessionId(), segmentName, startNumber)) {
-          startAtRequestedSegment(session, segmentName);
-        }
-      }
-      case COMPLETED, STOPPED, ABSENT -> startAtRequestedSegment(session, segmentName);
-      case FAILED -> {
-        log.warn(
-            "Transcode failed for session {}; replacing missing output", session.getSessionId());
-        startAtRequestedSegment(session, segmentName);
-      }
+    var shouldRestart =
+        switch (state) {
+          case ADMITTING, RUNNING ->
+              requiresRelocation(session.getSessionId(), segmentName, startNumber);
+          case COMPLETED, FAILED, STOPPED, ABSENT -> true;
+        };
+    if (!shouldRestart) {
+      return;
     }
+    if (state == TranscodeJobState.FAILED) {
+      log.warn("Transcode failed for session {}; replacing missing output", session.getSessionId());
+    }
+    startAtRequestedSegment(session, segmentName);
   }
 
   /**

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/SessionReaper.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/SessionReaper.java
@@ -28,7 +28,9 @@ public class SessionReaper {
 
   private void processSession(StreamSession session, Instant now) {
     switch (playbackTranscodeJobService.inspectActive(session.getSessionId())) {
-      case ActiveTranscodeJobInspection.None _ -> {}
+      case ActiveTranscodeJobInspection.None _ -> {
+        // A missing active job means this session is already suspended or never needed a worker.
+      }
       case ActiveTranscodeJobInspection.Unavailable(var jobRef) ->
           log.warn(
               "Unable to inspect active transcode for session {} job {}",

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/SessionReaper.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/SessionReaper.java
@@ -2,8 +2,7 @@ package com.streamarr.server.services.streaming;
 
 import com.streamarr.server.config.StreamingProperties;
 import com.streamarr.server.domain.streaming.StreamSession;
-import com.streamarr.server.domain.streaming.TranscodeHandle;
-import com.streamarr.server.domain.streaming.TranscodeStatus;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class SessionReaper {
 
   private final StreamingService streamingService;
-  private final TranscodeExecutor transcodeExecutor;
+  private final PlaybackTranscodeJobService playbackTranscodeJobService;
   private final StreamingProperties properties;
 
   @Scheduled(fixedDelayString = "${streaming.reaper-interval-ms:15000}")
@@ -28,13 +27,29 @@ public class SessionReaper {
   }
 
   private void processSession(StreamSession session, Instant now) {
-    if (isIdle(session, now) && session.hasActiveTranscodes()) {
-      log.info("Suspending idle session {}", session.getSessionId());
-      suspendSession(session);
+    switch (playbackTranscodeJobService.inspectActive(session.getSessionId())) {
+      case ActiveTranscodeJobInspection.None _ -> {}
+      case ActiveTranscodeJobInspection.Unavailable(var jobRef) ->
+          log.warn(
+              "Unable to inspect active transcode for session {} job {}",
+              session.getSessionId(),
+              jobRef);
+      case ActiveTranscodeJobInspection.Observed(var observation, _) ->
+          processObservation(session, now, observation.state());
+    }
+  }
+
+  private void processObservation(StreamSession session, Instant now, TranscodeJobState state) {
+    if (isIdle(session, now)
+        && (state == TranscodeJobState.ADMITTING || state == TranscodeJobState.RUNNING)) {
+      suspendSession(session.getSessionId());
       return;
     }
-
-    handleDeadProcesses(session);
+    if (state == TranscodeJobState.FAILED) {
+      log.warn(
+          "Transcode failed for session {}; missing output may be replaced",
+          session.getSessionId());
+    }
   }
 
   private boolean isIdle(StreamSession session, Instant now) {
@@ -42,37 +57,10 @@ public class SessionReaper {
     return idleSeconds > properties.sessionTimeout().toSeconds();
   }
 
-  private void suspendSession(StreamSession session) {
-    transcodeExecutor.stop(session.getSessionId());
-    for (var entry : session.getVariantHandles().entrySet()) {
-      var handle = entry.getValue();
-      if (handle.status() != TranscodeStatus.ACTIVE) {
-        continue;
-      }
-
-      session.setVariantHandle(
-          entry.getKey(),
-          new TranscodeHandle(handle.processId(), TranscodeStatus.SUSPENDED, handle.startNumber()));
-    }
-  }
-
-  private void handleDeadProcesses(StreamSession session) {
-    for (var entry : session.getVariantHandles().entrySet()) {
-      var label = entry.getKey();
-      var handle = entry.getValue();
-
-      if (handle.status() != TranscodeStatus.ACTIVE) {
-        continue;
-      }
-
-      if (transcodeExecutor.isRunning(session.getSessionId(), label)) {
-        continue;
-      }
-
-      log.warn("FFmpeg process died for session {} variant {}", session.getSessionId(), label);
-      session.setVariantHandle(
-          label,
-          new TranscodeHandle(handle.processId(), TranscodeStatus.FAILED, handle.startNumber()));
+  private void suspendSession(java.util.UUID sessionId) {
+    log.info("Suspending idle session {}", sessionId);
+    if (playbackTranscodeJobService.suspend(sessionId) == RuntimeTranscodeCleanup.PENDING) {
+      log.warn("Suspension cleanup remains pending for session {}", sessionId);
     }
   }
 }

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/local/InMemoryStreamSessionRepository.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/local/InMemoryStreamSessionRepository.java
@@ -41,7 +41,7 @@ public class InMemoryStreamSessionRepository implements RuntimeStreamSessionRegi
     private int starters;
     private final AtomicReference<CompletableFuture<Void>> startersDrained =
         new AtomicReference<>(CompletableFuture.completedFuture(null));
-    private boolean runtimeStopped;
+    private boolean runtimeStopped = true;
     private boolean reclaimRequested;
 
     private Slot(int inFlight) {

--- a/streamarr-server/src/test/java/com/streamarr/server/config/StreamingConfigTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/config/StreamingConfigTest.java
@@ -1,0 +1,25 @@
+package com.streamarr.server.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Streaming Configuration Tests")
+class StreamingConfigTest {
+
+  @Test
+  @DisplayName("Should retain local worker identity and create a new boot identity per context")
+  void shouldRetainLocalWorkerIdentityAndCreateNewBootIdentityPerContext() {
+    var config = new StreamingConfig();
+
+    var firstBoot = config.localWorkerTarget();
+    var secondBoot = config.localWorkerTarget();
+
+    assertThat(firstBoot.workerId()).isEqualTo(StreamingConfig.LOCAL_WORKER_ID);
+    assertThat(secondBoot.workerId()).isEqualTo(firstBoot.workerId());
+    assertThat(secondBoot.bootId()).isNotEqualTo(firstBoot.bootId());
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeMediaSourceCatalog.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakeMediaSourceCatalog.java
@@ -1,0 +1,19 @@
+package com.streamarr.server.fakes;
+
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import java.nio.file.Path;
+import java.util.UUID;
+
+public class FakeMediaSourceCatalog implements MediaSourceCatalog {
+
+  @Override
+  public MediaSourceRef referenceFor(UUID mediaFileId) {
+    return new MediaSourceRef(mediaFileId, "media/source.mkv");
+  }
+
+  @Override
+  public Path resolve(MediaSourceRef source) {
+    return Path.of("/media").resolve(source.relativeKey());
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakePlaybackTranscodeJobService.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakePlaybackTranscodeJobService.java
@@ -1,0 +1,150 @@
+package com.streamarr.server.fakes;
+
+import com.streamarr.server.services.streaming.ActiveTranscodeJobInspection;
+import com.streamarr.server.services.streaming.PlaybackTranscodeJobService;
+import com.streamarr.server.services.streaming.RuntimeTranscodeCleanup;
+import com.streamarr.server.services.streaming.StartPlaybackTranscodeJobCommand;
+import com.streamarr.transcode.engine.model.RenditionObservation;
+import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class FakePlaybackTranscodeJobService implements PlaybackTranscodeJobService {
+
+  private final CopyOnWriteArrayList<StartPlaybackTranscodeJobCommand> starts =
+      new CopyOnWriteArrayList<>();
+  private final ConcurrentHashMap<UUID, Long> generations = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<UUID, ActiveTranscodeJobInspection> inspections =
+      new ConcurrentHashMap<>();
+  private final CopyOnWriteArrayList<UUID> terminalCleanups = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<UUID> suspensions = new CopyOnWriteArrayList<>();
+  private final ConcurrentHashMap<UUID, RuntimeTranscodeCleanup> terminalCleanupBySession =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<UUID, RuntimeException> terminalCleanupFailuresBySession =
+      new ConcurrentHashMap<>();
+  private volatile RuntimeTranscodeCleanup terminalCleanup = RuntimeTranscodeCleanup.COMPLETE;
+
+  @Override
+  public TranscodeJobObservation start(StartPlaybackTranscodeJobCommand command) {
+    starts.add(command);
+    var generation =
+        generations.compute(command.sessionId(), (_, current) -> current == null ? 1 : current + 1);
+    var observation =
+        TranscodeJobObservation.builder()
+            .jobRef(new TranscodeJobRef(command.sessionId(), generation))
+            .state(TranscodeJobState.RUNNING)
+            .renditions(
+                command.renditions().stream()
+                    .map(
+                        rendition ->
+                            new RenditionObservation(rendition.label(), RenditionState.RUNNING))
+                    .toList())
+            .build();
+    inspections.put(
+        command.sessionId(),
+        new ActiveTranscodeJobInspection.Observed(observation, command.execution().startNumber()));
+    return observation;
+  }
+
+  public List<StartPlaybackTranscodeJobCommand> startCommands() {
+    return List.copyOf(starts);
+  }
+
+  @Override
+  public ActiveTranscodeJobInspection inspectActive(UUID sessionId) {
+    return inspections.getOrDefault(sessionId, new ActiveTranscodeJobInspection.None());
+  }
+
+  @Override
+  public RuntimeTranscodeCleanup suspend(UUID sessionId) {
+    suspensions.add(sessionId);
+    inspections.remove(sessionId);
+    return RuntimeTranscodeCleanup.COMPLETE;
+  }
+
+  @Override
+  public RuntimeTranscodeCleanup cleanupTerminal(UUID sessionId) {
+    terminalCleanups.add(sessionId);
+    var failure = terminalCleanupFailuresBySession.get(sessionId);
+    if (failure != null) {
+      throw failure;
+    }
+    var result = terminalCleanupBySession.getOrDefault(sessionId, terminalCleanup);
+    if (result == RuntimeTranscodeCleanup.COMPLETE) {
+      inspections.remove(sessionId);
+    }
+    return result;
+  }
+
+  public void makeInspectionUnavailable(UUID sessionId) {
+    var current = (ActiveTranscodeJobInspection.Observed) inspections.get(sessionId);
+    inspections.put(
+        sessionId, new ActiveTranscodeJobInspection.Unavailable(current.observation().jobRef()));
+  }
+
+  public void observe(UUID sessionId, TranscodeJobState state, int startNumber) {
+    var generation =
+        generations.compute(sessionId, (_, current) -> current == null ? 1 : current + 1);
+    var observation =
+        TranscodeJobObservation.builder()
+            .jobRef(new TranscodeJobRef(sessionId, generation))
+            .state(state)
+            .renditions(observedRenditions(state))
+            .build();
+    inspections.put(sessionId, new ActiveTranscodeJobInspection.Observed(observation, startNumber));
+  }
+
+  public List<UUID> suspensionAttempts() {
+    return List.copyOf(suspensions);
+  }
+
+  private static List<RenditionObservation> observedRenditions(TranscodeJobState state) {
+    if (state == TranscodeJobState.ABSENT) {
+      return List.of();
+    }
+    var renditionState =
+        switch (state) {
+          case ADMITTING -> RenditionState.STARTING;
+          case RUNNING -> RenditionState.RUNNING;
+          case COMPLETED -> RenditionState.COMPLETED;
+          case FAILED -> RenditionState.FAILED;
+          case STOPPED -> RenditionState.STOPPED;
+          case ABSENT -> throw new IllegalStateException("Absent has no rendition observation");
+        };
+    return List.of(new RenditionObservation("default", renditionState));
+  }
+
+  public void returnTerminalCleanup(RuntimeTranscodeCleanup result) {
+    terminalCleanup = result;
+  }
+
+  public void returnTerminalCleanup(UUID sessionId, RuntimeTranscodeCleanup result) {
+    terminalCleanupBySession.put(sessionId, result);
+    terminalCleanupFailuresBySession.remove(sessionId);
+  }
+
+  public void failTerminalCleanup(UUID sessionId, RuntimeException failure) {
+    terminalCleanupFailuresBySession.put(sessionId, failure);
+    terminalCleanupBySession.remove(sessionId);
+  }
+
+  public List<UUID> terminalCleanupAttempts() {
+    return List.copyOf(terminalCleanups);
+  }
+
+  public void reset() {
+    starts.clear();
+    generations.clear();
+    inspections.clear();
+    terminalCleanups.clear();
+    suspensions.clear();
+    terminalCleanupBySession.clear();
+    terminalCleanupFailuresBySession.clear();
+    terminalCleanup = RuntimeTranscodeCleanup.COMPLETE;
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/fakes/FakePlaybackTranscodeJobService.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/fakes/FakePlaybackTranscodeJobService.java
@@ -28,6 +28,7 @@ public class FakePlaybackTranscodeJobService implements PlaybackTranscodeJobServ
   private final ConcurrentHashMap<UUID, RuntimeException> terminalCleanupFailuresBySession =
       new ConcurrentHashMap<>();
   private volatile RuntimeTranscodeCleanup terminalCleanup = RuntimeTranscodeCleanup.COMPLETE;
+  private volatile RuntimeTranscodeCleanup suspensionCleanup = RuntimeTranscodeCleanup.COMPLETE;
 
   @Override
   public TranscodeJobObservation start(StartPlaybackTranscodeJobCommand command) {
@@ -64,7 +65,7 @@ public class FakePlaybackTranscodeJobService implements PlaybackTranscodeJobServ
   public RuntimeTranscodeCleanup suspend(UUID sessionId) {
     suspensions.add(sessionId);
     inspections.remove(sessionId);
-    return RuntimeTranscodeCleanup.COMPLETE;
+    return suspensionCleanup;
   }
 
   @Override
@@ -101,6 +102,10 @@ public class FakePlaybackTranscodeJobService implements PlaybackTranscodeJobServ
 
   public List<UUID> suspensionAttempts() {
     return List.copyOf(suspensions);
+  }
+
+  public void returnSuspensionCleanup(RuntimeTranscodeCleanup result) {
+    suspensionCleanup = result;
   }
 
   private static List<RenditionObservation> observedRenditions(TranscodeJobState state) {
@@ -146,5 +151,6 @@ public class FakePlaybackTranscodeJobService implements PlaybackTranscodeJobServ
     terminalCleanupBySession.clear();
     terminalCleanupFailuresBySession.clear();
     terminalCleanup = RuntimeTranscodeCleanup.COMPLETE;
+    suspensionCleanup = RuntimeTranscodeCleanup.COMPLETE;
   }
 }

--- a/streamarr-server/src/test/java/com/streamarr/server/services/library/LibraryManagementServiceRemoveIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/library/LibraryManagementServiceRemoveIT.java
@@ -22,8 +22,9 @@ import com.streamarr.server.exceptions.LibraryNotFoundException;
 import com.streamarr.server.exceptions.LibraryRefreshInProgressException;
 import com.streamarr.server.exceptions.LibraryScanInProgressException;
 import com.streamarr.server.fakes.FakeFfprobeService;
+import com.streamarr.server.fakes.FakeMediaSourceCatalog;
+import com.streamarr.server.fakes.FakePlaybackTranscodeJobService;
 import com.streamarr.server.fakes.FakeSegmentStore;
-import com.streamarr.server.fakes.FakeTranscodeExecutor;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
 import com.streamarr.server.jooq.generated.enums.StreamSessionStatus;
 import com.streamarr.server.jooq.generated.enums.StreamSessionTerminalReason;
@@ -42,9 +43,11 @@ import com.streamarr.server.services.streaming.CreatePlaybackSessionCommand;
 import com.streamarr.server.services.streaming.FfprobeService;
 import com.streamarr.server.services.streaming.PersistedStreamSessionReaper;
 import com.streamarr.server.services.streaming.PlaybackSessionCreationService;
+import com.streamarr.server.services.streaming.PlaybackTranscodeJobService;
+import com.streamarr.server.services.streaming.RuntimeTranscodeCleanup;
 import com.streamarr.server.services.streaming.SegmentStore;
 import com.streamarr.server.services.streaming.StreamingService;
-import com.streamarr.server.services.streaming.TranscodeExecutor;
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
 import com.streamarr.server.support.AuthTestSupport;
 import com.streamarr.server.support.AuthTestSupport.TestIdentity;
 import java.io.IOException;
@@ -124,17 +127,23 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
 
   @Autowired private DSLContext dsl;
 
-  @TestBean TranscodeExecutor transcodeExecutor;
+  @TestBean PlaybackTranscodeJobService playbackTranscodeJobService;
+  @TestBean MediaSourceCatalog libraryMediaSourceCatalog;
   @TestBean FfprobeService ffprobeService;
   @TestBean SegmentStore segmentStore;
 
-  private static final StopFailingTranscodeExecutor FAKE_EXECUTOR =
-      new StopFailingTranscodeExecutor();
+  private static final FakePlaybackTranscodeJobService FAKE_TRANSCODE_JOBS =
+      new FakePlaybackTranscodeJobService();
+  private static final FakeMediaSourceCatalog FAKE_SOURCE_CATALOG = new FakeMediaSourceCatalog();
   private static final FakeFfprobeService FAKE_FFPROBE = new FakeFfprobeService();
   private static final FakeSegmentStore FAKE_SEGMENT_STORE = new FakeSegmentStore();
 
-  static TranscodeExecutor transcodeExecutor() {
-    return FAKE_EXECUTOR;
+  static PlaybackTranscodeJobService playbackTranscodeJobService() {
+    return FAKE_TRANSCODE_JOBS;
+  }
+
+  static MediaSourceCatalog libraryMediaSourceCatalog() {
+    return FAKE_SOURCE_CATALOG;
   }
 
   static FfprobeService ffprobeService() {
@@ -153,7 +162,7 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
     seriesRepository.deleteAll();
     movieRepository.deleteAll();
     libraryRepository.deleteAll();
-    FAKE_EXECUTOR.reset();
+    FAKE_TRANSCODE_JOBS.reset();
   }
 
   @Test
@@ -305,9 +314,9 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
       assertThat(streamingService.getActiveSessionCount())
           .as("Streaming session should be terminated when library is removed")
           .isZero();
-      assertThat(FAKE_EXECUTOR.getStopped())
-          .as("Transcode process should be stopped")
-          .contains(fixture.streamSessionId());
+      assertThat(FAKE_TRANSCODE_JOBS.terminalCleanupAttempts())
+          .as("Exact transcode cleanup should be attempted once")
+          .containsExactly(fixture.streamSessionId());
     } finally {
       cleanupFixture(fixture);
     }
@@ -319,7 +328,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
     var fixture = createActiveStream("Retained Streaming Movie", "/test/retained-streaming.mkv");
 
     try {
-      FAKE_EXECUTOR.failStopFor(fixture.streamSessionId());
+      FAKE_TRANSCODE_JOBS.returnTerminalCleanup(
+          fixture.streamSessionId(), RuntimeTranscodeCleanup.PENDING);
 
       libraryManagementService.removeLibrary(fixture.libraryId());
 
@@ -330,6 +340,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
           .isTrue();
       assertThat(intentExists("media_file_deletion_intent", "media_file_id", fixture.mediaFileId()))
           .isTrue();
+      assertThat(FAKE_TRANSCODE_JOBS.terminalCleanupAttempts())
+          .containsExactly(fixture.streamSessionId());
     } finally {
       cleanupFixture(fixture);
     }
@@ -341,10 +353,12 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
     var fixture = createActiveStream("Retried Streaming Movie", "/test/retried-streaming.mkv");
 
     try {
-      FAKE_EXECUTOR.failStopFor(fixture.streamSessionId());
+      FAKE_TRANSCODE_JOBS.returnTerminalCleanup(
+          fixture.streamSessionId(), RuntimeTranscodeCleanup.PENDING);
       libraryManagementService.removeLibrary(fixture.libraryId());
 
-      FAKE_EXECUTOR.allowStopFor(fixture.streamSessionId());
+      FAKE_TRANSCODE_JOBS.returnTerminalCleanup(
+          fixture.streamSessionId(), RuntimeTranscodeCleanup.COMPLETE);
       deletionRetryWorker.retryPending();
 
       assertThat(libraryRepository.findById(fixture.libraryId())).isEmpty();
@@ -352,6 +366,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
       assertStreamMissing(fixture.streamSessionId());
       assertThat(intentExists("library_deletion_intent", "library_id", fixture.libraryId()))
           .isFalse();
+      assertThat(FAKE_TRANSCODE_JOBS.terminalCleanupAttempts())
+          .containsExactly(fixture.streamSessionId(), fixture.streamSessionId());
     } finally {
       cleanupFixture(fixture);
     }
@@ -433,7 +449,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
         createActiveStream("Orphaned Streaming Movie", "/test/missing-orphaned-streaming.mkv");
 
     try {
-      FAKE_EXECUTOR.failStopFor(fixture.streamSessionId());
+      FAKE_TRANSCODE_JOBS.returnTerminalCleanup(
+          fixture.streamSessionId(), RuntimeTranscodeCleanup.PENDING);
 
       orphanedMediaFileCleanupService.cleanupOrphanedFiles(fixture.library());
 
@@ -443,7 +460,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
           .isTrue();
       assertThat(deletionTransactions.finalizeMediaFileDeletion(fixture.mediaFileId())).isFalse();
 
-      FAKE_EXECUTOR.allowStopFor(fixture.streamSessionId());
+      FAKE_TRANSCODE_JOBS.returnTerminalCleanup(
+          fixture.streamSessionId(), RuntimeTranscodeCleanup.COMPLETE);
       deletionRetryWorker.retryPending();
 
       assertThat(mediaFileRepository.findById(fixture.mediaFileId())).isEmpty();
@@ -452,6 +470,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
       assertStreamMissing(fixture.streamSessionId());
       assertThat(intentExists("media_file_deletion_intent", "media_file_id", fixture.mediaFileId()))
           .isFalse();
+      assertThat(FAKE_TRANSCODE_JOBS.terminalCleanupAttempts())
+          .containsExactly(fixture.streamSessionId(), fixture.streamSessionId());
     } finally {
       cleanupFixture(fixture);
     }
@@ -817,7 +837,8 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
   }
 
   private void cleanupFixture(ActiveStreamFixture fixture) {
-    FAKE_EXECUTOR.allowStopFor(fixture.streamSessionId());
+    FAKE_TRANSCODE_JOBS.returnTerminalCleanup(
+        fixture.streamSessionId(), RuntimeTranscodeCleanup.COMPLETE);
     deletionRetryWorker.retryPending();
     streamingService.terminateRuntime(fixture.streamSessionId());
     dsl.deleteFrom(STREAM_SESSION).where(STREAM_SESSION.ID.eq(fixture.streamSessionId())).execute();
@@ -854,33 +875,6 @@ class LibraryManagementServiceRemoveIT extends AbstractIntegrationTest {
 
     private UUID libraryId() {
       return library.getId();
-    }
-  }
-
-  private static final class StopFailingTranscodeExecutor extends FakeTranscodeExecutor {
-
-    private final Set<UUID> stopFailures = new java.util.HashSet<>();
-
-    private void failStopFor(UUID streamSessionId) {
-      stopFailures.add(streamSessionId);
-    }
-
-    private void allowStopFor(UUID streamSessionId) {
-      stopFailures.remove(streamSessionId);
-    }
-
-    @Override
-    public void stop(UUID streamSessionId) {
-      if (stopFailures.contains(streamSessionId)) {
-        throw new IllegalStateException("simulated stop failure");
-      }
-      super.stop(streamSessionId);
-    }
-
-    @Override
-    public void reset() {
-      super.reset();
-      stopFailures.clear();
     }
   }
 }

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceIT.java
@@ -7,16 +7,16 @@ import com.streamarr.server.AbstractIntegrationTest;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.MediaFileStatus;
 import com.streamarr.server.domain.streaming.StreamingOptions;
-import com.streamarr.server.domain.streaming.TranscodeHandle;
-import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.exceptions.MediaFileNotFoundException;
 import com.streamarr.server.fakes.FakeFfprobeService;
+import com.streamarr.server.fakes.FakeMediaSourceCatalog;
+import com.streamarr.server.fakes.FakePlaybackTranscodeJobService;
 import com.streamarr.server.fakes.FakeSegmentStore;
-import com.streamarr.server.fakes.FakeTranscodeExecutor;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
 import com.streamarr.server.repositories.LibraryRepository;
 import com.streamarr.server.repositories.media.MediaFileRepository;
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,16 +35,19 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
   @Autowired private MediaFileRepository mediaFileRepository;
   @Autowired private LibraryRepository libraryRepository;
 
-  @TestBean TranscodeExecutor transcodeExecutor;
+  @TestBean PlaybackTranscodeJobService playbackTranscodeJobService;
   @TestBean FfprobeService ffprobeService;
   @TestBean SegmentStore segmentStore;
+  @TestBean MediaSourceCatalog libraryMediaSourceCatalog;
 
-  private static final FakeTranscodeExecutor FAKE_EXECUTOR = new FakeTranscodeExecutor();
+  private static final FakePlaybackTranscodeJobService FAKE_TRANSCODE_JOBS =
+      new FakePlaybackTranscodeJobService();
   private static final FakeFfprobeService FAKE_FFPROBE = new FakeFfprobeService();
   private static final FakeSegmentStore FAKE_SEGMENT_STORE = new FakeSegmentStore();
+  private static final FakeMediaSourceCatalog FAKE_SOURCE_CATALOG = new FakeMediaSourceCatalog();
 
-  static TranscodeExecutor transcodeExecutor() {
-    return FAKE_EXECUTOR;
+  static PlaybackTranscodeJobService playbackTranscodeJobService() {
+    return FAKE_TRANSCODE_JOBS;
   }
 
   static FfprobeService ffprobeService() {
@@ -55,10 +58,15 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
     return FAKE_SEGMENT_STORE;
   }
 
+  static MediaSourceCatalog libraryMediaSourceCatalog() {
+    return FAKE_SOURCE_CATALOG;
+  }
+
   private MediaFile savedMediaFile;
 
   @BeforeEach
   void setUp() {
+    FAKE_TRANSCODE_JOBS.reset();
     var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
 
     var file =
@@ -89,7 +97,12 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
 
     assertThat(session.getMediaProbe()).isNotNull();
     assertThat(session.getTranscodeDecision()).isNotNull();
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
+    assertThat(FAKE_TRANSCODE_JOBS.inspectActive(session.getSessionId()))
+        .isInstanceOfSatisfying(
+            ActiveTranscodeJobInspection.Observed.class,
+            active ->
+                assertThat(active.observation().state())
+                    .isEqualTo(com.streamarr.transcode.engine.model.TranscodeJobState.RUNNING));
   }
 
   @Test
@@ -128,15 +141,14 @@ class HlsStreamingServiceIT extends AbstractIntegrationTest {
   @DisplayName("Should resume transcode when segment requested from suspended session")
   void shouldResumeTranscodeWhenSegmentRequestedFromSuspendedSession() {
     var session = createSession(savedMediaFile.getId(), UUID.randomUUID(), defaultOptions());
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-
-    session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    FAKE_EXECUTOR.markDead(session.getSessionId());
+    var startsBefore = FAKE_TRANSCODE_JOBS.startCommands().size();
+    FAKE_TRANSCODE_JOBS.suspend(session.getSessionId());
 
     streamingService.resumeSessionIfNeeded(session.getSessionId(), "segment0.ts");
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-    assertThat(FAKE_EXECUTOR.isRunning(session.getSessionId())).isTrue();
+    assertThat(FAKE_TRANSCODE_JOBS.startCommands()).hasSize(startsBefore + 1);
+    assertThat(FAKE_TRANSCODE_JOBS.inspectActive(session.getSessionId()))
+        .isInstanceOf(ActiveTranscodeJobInspection.Observed.class);
   }
 
   private StreamingOptions defaultOptions() {

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.LoggerFactory;
 
 @Tag("UnitTest")
@@ -131,6 +133,30 @@ class HlsStreamingServiceTest {
                 reservation, StreamSession.builder().sessionId(streamSessionId).build()))
         .isFalse();
     assertThat(shutdownRegistry.beginTranscodeStart(streamSessionId)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should finish fencing when shutdown cleanup remains pending")
+  void shouldFinishFencingWhenShutdownCleanupRemainsPending() {
+    var session = createSession(seedMediaFile().getId(), UUID.randomUUID(), defaultOptions());
+    transcodeJobService.returnTerminalCleanup(RuntimeTranscodeCleanup.PENDING);
+    var logger = (Logger) LoggerFactory.getLogger(HlsStreamingService.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+
+    try {
+      service.shutdownRuntime();
+    } finally {
+      logger.detachAppender(appender);
+    }
+
+    assertThat(transcodeJobService.terminalCleanupAttempts())
+        .containsExactly(session.getSessionId());
+    assertThat(appender.list)
+        .filteredOn(event -> event.getLevel() == Level.WARN)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .anyMatch(message -> message.contains(session.getSessionId().toString()));
   }
 
   @Test
@@ -395,8 +421,24 @@ class HlsStreamingServiceTest {
     transcodeJobService.makeInspectionUnavailable(sessions.getFirst().getSessionId());
     var oneMore = seedMediaFile();
     var mediaFileId = oneMore.getId();
+    var profileId = UUID.randomUUID();
+    var options = fullHdOptions();
 
-    assertThatThrownBy(() -> createSession(mediaFileId, UUID.randomUUID(), fullHdOptions()))
+    assertThatThrownBy(() -> createSession(mediaFileId, profileId, options))
+        .isInstanceOf(MaxConcurrentTranscodesException.class);
+  }
+
+  @Test
+  @DisplayName("Should consume capacity while a whole job is admitting")
+  void shouldConsumeCapacityWhileWholeJobIsAdmitting() {
+    var sessions = fillTranscodeCapacity();
+    transcodeJobService.observe(sessions.getFirst().getSessionId(), TranscodeJobState.ADMITTING, 0);
+    var oneMore = seedMediaFile();
+    var mediaFileId = oneMore.getId();
+    var profileId = UUID.randomUUID();
+    var options = fullHdOptions();
+
+    assertThatThrownBy(() -> createSession(mediaFileId, profileId, options))
         .isInstanceOf(MaxConcurrentTranscodesException.class);
   }
 
@@ -668,6 +710,28 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), options);
 
     assertThat(session.getTranscodeDecision().transcodeMode()).isEqualTo(TranscodeMode.REMUX);
+  }
+
+  @Test
+  @DisplayName("Should use a safe execution framerate when remux source reports zero")
+  void shouldUseSafeExecutionFramerateWhenRemuxSourceReportsZero() {
+    ffprobeService.setDefaultProbe(
+        MediaProbe.builder()
+            .duration(Duration.ofMinutes(120))
+            .framerate(0)
+            .width(1920)
+            .height(1080)
+            .videoCodec("h264")
+            .audioCodec("aac")
+            .bitrate(5_000_000L)
+            .build());
+    var file = seedMediaFile();
+    var options = StreamingOptions.builder().supportedCodecs(List.of("h264")).build();
+
+    createSession(file.getId(), UUID.randomUUID(), options);
+
+    assertThat(transcodeJobService.startCommands().getLast().execution().framerate())
+        .isEqualTo(1.0);
   }
 
   @Test
@@ -1220,6 +1284,22 @@ class HlsStreamingServiceTest {
     service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
 
     assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = TranscodeJobState.class,
+      names = {"COMPLETED", "FAILED", "STOPPED", "ABSENT"})
+  @DisplayName("Should restart when an observed whole job cannot produce a missing segment")
+  void shouldRestartWhenObservedWholeJobCannotProduceMissingSegment(TranscodeJobState state) {
+    var session = createSession(seedMediaFile().getId(), UUID.randomUUID(), defaultOptions());
+    transcodeJobService.observe(session.getSessionId(), state, 0);
+    var requestsBefore = transcodeJobService.startCommands().size();
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
+
+    assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore + 1);
+    assertLastStartPosition(5, 30);
   }
 
   @Test

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -3,6 +3,7 @@ package com.streamarr.server.services.streaming;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -21,20 +22,30 @@ import com.streamarr.server.exceptions.MaxConcurrentTranscodesException;
 import com.streamarr.server.exceptions.MediaFileNotFoundException;
 import com.streamarr.server.fakes.FakeFfprobeService;
 import com.streamarr.server.fakes.FakeMediaFileRepository;
+import com.streamarr.server.fakes.FakeMediaSourceCatalog;
+import com.streamarr.server.fakes.FakePlaybackTranscodeJobService;
 import com.streamarr.server.fakes.FakeSegmentStore;
 import com.streamarr.server.fakes.FakeStreamSessionRepository;
 import com.streamarr.server.fakes.FakeTranscodeExecutor;
 import com.streamarr.server.services.concurrency.MutexFactory;
+import com.streamarr.server.services.streaming.worker.InspectJobQuery;
+import com.streamarr.server.services.streaming.worker.InspectJobResult;
+import com.streamarr.server.services.streaming.worker.StartJobCommand;
+import com.streamarr.server.services.streaming.worker.StartJobResult;
+import com.streamarr.server.services.streaming.worker.StopJobCommand;
+import com.streamarr.server.services.streaming.worker.StopJobResult;
+import com.streamarr.server.services.streaming.worker.TranscodeWorkerPort;
+import com.streamarr.server.services.streaming.worker.WorkerTarget;
+import com.streamarr.transcode.engine.model.RenditionObservation;
 import com.streamarr.transcode.engine.model.RenditionRequest;
+import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
 import com.streamarr.transcode.engine.model.TranscodeMode;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -49,6 +60,8 @@ class HlsStreamingServiceTest {
   private FakeTranscodeExecutor transcodeExecutor;
   private FakeSegmentStore segmentStore;
   private FakeFfprobeService ffprobeService;
+  private FakePlaybackTranscodeJobService transcodeJobService;
+  private FakeMediaSourceCatalog mediaSourceCatalog;
   private StreamingProperties properties;
   private RuntimeStreamSessionRegistry runtimeRegistry;
   private HlsStreamingService service;
@@ -59,6 +72,8 @@ class HlsStreamingServiceTest {
     transcodeExecutor = new FakeTranscodeExecutor();
     segmentStore = new FakeSegmentStore();
     ffprobeService = new FakeFfprobeService();
+    transcodeJobService = new FakePlaybackTranscodeJobService();
+    mediaSourceCatalog = new FakeMediaSourceCatalog();
     properties =
         StreamingProperties.builder()
             .maxConcurrentTranscodes(3)
@@ -73,49 +88,15 @@ class HlsStreamingServiceTest {
     service =
         new HlsStreamingService(
             mediaFileRepository,
-            transcodeExecutor,
             segmentStore,
             ffprobeService,
             decisionService,
             qualityLadderService,
             properties,
             runtimeRegistry,
-            new MutexFactory<>());
-  }
-
-  @Test
-  @DisplayName("Should stop a late transcode when destroy wins during startup")
-  void shouldStopLateTranscodeWhenDestroyWinsDuringStartup() throws Exception {
-    var file = seedMediaFile();
-    var streamSessionId = UUID.randomUUID();
-    var blockingExecutor = new BlockingTranscodeExecutor();
-    var racingRegistry = new FakeStreamSessionRepository();
-    var reservation = racingRegistry.reserve(streamSessionId).orElseThrow();
-    var racingService = createService(blockingExecutor, racingRegistry);
-
-    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-      var creation =
-          executor.submit(
-              () ->
-                  racingService.createSession(
-                      CreateRuntimeStreamSessionCommand.builder()
-                          .streamSessionId(streamSessionId)
-                          .mediaFileId(file.getId())
-                          .profileId(UUID.randomUUID())
-                          .options(defaultOptions())
-                          .initialLastAccessedAt(Instant.now())
-                          .reservation(reservation)
-                          .build()));
-      assertThat(blockingExecutor.awaitStart()).isTrue();
-
-      racingService.destroySession(streamSessionId);
-      blockingExecutor.releaseStart();
-      assertThatThrownBy(() -> creation.get(5, TimeUnit.SECONDS))
-          .hasCauseInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
-    }
-
-    assertThat(racingService.accessSession(streamSessionId)).isEmpty();
-    assertThat(blockingExecutor.isRunning(streamSessionId)).isFalse();
+            new MutexFactory<>(),
+            transcodeJobService,
+            mediaSourceCatalog);
   }
 
   @Test
@@ -125,24 +106,7 @@ class HlsStreamingServiceTest {
     var streamSessionId = UUID.randomUUID();
     var rejectingRegistry = new RejectingAttachRegistry();
     var reservation = rejectingRegistry.reserve(streamSessionId).orElseThrow();
-    var rejectingService = createService(transcodeExecutor, rejectingRegistry);
-
-    assertThatThrownBy(
-            () ->
-                rejectingService.createSession(
-                    runtimeCreationCommand(streamSessionId, file.getId(), reservation)))
-        .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
-    assertThat(transcodeExecutor.getStarted()).doesNotContain(streamSessionId);
-  }
-
-  @Test
-  @DisplayName("Should reject runtime creation when transcode startup cannot begin")
-  void shouldRejectRuntimeCreationWhenTranscodeStartupCannotBegin() {
-    var file = seedMediaFile();
-    var streamSessionId = UUID.randomUUID();
-    var rejectingRegistry = new RejectingTranscodeStartRegistry();
-    var reservation = rejectingRegistry.reserve(streamSessionId).orElseThrow();
-    var rejectingService = createService(transcodeExecutor, rejectingRegistry);
+    var rejectingService = createService(rejectingRegistry);
 
     assertThatThrownBy(
             () ->
@@ -158,7 +122,7 @@ class HlsStreamingServiceTest {
     var streamSessionId = UUID.randomUUID();
     var shutdownRegistry = new FakeStreamSessionRepository();
     var reservation = shutdownRegistry.reserve(streamSessionId).orElseThrow();
-    var shutdownService = createService(transcodeExecutor, shutdownRegistry);
+    var shutdownService = createService(shutdownRegistry);
 
     shutdownService.shutdownRuntime();
 
@@ -170,52 +134,25 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName("Should wait for in-flight starter before runtime shutdown returns")
-  void shouldWaitForInFlightStarterBeforeRuntimeShutdownReturns() throws Exception {
-    var file = seedMediaFile();
-    var streamSessionId = UUID.randomUUID();
-    var blockingExecutor = new BlockingTranscodeExecutor();
-    var shutdownRegistry = new FakeStreamSessionRepository();
-    var reservation = shutdownRegistry.reserve(streamSessionId).orElseThrow();
-    var shutdownService = createService(blockingExecutor, shutdownRegistry);
+  @DisplayName("Should retain segments and terminal authority while exact cleanup is pending")
+  void shouldRetainSegmentsAndTerminalAuthorityWhileExactCleanupIsPending() {
+    var session = createSession(seedMediaFile().getId(), UUID.randomUUID(), defaultOptions());
+    segmentStore.addSegment(session.getSessionId(), "segment0.ts", new byte[] {1});
+    transcodeJobService.returnTerminalCleanup(RuntimeTranscodeCleanup.PENDING);
 
-    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-      var creation =
-          executor.submit(
-              () ->
-                  shutdownService.createSession(
-                      CreateRuntimeStreamSessionCommand.builder()
-                          .streamSessionId(streamSessionId)
-                          .mediaFileId(file.getId())
-                          .profileId(UUID.randomUUID())
-                          .options(defaultOptions())
-                          .initialLastAccessedAt(Instant.now())
-                          .reservation(reservation)
-                          .build()));
-      assertThat(blockingExecutor.awaitStart()).isTrue();
-      var shutdown = executor.submit(shutdownService::shutdownRuntime);
+    var quiescent = service.terminateRuntime(session.getSessionId());
 
-      try {
-        assertThatThrownBy(() -> shutdown.get(200, TimeUnit.MILLISECONDS))
-            .isInstanceOf(TimeoutException.class);
-      } finally {
-        blockingExecutor.releaseStart();
-      }
-
-      assertThatThrownBy(() -> creation.get(5, TimeUnit.SECONDS))
-          .hasCauseInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
-      shutdown.get(5, TimeUnit.SECONDS);
-    }
-
-    assertThat(blockingExecutor.isRunning(streamSessionId)).isFalse();
+    assertThat(quiescent).isFalse();
+    assertThat(segmentStore.segmentExists(session.getSessionId(), "segment0.ts")).isTrue();
+    assertThat(transcodeJobService.terminalCleanupAttempts())
+        .containsExactly(session.getSessionId());
   }
 
   @Test
   @DisplayName("Should isolate a stop failure while shutting down runtime sessions")
   void shouldIsolateStopFailureWhileShuttingDownRuntimeSessions() {
-    var shutdownExecutor = new SelectiveStopFailureTranscodeExecutor();
     var shutdownRegistry = new OrderedFenceRegistry();
-    var shutdownService = createService(shutdownExecutor, shutdownRegistry);
+    var shutdownService = createService(shutdownRegistry);
     var failingSession =
         RuntimeStreamSessionTestDriver.create(
             shutdownService,
@@ -230,57 +167,29 @@ class HlsStreamingServiceTest {
             seedMediaFile().getId(),
             UUID.randomUUID(),
             defaultOptions());
-    shutdownExecutor.failStopping(failingSession.getSessionId());
+    transcodeJobService.failTerminalCleanup(
+        failingSession.getSessionId(), new IllegalStateException("stop failed"));
     shutdownRegistry.fenceInOrder(failingSession.getSessionId(), healthySession.getSessionId());
 
     assertThatNoException().isThrownBy(shutdownService::shutdownRuntime);
 
-    assertThat(shutdownExecutor.isRunning(healthySession.getSessionId())).isFalse();
-    assertThat(shutdownExecutor.isRunning(failingSession.getSessionId())).isFalse();
-    assertThat(shutdownExecutor.getStopped()).contains(healthySession.getSessionId());
-    assertThat(shutdownExecutor.getForceStopAllAttempts()).isEqualTo(1);
+    assertThat(transcodeJobService.terminalCleanupAttempts())
+        .containsExactly(failingSession.getSessionId(), healthySession.getSessionId());
     assertThat(shutdownService.getAllSessions()).isEmpty();
   }
 
-  @Test
-  @DisplayName("Should retain failed late startup bookkeeping when its stop fails")
-  void shouldRetainFailedLateStartupBookkeepingWhenItsStopFails() {
-    var file = seedMediaFile();
-    var streamSessionId = UUID.randomUUID();
-    var rejectingRegistry = new RejectingCompletedStartRegistry();
-    var reservation = rejectingRegistry.reserve(streamSessionId).orElseThrow();
-    var failingExecutor = new StopFailureTranscodeExecutor();
-    var rejectingService = createService(failingExecutor, rejectingRegistry);
-    var command = runtimeCreationCommand(streamSessionId, file.getId(), reservation);
-
-    assertThatThrownBy(() -> rejectingService.createSession(command))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("stop failed");
-
-    rejectingRegistry.releaseReservation(reservation);
-    assertThat(rejectingRegistry.releaseTerminal(streamSessionId)).isFalse();
-    assertThat(rejectingRegistry.reserve(streamSessionId)).isEmpty();
-    assertThat(failingExecutor.isRunning(streamSessionId)).isTrue();
-
-    assertThat(rejectingService.terminateRuntime(streamSessionId)).isTrue();
-    assertThat(failingExecutor.isRunning(streamSessionId)).isFalse();
-    var replacement = rejectingRegistry.reserve(streamSessionId);
-    assertThat(replacement).isPresent();
-    rejectingRegistry.releaseReservation(replacement.orElseThrow());
-  }
-
-  private HlsStreamingService createService(
-      TranscodeExecutor executor, RuntimeStreamSessionRegistry repository) {
+  private HlsStreamingService createService(RuntimeStreamSessionRegistry repository) {
     return new HlsStreamingService(
         mediaFileRepository,
-        executor,
         segmentStore,
         ffprobeService,
         new TranscodeDecisionService(),
         new QualityLadderService(),
         properties,
         repository,
-        new MutexFactory<>());
+        new MutexFactory<>(),
+        transcodeJobService,
+        mediaSourceCatalog);
   }
 
   private StreamSession createSession(UUID mediaFileId, UUID profileId, StreamingOptions options) {
@@ -356,8 +265,9 @@ class HlsStreamingServiceTest {
 
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
 
-    assertThat(transcodeExecutor.getStarted()).contains(session.getSessionId());
-    assertThat(transcodeExecutor.isRunning(session.getSessionId())).isTrue();
+    assertThat(transcodeJobService.startCommands())
+        .singleElement()
+        .satisfies(command -> assertThat(command.sessionId()).isEqualTo(session.getSessionId()));
   }
 
   @Test
@@ -405,16 +315,16 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName("Should remove session and stop transcode when session is destroyed")
-  void shouldRemoveSessionAndStopTranscodeWhenSessionIsDestroyed() {
+  @DisplayName("Should remove session after exact transcode cleanup when session is destroyed")
+  void shouldRemoveSessionAfterExactTranscodeCleanupWhenSessionIsDestroyed() {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
 
     service.destroySession(session.getSessionId());
 
     assertThat(service.accessSession(session.getSessionId())).isEmpty();
-    assertThat(transcodeExecutor.getStopped()).contains(session.getSessionId());
-    assertThat(transcodeExecutor.isRunning(session.getSessionId())).isFalse();
+    assertThat(transcodeJobService.terminalCleanupAttempts())
+        .containsExactly(session.getSessionId());
   }
 
   @Test
@@ -453,6 +363,73 @@ class HlsStreamingServiceTest {
   @Test
   @DisplayName("Should not count suspended sessions against transcode limit")
   void shouldNotCountSuspendedSessionsAgainstTranscodeLimit() {
+    var sessions = fillTranscodeCapacity();
+
+    var suspended = sessions.getFirst();
+    transcodeJobService.suspend(suspended.getSessionId());
+
+    var oneMore = seedMediaFile();
+    var newSession = createSession(oneMore.getId(), UUID.randomUUID(), fullHdOptions());
+
+    assertThat(newSession).isNotNull();
+  }
+
+  @Test
+  @DisplayName("Should not count a completed whole job against transcode capacity")
+  void shouldNotCountCompletedWholeJobAgainstTranscodeCapacity() {
+    var sessions = fillTranscodeCapacity();
+    transcodeJobService.observe(
+        sessions.getFirst().getSessionId(),
+        com.streamarr.transcode.engine.model.TranscodeJobState.COMPLETED,
+        0);
+
+    var oneMore = seedMediaFile();
+
+    assertThat(createSession(oneMore.getId(), UUID.randomUUID(), fullHdOptions())).isNotNull();
+  }
+
+  @Test
+  @DisplayName("Should consume capacity when active whole-job inspection is unavailable")
+  void shouldConsumeCapacityWhenActiveWholeJobInspectionIsUnavailable() {
+    var sessions = fillTranscodeCapacity();
+    transcodeJobService.makeInspectionUnavailable(sessions.getFirst().getSessionId());
+    var oneMore = seedMediaFile();
+    var mediaFileId = oneMore.getId();
+
+    assertThatThrownBy(() -> createSession(mediaFileId, UUID.randomUUID(), fullHdOptions()))
+        .isInstanceOf(MaxConcurrentTranscodesException.class);
+  }
+
+  @Test
+  @DisplayName("Should reserve final transcode slot while whole-job start is unresolved")
+  void shouldReserveFinalTranscodeSlotWhileWholeJobStartIsUnresolved() throws Exception {
+    var worker = new BlockingTranscodeWorker();
+    var limitedProperties =
+        StreamingProperties.builder()
+            .maxConcurrentTranscodes(1)
+            .segmentDuration(Duration.ofSeconds(6))
+            .sessionTimeout(Duration.ofSeconds(60))
+            .build();
+    var limitedRegistry = new FakeStreamSessionRepository();
+    var blockingJobs =
+        DefaultPlaybackTranscodeJobService.builder()
+            .worker(worker)
+            .workerTarget(worker.target())
+            .runtimeRegistry(limitedRegistry)
+            .sessionMutexes(new MutexFactory<>())
+            .build();
+    var limitedService =
+        new HlsStreamingService(
+            mediaFileRepository,
+            segmentStore,
+            ffprobeService,
+            new TranscodeDecisionService(),
+            new QualityLadderService(),
+            limitedProperties,
+            limitedRegistry,
+            new MutexFactory<>(),
+            blockingJobs,
+            mediaSourceCatalog);
     ffprobeService.setDefaultProbe(
         MediaProbe.builder()
             .duration(Duration.ofMinutes(120))
@@ -463,26 +440,38 @@ class HlsStreamingServiceTest {
             .audioCodec("aac")
             .bitrate(5_000_000L)
             .build());
+    var firstFile = seedMediaFile();
+    var secondFile = seedMediaFile();
+    Throwable secondOutcome;
 
-    var options =
-        StreamingOptions.builder()
-            .quality(VideoQuality.FULL_HD_1080P)
-            .supportedCodecs(List.of("h264"))
-            .build();
-
-    var sessions = new java.util.ArrayList<StreamSession>();
-    for (int i = 0; i < 3; i++) {
-      var file = seedMediaFile();
-      sessions.add(createSession(file.getId(), UUID.randomUUID(), options));
+    try (var executor = java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor()) {
+      var first =
+          executor.submit(
+              () ->
+                  RuntimeStreamSessionTestDriver.create(
+                      limitedService,
+                      limitedRegistry,
+                      firstFile.getId(),
+                      UUID.randomUUID(),
+                      fullHdOptions()));
+      assertThat(worker.awaitStart()).isTrue();
+      try {
+        secondOutcome =
+            catchThrowable(
+                () ->
+                    RuntimeStreamSessionTestDriver.create(
+                        limitedService,
+                        limitedRegistry,
+                        secondFile.getId(),
+                        UUID.randomUUID(),
+                        fullHdOptions()));
+      } finally {
+        worker.releaseStart();
+      }
+      assertThat(first.get(5, java.util.concurrent.TimeUnit.SECONDS)).isNotNull();
     }
 
-    var suspended = sessions.getFirst();
-    suspended.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-
-    var oneMore = seedMediaFile();
-    var newSession = createSession(oneMore.getId(), UUID.randomUUID(), options);
-
-    assertThat(newSession).isNotNull();
+    assertThat(secondOutcome).isInstanceOf(MaxConcurrentTranscodesException.class);
   }
 
   @Test
@@ -590,7 +579,8 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), options);
 
     assertThat(session.getVariants()).hasSizeGreaterThan(1);
-    assertThat(session.getVariantHandles()).hasSizeGreaterThan(1);
+    assertThat(transcodeJobService.startCommands().getLast().renditions())
+        .hasSameSizeAs(session.getVariants());
   }
 
   @Test
@@ -606,7 +596,104 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), options);
 
     assertThat(session.getVariants()).isEmpty();
-    assertThat(session.getHandle()).isNotNull();
+    assertThat(transcodeJobService.startCommands().getLast().renditions())
+        .singleElement()
+        .satisfies(
+            rendition -> assertThat(rendition.label()).isEqualTo(RenditionRequest.DEFAULT_VARIANT));
+  }
+
+  @Test
+  @DisplayName("Should create remux session when source bitrate is unavailable")
+  void shouldCreateRemuxSessionWhenSourceBitrateIsUnavailable() {
+    ffprobeService.setDefaultProbe(
+        MediaProbe.builder()
+            .duration(Duration.ofMinutes(120))
+            .framerate(23.976)
+            .width(1920)
+            .height(1080)
+            .videoCodec("h264")
+            .audioCodec("aac")
+            .bitrate(0)
+            .build());
+    var file = seedMediaFile();
+    var options = StreamingOptions.builder().supportedCodecs(List.of("h264")).build();
+
+    var session = createSession(file.getId(), UUID.randomUUID(), options);
+
+    assertThat(session.getTranscodeDecision().transcodeMode()).isEqualTo(TranscodeMode.REMUX);
+  }
+
+  @Test
+  @DisplayName("Should create audio-transcode session when source bitrate is unavailable")
+  void shouldCreateAudioTranscodeSessionWhenSourceBitrateIsUnavailable() {
+    ffprobeService.setDefaultProbe(
+        MediaProbe.builder()
+            .duration(Duration.ofMinutes(120))
+            .framerate(23.976)
+            .width(1920)
+            .height(1080)
+            .videoCodec("h264")
+            .audioCodec("ac3")
+            .bitrate(0)
+            .build());
+    var file = seedMediaFile();
+    var options =
+        StreamingOptions.builder()
+            .supportedCodecs(List.of("h264"))
+            .supportedAudioCodecs(List.of("aac"))
+            .build();
+
+    var session = createSession(file.getId(), UUID.randomUUID(), options);
+
+    assertThat(session.getTranscodeDecision().transcodeMode())
+        .isEqualTo(TranscodeMode.AUDIO_TRANSCODE);
+  }
+
+  @Test
+  @DisplayName("Should create remux session when source framerate is unavailable")
+  void shouldCreateRemuxSessionWhenSourceFramerateIsUnavailable() {
+    ffprobeService.setDefaultProbe(
+        MediaProbe.builder()
+            .duration(Duration.ofMinutes(120))
+            .framerate(Double.NaN)
+            .width(1920)
+            .height(1080)
+            .videoCodec("h264")
+            .audioCodec("aac")
+            .bitrate(5_000_000L)
+            .build());
+    var file = seedMediaFile();
+    var options = StreamingOptions.builder().supportedCodecs(List.of("h264")).build();
+
+    var session = createSession(file.getId(), UUID.randomUUID(), options);
+
+    assertThat(session.getTranscodeDecision().transcodeMode()).isEqualTo(TranscodeMode.REMUX);
+  }
+
+  @Test
+  @DisplayName("Should create audio-transcode session when source framerate is unavailable")
+  void shouldCreateAudioTranscodeSessionWhenSourceFramerateIsUnavailable() {
+    ffprobeService.setDefaultProbe(
+        MediaProbe.builder()
+            .duration(Duration.ofMinutes(120))
+            .framerate(Double.NaN)
+            .width(1920)
+            .height(1080)
+            .videoCodec("h264")
+            .audioCodec("ac3")
+            .bitrate(5_000_000L)
+            .build());
+    var file = seedMediaFile();
+    var options =
+        StreamingOptions.builder()
+            .supportedCodecs(List.of("h264"))
+            .supportedAudioCodecs(List.of("aac"))
+            .build();
+
+    var session = createSession(file.getId(), UUID.randomUUID(), options);
+
+    assertThat(session.getTranscodeDecision().transcodeMode())
+        .isEqualTo(TranscodeMode.AUDIO_TRANSCODE);
   }
 
   @Test
@@ -633,7 +720,10 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), options);
 
     assertThat(session.getVariants()).isEmpty();
-    assertThat(session.getHandle()).isNotNull();
+    assertThat(transcodeJobService.startCommands().getLast().renditions())
+        .singleElement()
+        .satisfies(
+            rendition -> assertThat(rendition.label()).isEqualTo(RenditionRequest.DEFAULT_VARIANT));
   }
 
   @Test
@@ -660,7 +750,8 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), options);
 
     assertThat(session.getVariants()).hasSizeGreaterThan(1);
-    assertThat(transcodeExecutor.getStartedVariants())
+    assertThat(transcodeJobService.startCommands().getLast().renditions())
+        .extracting(com.streamarr.transcode.engine.model.RenditionSpec::label)
         .containsExactlyInAnyOrderElementsOf(
             session.getVariants().stream().map(v -> v.label()).toList());
   }
@@ -718,8 +809,8 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName("Should remove session and stop transcode when destroy requested by owning profile")
-  void shouldRemoveSessionAndStopTranscodeWhenDestroyRequestedByOwningProfile() {
+  @DisplayName("Should clean transcode when destroy is requested by owning profile")
+  void shouldCleanTranscodeWhenDestroyRequestedByOwningProfile() {
     var file = seedMediaFile();
     var profileId = UUID.randomUUID();
     var session = createSession(file.getId(), profileId, defaultOptions());
@@ -727,7 +818,8 @@ class HlsStreamingServiceTest {
     service.destroySession(session.getSessionId(), profileId);
 
     assertThat(service.accessSession(session.getSessionId())).isEmpty();
-    assertThat(transcodeExecutor.getStopped()).contains(session.getSessionId());
+    assertThat(transcodeJobService.terminalCleanupAttempts())
+        .containsExactly(session.getSessionId());
   }
 
   @Test
@@ -769,14 +861,15 @@ class HlsStreamingServiceTest {
     var limitedService =
         new HlsStreamingService(
             mediaFileRepository,
-            new FakeTranscodeExecutor(),
             segmentStore,
             ffprobeService,
             new TranscodeDecisionService(),
             new QualityLadderService(),
             limitedProperties,
             limitedRegistry,
-            new MutexFactory<>());
+            new MutexFactory<>(),
+            new FakePlaybackTranscodeJobService(),
+            new FakeMediaSourceCatalog());
 
     ffprobeService.setDefaultProbe(
         MediaProbe.builder()
@@ -884,12 +977,13 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
+    var startsBefore = transcodeJobService.startCommands().size();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
 
-    assertThat(transcodeExecutor.isRunning(session.getSessionId())).isTrue();
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
+    assertThat(transcodeJobService.startCommands()).hasSize(startsBefore + 1);
+    assertLastStartPosition(5, 30);
   }
 
   @Test
@@ -897,11 +991,11 @@ class HlsStreamingServiceTest {
   void shouldNotRestartFfmpegWhenSessionIsActivelyTranscoding() {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
-    var startedBefore = transcodeExecutor.getStarted().size();
+    var startedBefore = transcodeJobService.startCommands().size();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment0.ts");
 
-    assertThat(transcodeExecutor.getStarted()).hasSize(startedBefore);
+    assertThat(transcodeJobService.startCommands()).hasSize(startedBefore);
   }
 
   @Test
@@ -910,7 +1004,7 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
     segmentStore.addSegment(session.getSessionId(), "segment5.ts", new byte[] {0x47});
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
@@ -932,7 +1026,7 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
     session.setLastAccessedAt(Instant.now().minusSeconds(200));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
     var oldAccessTime = session.getLastAccessedAt();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
@@ -946,14 +1040,11 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.startNumber()).isEqualTo(5);
-    assertThat(lastRequest.seekPosition()).isEqualTo(30);
+    assertLastStartPosition(5, 30);
   }
 
   @Test
@@ -962,14 +1053,11 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment12.m4s");
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.startNumber()).isEqualTo(12);
-    assertThat(lastRequest.seekPosition()).isEqualTo(72);
+    assertLastStartPosition(12, 72);
   }
 
   @Test
@@ -978,14 +1066,11 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "720p/segment3.ts");
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.startNumber()).isEqualTo(3);
-    assertThat(lastRequest.seekPosition()).isEqualTo(18);
+    assertLastStartPosition(3, 18);
   }
 
   @Test
@@ -994,14 +1079,11 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "init.mp4");
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.startNumber()).isZero();
-    assertThat(lastRequest.seekPosition()).isZero();
+    assertLastStartPosition(0, 0);
   }
 
   @Test
@@ -1010,14 +1092,11 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment0.ts");
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.startNumber()).isZero();
-    assertThat(lastRequest.seekPosition()).isZero();
+    assertLastStartPosition(0, 0);
   }
 
   @Test
@@ -1046,25 +1125,19 @@ class HlsStreamingServiceTest {
 
     for (var label : variantLabels) {
       session.setVariantHandle(label, new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-      transcodeExecutor.markDead(session.getSessionId(), label);
     }
+    transcodeJobService.suspend(session.getSessionId());
 
-    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+    var requestsBefore = transcodeJobService.startCommands().size();
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
-    var resumeRequests =
-        transcodeExecutor
-            .getStartedRequests()
-            .subList(requestsBefore, transcodeExecutor.getStartedRequests().size());
+    assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore + 1);
+    var resume = transcodeJobService.startCommands().getLast();
 
-    assertThat(resumeRequests).hasSize(variantLabels.size());
-    assertThat(resumeRequests).extracting(RenditionRequest::startNumber).containsOnly(5);
-    assertThat(resumeRequests).extracting(RenditionRequest::seekPosition).containsOnly(30);
-    assertThat(resumeRequests)
-        .extracting(RenditionRequest::variantLabel)
+    assertThat(resume.execution().startNumber()).isEqualTo(5);
+    assertThat(resume.execution().seekPosition()).isEqualTo(30);
+    assertThat(resume.renditions())
+        .extracting(com.streamarr.transcode.engine.model.RenditionSpec::label)
         .containsExactlyInAnyOrderElementsOf(variantLabels);
-    for (var label : variantLabels) {
-      assertThat(session.getVariantHandle(label).status()).isEqualTo(TranscodeStatus.ACTIVE);
-    }
   }
 
   @Test
@@ -1079,9 +1152,7 @@ class HlsStreamingServiceTest {
     service.resumeSessionIfNeeded(session.getSessionId(), "segment10.ts");
 
     // The encoder started at segment50 and will never produce segment10.
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.seekPosition()).isEqualTo(60);
-    assertThat(lastRequest.startNumber()).isEqualTo(10);
+    assertLastStartPosition(10, 60);
   }
 
   @Test
@@ -1090,13 +1161,13 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var profileId = UUID.randomUUID();
     var session = createSession(file.getId(), profileId, defaultOptions());
+    var legacyStopsBefore = transcodeExecutor.getStopped().size();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
 
     // Nothing near segment100 has been produced; waiting would stall the player.
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.seekPosition()).isEqualTo(600);
-    assertThat(lastRequest.startNumber()).isEqualTo(100);
+    assertLastStartPosition(100, 600);
+    assertThat(transcodeExecutor.getStopped()).hasSize(legacyStopsBefore);
   }
 
   @Test
@@ -1104,12 +1175,12 @@ class HlsStreamingServiceTest {
   void shouldWaitWhenTheRequestedSegmentIsNearTheEncoderStart() {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
-    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+    var requestsBefore = transcodeJobService.startCommands().size();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment2.ts");
 
     // The encoder started at segment0 and will reach segment2 shortly.
-    assertThat(transcodeExecutor.getStartedRequests()).hasSize(requestsBefore);
+    assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore);
   }
 
   @Test
@@ -1118,12 +1189,12 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     segmentStore.addSegment(session.getSessionId(), "segment96.ts", new byte[] {1});
-    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+    var requestsBefore = transcodeJobService.startCommands().size();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
 
     // segment96 exists, so the encoder is close behind the request.
-    assertThat(transcodeExecutor.getStartedRequests()).hasSize(requestsBefore);
+    assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore);
   }
 
   @Test
@@ -1132,11 +1203,23 @@ class HlsStreamingServiceTest {
     var file = seedMediaFile();
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
     segmentStore.addSegment(session.getSessionId(), "segment10.ts", new byte[] {1});
-    var requestsBefore = transcodeExecutor.getStartedRequests().size();
+    var requestsBefore = transcodeJobService.startCommands().size();
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment10.ts");
 
-    assertThat(transcodeExecutor.getStartedRequests()).hasSize(requestsBefore);
+    assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore);
+  }
+
+  @Test
+  @DisplayName("Should fail closed when active whole-job inspection is unavailable")
+  void shouldFailClosedWhenActiveWholeJobInspectionIsUnavailable() {
+    var session = createSession(seedMediaFile().getId(), UUID.randomUUID(), defaultOptions());
+    transcodeJobService.makeInspectionUnavailable(session.getSessionId());
+    var requestsBefore = transcodeJobService.startCommands().size();
+
+    service.resumeSessionIfNeeded(session.getSessionId(), "segment100.ts");
+
+    assertThat(transcodeJobService.startCommands()).hasSize(requestsBefore);
   }
 
   @Test
@@ -1146,71 +1229,44 @@ class HlsStreamingServiceTest {
     var session = createSession(file.getId(), UUID.randomUUID(), defaultOptions());
 
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    transcodeExecutor.markDead(session.getSessionId());
+    transcodeJobService.suspend(session.getSessionId());
 
     service.resumeSessionIfNeeded(session.getSessionId(), "segment5.ts");
 
     // The timeline is absolute: segment5 always covers [30s, 36s).
-    var lastRequest = transcodeExecutor.getStartedRequests().getLast();
-    assertThat(lastRequest.seekPosition()).isEqualTo(30);
-    assertThat(lastRequest.startNumber()).isEqualTo(5);
+    assertLastStartPosition(5, 30);
   }
 
-  private static final class BlockingTranscodeExecutor implements TranscodeExecutor {
+  private void assertLastStartPosition(int startNumber, int seekPosition) {
+    var execution = transcodeJobService.startCommands().getLast().execution();
+    assertThat(execution.startNumber()).isEqualTo(startNumber);
+    assertThat(execution.seekPosition()).isEqualTo(seekPosition);
+  }
 
-    private final FakeTranscodeExecutor delegate = new FakeTranscodeExecutor();
-    private final CountDownLatch startEntered = new CountDownLatch(1);
-    private final CountDownLatch allowStart = new CountDownLatch(1);
-
-    @Override
-    public TranscodeHandle start(RenditionRequest request) {
-      startEntered.countDown();
-      await(allowStart);
-      return delegate.start(request);
+  private List<StreamSession> fillTranscodeCapacity() {
+    ffprobeService.setDefaultProbe(
+        MediaProbe.builder()
+            .duration(Duration.ofMinutes(120))
+            .framerate(23.976)
+            .width(1920)
+            .height(1080)
+            .videoCodec("hevc")
+            .audioCodec("aac")
+            .bitrate(5_000_000L)
+            .build());
+    var sessions = new java.util.ArrayList<StreamSession>();
+    for (int i = 0; i < properties.maxConcurrentTranscodes(); i++) {
+      var file = seedMediaFile();
+      sessions.add(createSession(file.getId(), UUID.randomUUID(), fullHdOptions()));
     }
+    return List.copyOf(sessions);
+  }
 
-    private boolean awaitStart() throws InterruptedException {
-      return startEntered.await(5, TimeUnit.SECONDS);
-    }
-
-    private void releaseStart() {
-      allowStart.countDown();
-    }
-
-    @Override
-    public void stop(UUID sessionId) {
-      delegate.stop(sessionId);
-    }
-
-    @Override
-    public void forceStopAll() {
-      delegate.forceStopAll();
-    }
-
-    @Override
-    public boolean isRunning(UUID sessionId) {
-      return delegate.isRunning(sessionId);
-    }
-
-    @Override
-    public boolean isRunning(UUID sessionId, String variantLabel) {
-      return delegate.isRunning(sessionId, variantLabel);
-    }
-
-    @Override
-    public boolean isHealthy() {
-      return delegate.isHealthy();
-    }
-
-    private static void await(CountDownLatch latch) {
-      try {
-        latch.await();
-      } catch (InterruptedException exception) {
-        Thread.currentThread().interrupt();
-        throw new IllegalStateException(
-            "Interrupted while controlling transcode startup", exception);
-      }
-    }
+  private static StreamingOptions fullHdOptions() {
+    return StreamingOptions.builder()
+        .quality(VideoQuality.FULL_HD_1080P)
+        .supportedCodecs(List.of("h264"))
+        .build();
   }
 
   private static final class RejectingAttachRegistry extends FakeStreamSessionRepository {
@@ -1218,31 +1274,6 @@ class HlsStreamingServiceTest {
     @Override
     public boolean attach(RuntimeSessionReservation reservation, StreamSession session) {
       return false;
-    }
-  }
-
-  private static final class RejectingTranscodeStartRegistry extends FakeStreamSessionRepository {
-
-    @Override
-    public java.util.Optional<RuntimeTranscodeStart> beginTranscodeStart(UUID sessionId) {
-      return java.util.Optional.empty();
-    }
-  }
-
-  private static final class SelectiveStopFailureTranscodeExecutor extends FakeTranscodeExecutor {
-
-    private UUID failingSessionId;
-
-    void failStopping(UUID sessionId) {
-      failingSessionId = sessionId;
-    }
-
-    @Override
-    public void stop(UUID sessionId) {
-      if (sessionId.equals(failingSessionId)) {
-        throw new IllegalStateException("stop failed");
-      }
-      super.stop(sessionId);
     }
   }
 
@@ -1261,26 +1292,66 @@ class HlsStreamingServiceTest {
     }
   }
 
-  private static final class RejectingCompletedStartRegistry extends FakeStreamSessionRepository {
+  private static final class BlockingTranscodeWorker implements TranscodeWorkerPort {
 
-    @Override
-    public boolean completeTranscodeStart(RuntimeTranscodeStart start) {
-      terminalize(start.sessionId());
-      return super.completeTranscodeStart(start);
+    private final WorkerTarget target = new WorkerTarget(UUID.randomUUID(), UUID.randomUUID());
+    private final java.util.concurrent.CountDownLatch startEntered =
+        new java.util.concurrent.CountDownLatch(1);
+    private final java.util.concurrent.CountDownLatch allowStart =
+        new java.util.concurrent.CountDownLatch(1);
+
+    private WorkerTarget target() {
+      return target;
     }
-  }
 
-  private static final class StopFailureTranscodeExecutor extends FakeTranscodeExecutor {
+    private boolean awaitStart() throws InterruptedException {
+      return startEntered.await(5, java.util.concurrent.TimeUnit.SECONDS);
+    }
 
-    private boolean failNextStop = true;
+    private void releaseStart() {
+      allowStart.countDown();
+    }
 
     @Override
-    public void stop(UUID sessionId) {
-      if (failNextStop) {
-        failNextStop = false;
-        throw new IllegalStateException("stop failed");
+    public StartJobResult start(StartJobCommand command) {
+      startEntered.countDown();
+      await(allowStart);
+      var specification = command.specification();
+      return new StartJobResult.Accepted(
+          TranscodeJobObservation.builder()
+              .jobRef(specification.jobRef())
+              .state(TranscodeJobState.RUNNING)
+              .renditions(
+                  specification.renditions().stream()
+                      .map(
+                          rendition ->
+                              new RenditionObservation(rendition.label(), RenditionState.RUNNING))
+                      .toList())
+              .build());
+    }
+
+    @Override
+    public StopJobResult stop(StopJobCommand command) {
+      return new StopJobResult.Stopped(command.jobRef());
+    }
+
+    @Override
+    public InspectJobResult inspect(InspectJobQuery query) {
+      return new InspectJobResult.Observed(
+          TranscodeJobObservation.builder()
+              .jobRef(query.jobRef())
+              .state(TranscodeJobState.ABSENT)
+              .renditions(List.of())
+              .build());
+    }
+
+    private static void await(java.util.concurrent.CountDownLatch latch) {
+      try {
+        latch.await();
+      } catch (InterruptedException exception) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(exception);
       }
-      super.stop(sessionId);
     }
   }
 }

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingSmokeTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/HlsStreamingSmokeTest.java
@@ -8,21 +8,26 @@ import com.streamarr.server.config.StreamingProperties;
 import com.streamarr.server.domain.media.MediaFile;
 import com.streamarr.server.domain.media.MediaFileStatus;
 import com.streamarr.server.domain.streaming.StreamingOptions;
-import com.streamarr.server.domain.streaming.TranscodeStatus;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.fakes.FakeMediaFileRepository;
 import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.streaming.ffmpeg.LocalFfprobeService;
-import com.streamarr.server.services.streaming.ffmpeg.LocalTranscodeExecutor;
 import com.streamarr.server.services.streaming.local.InMemoryStreamSessionRepository;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
+import com.streamarr.server.services.streaming.worker.WorkerTarget;
+import com.streamarr.server.services.streaming.worker.local.LocalTranscodeWorkerAdapter;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegCommandBuilder;
 import com.streamarr.transcode.engine.ffmpeg.FfmpegProcessKey;
 import com.streamarr.transcode.engine.ffmpeg.LocalFfmpegProcessManager;
 import com.streamarr.transcode.engine.ffmpeg.TranscodeCapabilityService;
+import com.streamarr.transcode.engine.job.LocalTranscodeEngine;
 import com.streamarr.transcode.engine.model.ContainerFormat;
+import com.streamarr.transcode.engine.model.MediaSourceRef;
 import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
 import com.streamarr.transcode.engine.model.TranscodeMode;
+import com.streamarr.transcode.engine.segment.LocalSegmentStorage;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -48,6 +53,9 @@ class HlsStreamingSmokeTest {
   private FakeMediaFileRepository mediaFileRepository;
   private LocalSegmentStore segmentStore;
   private HlsStreamingService streamingService;
+  private PlaybackTranscodeJobService transcodeJobs;
+  private LocalTranscodeEngine transcodeEngine;
+  private LocalFfmpegProcessManager processManager;
   private RuntimeStreamSessionRegistry runtimeRegistry;
   private HlsPlaylistService playlistService;
   private Path segmentBaseDir;
@@ -70,7 +78,8 @@ class HlsStreamingSmokeTest {
   @BeforeEach
   void setUp() throws IOException {
     segmentBaseDir = Files.createTempDirectory("streamarr-smoke-");
-    segmentStore = new LocalSegmentStore(segmentBaseDir);
+    var segmentStorage = new LocalSegmentStorage(segmentBaseDir);
+    segmentStore = new LocalSegmentStore(segmentStorage);
 
     var objectMapper = new ObjectMapper();
     var ffprobeService =
@@ -99,9 +108,14 @@ class HlsStreamingSmokeTest {
     capabilityService.detectCapabilities();
 
     var commandBuilder = new FfmpegCommandBuilder("ffmpeg");
-    var processManager = new LocalFfmpegProcessManager();
-    var transcodeExecutor =
-        new LocalTranscodeExecutor(commandBuilder, processManager, segmentStore, capabilityService);
+    processManager = new LocalFfmpegProcessManager();
+    transcodeEngine =
+        LocalTranscodeEngine.builder()
+            .commandBuilder(commandBuilder)
+            .processManager(processManager)
+            .segmentStorage(segmentStorage)
+            .capabilityService(capabilityService)
+            .build();
 
     var decisionService = new TranscodeDecisionService();
     var qualityLadderService = new QualityLadderService();
@@ -114,17 +128,28 @@ class HlsStreamingSmokeTest {
 
     mediaFileRepository = new FakeMediaFileRepository();
     runtimeRegistry = new InMemoryStreamSessionRepository();
+    var sourceCatalog = new SmokeMediaSourceCatalog();
+    var workerTarget = new WorkerTarget(UUID.randomUUID(), UUID.randomUUID());
+    var worker = new LocalTranscodeWorkerAdapter(workerTarget, sourceCatalog, transcodeEngine);
+    transcodeJobs =
+        DefaultPlaybackTranscodeJobService.builder()
+            .worker(worker)
+            .workerTarget(workerTarget)
+            .runtimeRegistry(runtimeRegistry)
+            .sessionMutexes(new MutexFactory<>())
+            .build();
     streamingService =
         new HlsStreamingService(
             mediaFileRepository,
-            transcodeExecutor,
             segmentStore,
             ffprobeService,
             decisionService,
             qualityLadderService,
             properties,
             runtimeRegistry,
-            new MutexFactory<>());
+            new MutexFactory<>(),
+            transcodeJobs,
+            sourceCatalog);
 
     playlistService = new HlsPlaylistService(properties);
   }
@@ -138,7 +163,7 @@ class HlsStreamingSmokeTest {
     } catch (Exception _) {
       // best-effort cleanup
     }
-    segmentStore.shutdown();
+    transcodeEngine.shutdown();
   }
 
   private StreamingOptions defaultOptions() {
@@ -227,8 +252,11 @@ class HlsStreamingSmokeTest {
 
     var session = createSession(file.getId(), UUID.randomUUID(), options);
 
-    assertThat(session.getHandle()).isNotNull();
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
+    assertThat(transcodeJobs.inspectActive(session.getSessionId()))
+        .isInstanceOfSatisfying(
+            ActiveTranscodeJobInspection.Observed.class,
+            active ->
+                assertThat(active.observation().state()).isEqualTo(TranscodeJobState.RUNNING));
 
     var segmentReady =
         segmentStore.waitForSegment(session.getSessionId(), "segment0.ts", Duration.ofSeconds(30));
@@ -323,16 +351,15 @@ class HlsStreamingSmokeTest {
 
     segmentStore.waitForSegment(sessionId, "segment0.ts", Duration.ofSeconds(30));
 
-    var handle = session.getHandle();
-    assertThat(handle).isNotNull();
-    assertThat(handle.status()).isEqualTo(TranscodeStatus.ACTIVE);
+    var jobRef =
+        ((ActiveTranscodeJobInspection.Observed) transcodeJobs.inspectActive(sessionId))
+            .observation()
+            .jobRef();
+    assertThat(processManager.isRunning(jobRef)).isTrue();
 
     streamingService.destroySession(sessionId);
 
-    var processHandle = ProcessHandle.of(handle.processId());
-    assertThat(processHandle)
-        .satisfiesAnyOf(
-            ph -> assertThat(ph).isEmpty(), ph -> assertThat(ph.get().isAlive()).isFalse());
+    assertThat(processManager.isRunning(jobRef)).isFalse();
   }
 
   @Test
@@ -380,5 +407,18 @@ class HlsStreamingSmokeTest {
             });
 
     processManager.stopJob(jobRef);
+  }
+
+  private static final class SmokeMediaSourceCatalog implements MediaSourceCatalog {
+
+    @Override
+    public MediaSourceRef referenceFor(UUID mediaFileId) {
+      return new MediaSourceRef(mediaFileId, TEST_VIDEO.getFileName().toString());
+    }
+
+    @Override
+    public Path resolve(MediaSourceRef source) {
+      return TEST_VIDEO;
+    }
   }
 }

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/PlaybackSessionCreationServiceIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/PlaybackSessionCreationServiceIT.java
@@ -28,12 +28,10 @@ import com.streamarr.server.domain.streaming.MediaProbe;
 import com.streamarr.server.domain.streaming.StreamSession;
 import com.streamarr.server.domain.streaming.StreamSessionTerminalReason;
 import com.streamarr.server.domain.streaming.StreamingOptions;
-import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.VideoQuality;
 import com.streamarr.server.fakes.FakeFfprobeService;
 import com.streamarr.server.fakes.FakeMediaFileRepository;
 import com.streamarr.server.fakes.FakeSegmentStore;
-import com.streamarr.server.fakes.FakeTranscodeExecutor;
 import com.streamarr.server.fixtures.LibraryFixtureCreator;
 import com.streamarr.server.jooq.generated.enums.StreamSessionStatus;
 import com.streamarr.server.repositories.LibraryRepository;
@@ -56,9 +54,26 @@ import com.streamarr.server.services.concurrency.MutexFactoryProvider;
 import com.streamarr.server.services.library.MediaParentDeletionService;
 import com.streamarr.server.services.streaming.local.InMemoryStreamSessionRepository;
 import com.streamarr.server.services.streaming.local.LocalSegmentStore;
+import com.streamarr.server.services.streaming.source.MediaSourceCatalog;
+import com.streamarr.server.services.streaming.source.MediaSourceUnavailableException;
+import com.streamarr.server.services.streaming.worker.InspectJobQuery;
+import com.streamarr.server.services.streaming.worker.InspectJobResult;
+import com.streamarr.server.services.streaming.worker.StartJobCommand;
+import com.streamarr.server.services.streaming.worker.StartJobRejection;
+import com.streamarr.server.services.streaming.worker.StartJobResult;
+import com.streamarr.server.services.streaming.worker.StopJobCommand;
+import com.streamarr.server.services.streaming.worker.StopJobResult;
+import com.streamarr.server.services.streaming.worker.TranscodeWorkerPort;
+import com.streamarr.server.services.streaming.worker.WorkerTarget;
 import com.streamarr.server.support.AuthTestSupport;
 import com.streamarr.server.support.AuthTestSupport.TestIdentity;
-import com.streamarr.transcode.engine.model.RenditionRequest;
+import com.streamarr.transcode.engine.model.MediaSourceRef;
+import com.streamarr.transcode.engine.model.RenditionObservation;
+import com.streamarr.transcode.engine.model.RenditionSpec;
+import com.streamarr.transcode.engine.model.RenditionState;
+import com.streamarr.transcode.engine.model.TranscodeJobObservation;
+import com.streamarr.transcode.engine.model.TranscodeJobRef;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
@@ -71,6 +86,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -101,17 +118,22 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
 
   private static final IllegalStateException TOKEN_FAILURE =
       new IllegalStateException("simulated playback token encoding failure");
-  private static final IllegalStateException TRANSCODE_FAILURE =
-      new IllegalStateException("simulated second variant startup failure");
-  private static final ControllableTranscodeExecutor TRANSCODE_EXECUTOR =
-      new ControllableTranscodeExecutor();
   private static final FakeFfprobeService FFPROBE_SERVICE = new FakeFfprobeService();
   private static final ObservingFailingSegmentStore SEGMENT_STORE =
       new ObservingFailingSegmentStore();
+  private static final WorkerTarget WORKER_TARGET =
+      new WorkerTarget(
+          UUID.fromString("70000000-0000-0000-0000-000000000001"),
+          UUID.fromString("70000000-0000-0000-0000-000000000002"));
+  private static final ControllableTranscodeWorker TRANSCODE_WORKER =
+      new ControllableTranscodeWorker();
+  private static final FakeMediaSourceCatalog MEDIA_SOURCE_CATALOG = new FakeMediaSourceCatalog();
 
-  @TestBean TranscodeExecutor transcodeExecutor;
   @TestBean FfprobeService ffprobeService;
   @TestBean SegmentStore segmentStore;
+  @TestBean TranscodeWorkerPort transcodeWorkerPort;
+  @TestBean WorkerTarget workerTarget;
+  @TestBean MediaSourceCatalog libraryMediaSourceCatalog;
 
   @Autowired private StreamingService streamingService;
   @Autowired private PlaybackSessionCreationService playbackSessionCreationService;
@@ -145,10 +167,6 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
   private UUID mediaFileId;
   private UUID streamSessionId;
 
-  static TranscodeExecutor transcodeExecutor() {
-    return TRANSCODE_EXECUTOR;
-  }
-
   static FfprobeService ffprobeService() {
     return FFPROBE_SERVICE;
   }
@@ -157,9 +175,21 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     return SEGMENT_STORE;
   }
 
+  static TranscodeWorkerPort transcodeWorkerPort() {
+    return TRANSCODE_WORKER;
+  }
+
+  static WorkerTarget workerTarget() {
+    return WORKER_TARGET;
+  }
+
+  static MediaSourceCatalog libraryMediaSourceCatalog() {
+    return MEDIA_SOURCE_CATALOG;
+  }
+
   @BeforeEach
   void setUp() {
-    TRANSCODE_EXECUTOR.reset();
+    TRANSCODE_WORKER.reset();
     FFPROBE_SERVICE.setDefaultProbe(defaultProbe("h264"));
     SEGMENT_STORE.reset(dsl);
     testIdentity = authTestSupport.createIdentity();
@@ -174,6 +204,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     var library = libraryRepository.saveAndFlush(LibraryFixtureCreator.buildFakeLibrary());
     libraryId = library.getId();
     mediaFileId = saveMediaFile(libraryId).getId();
+    MEDIA_SOURCE_CATALOG.reset(mediaFileId, libraryId);
   }
 
   @AfterEach
@@ -225,7 +256,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
             com.streamarr.server.jooq.generated.enums.StreamSessionTerminalReason.STARTUP_FAILURE);
     assertThat(stateProbe.activeCount(streamSessionId)).isZero();
     assertThat(streamingService.getActiveSessionCount()).isZero();
-    assertThat(TRANSCODE_EXECUTOR.isRunning(streamSessionId)).isFalse();
+    assertThat(TRANSCODE_WORKER.isRunning(streamSessionId)).isFalse();
 
     SEGMENT_STORE.allowDeletion();
     cleanupWorker.reapPersistedSessions();
@@ -390,7 +421,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     streamSessionId = created.sessionId();
 
     assertThat(retryingLifecycle.activationAttempts()).isEqualTo(3);
-    assertThat(TRANSCODE_EXECUTOR.startAttempts()).isEqualTo(1);
+    assertThat(TRANSCODE_WORKER.startAttempts()).isEqualTo(1);
     assertThat(new StreamSessionStateProbe(dsl).status(streamSessionId))
         .contains(StreamSessionStatus.ACTIVE);
   }
@@ -563,7 +594,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
   @Test
   @DisplayName("Should commit provisioning authority before FFmpeg starts")
   void shouldCommitProvisioningAuthorityBeforeFfmpegStarts() {
-    TRANSCODE_EXECUTOR.observeFirstStart(
+    TRANSCODE_WORKER.observeFirstStart(
         sessionId ->
             new StreamSessionStateProbe(dsl)
                 .status(sessionId)
@@ -572,7 +603,56 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
 
     createPlaybackSession();
 
-    assertThat(TRANSCODE_EXECUTOR.observedProvisioningAtFirstStart()).isTrue();
+    assertThat(TRANSCODE_WORKER.observedProvisioningAtFirstStart()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should submit one complete ladder while durable authority is provisioning")
+  void shouldSubmitOneCompleteLadderWhileDurableAuthorityIsProvisioning() throws Exception {
+    FFPROBE_SERVICE.setDefaultProbe(defaultProbe("hevc"));
+    TRANSCODE_WORKER.blockNextStart();
+
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var creation =
+          executor.submit(
+              () ->
+                  playbackSessionCreationService.create(
+                      CreatePlaybackSessionCommand.builder()
+                          .mediaFileId(mediaFileId)
+                          .options(defaultOptions())
+                          .sourceIdentity(sourceIdentity())
+                          .build()));
+
+      try {
+        assertThat(TRANSCODE_WORKER.awaitBlockedStart())
+            .as("the whole-ladder worker start was reached")
+            .isTrue();
+
+        var startCommand = TRANSCODE_WORKER.blockedStartCommand();
+        var specification = startCommand.specification();
+        streamSessionId = specification.sessionId();
+
+        assertThat(new StreamSessionStateProbe(dsl).status(streamSessionId))
+            .contains(StreamSessionStatus.PROVISIONING);
+        assertThat(TRANSCODE_WORKER.startCommands()).containsExactly(startCommand);
+        assertThat(startCommand.target()).isEqualTo(WORKER_TARGET);
+        assertThat(specification.jobRef().jobId()).isEqualTo(streamSessionId);
+        assertThat(specification.jobRef().generation()).isEqualTo(1);
+        assertThat(specification.source())
+            .isEqualTo(MEDIA_SOURCE_CATALOG.referenceFor(mediaFileId));
+        assertThat(specification.renditions()).containsExactlyElementsOf(completeLadder());
+      } finally {
+        TRANSCODE_WORKER.releaseStart();
+      }
+
+      var created = creation.get(5, TimeUnit.SECONDS);
+      streamSessionId = created.sessionId();
+
+      assertThat(created.playbackToken().value()).isNotBlank();
+      assertThat(TRANSCODE_WORKER.startCommands()).hasSize(1);
+      assertThat(new StreamSessionStateProbe(dsl).status(streamSessionId))
+          .contains(StreamSessionStatus.ACTIVE);
+    }
   }
 
   @Test
@@ -591,7 +671,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                                 .sourceIdentity(sourceIdentity())
                                 .build())))
         .isInstanceOf(org.springframework.transaction.IllegalTransactionStateException.class);
-    assertThat(TRANSCODE_EXECUTOR.startAttempts()).isZero();
+    assertThat(TRANSCODE_WORKER.startAttempts()).isZero();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -620,7 +700,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThatThrownBy(this::createPlaybackSession)
         .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
 
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -638,7 +718,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThatThrownBy(this::createPlaybackSession)
         .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
 
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -668,7 +748,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                                 .values(mediaFileId)
                                 .execute();
                             deletionPrepared.countDown();
-                            ControllableTranscodeExecutor.await(allowDeletionCommit);
+                            await(allowDeletionCommit);
                           }));
       assertThat(deletionPrepared.await(5, TimeUnit.SECONDS)).isTrue();
 
@@ -912,7 +992,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                             .forUpdate()
                             .fetchSingle();
                         rowLocked.countDown();
-                        ControllableTranscodeExecutor.await(releaseLock);
+                        await(releaseLock);
                       }));
       assertThat(rowLocked.await(5, TimeUnit.SECONDS)).isTrue();
 
@@ -1092,7 +1172,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
 
   private void assertNewPlaybackAndNextSegmentRefused(
       String accessToken, ApiPlaybackSession created) throws Exception {
-    var startsBeforeRefusedCreation = TRANSCODE_EXECUTOR.getStartedRequests().size();
+    var startsBeforeRefusedCreation = TRANSCODE_WORKER.startCommands().size();
     var rowsBeforeRefusedCreation =
         new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId());
     var refusedCreation =
@@ -1115,7 +1195,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThat(List.of(refusedCreation.getStatus(), nextSegment.getStatus()))
         .containsExactly(200, 404);
     assertThat(refusedCreation.getContentAsString()).contains("SESSION_NOT_FOUND");
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).hasSize(startsBeforeRefusedCreation);
+    assertThat(TRANSCODE_WORKER.startCommands()).hasSize(startsBeforeRefusedCreation);
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isEqualTo(rowsBeforeRefusedCreation);
   }
@@ -1176,7 +1256,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThat(SEGMENT_STORE.observedTerminatingAuthority()).isTrue();
     assertThat(new StreamSessionStateProbe(dsl).status(streamSessionId)).isEmpty();
     assertThat(streamingService.getActiveSessionCount()).isZero();
-    assertThat(TRANSCODE_EXECUTOR.isRunning(streamSessionId)).isFalse();
+    assertThat(TRANSCODE_WORKER.isRunning(streamSessionId)).isFalse();
   }
 
   @Test
@@ -1303,7 +1383,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThat(access).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).status(streamSessionId)).isEmpty();
     assertThat(streamingService.getActiveSessionCount()).isZero();
-    assertThat(TRANSCODE_EXECUTOR.isRunning(streamSessionId)).isFalse();
+    assertThat(TRANSCODE_WORKER.isRunning(streamSessionId)).isFalse();
   }
 
   @Test
@@ -1323,7 +1403,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                         .build()))
         .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
 
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -1338,7 +1418,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThatThrownBy(this::createPlaybackSession)
         .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
 
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -1362,7 +1442,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                         .build()))
         .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
 
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -1383,7 +1463,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                         .build()))
         .isInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
 
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -1392,7 +1472,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
   @DisplayName("Should leave no playable runtime when auth is revoked during startup")
   void shouldLeaveNoPlayableRuntimeWhenAuthIsRevokedDuringStartup() throws Exception {
     SEGMENT_STORE.failDeletion();
-    TRANSCODE_EXECUTOR.blockNextStart();
+    TRANSCODE_WORKER.blockNextStart();
     var identity = sourceIdentity();
 
     try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
@@ -1405,12 +1485,12 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                           .options(defaultOptions())
                           .sourceIdentity(identity)
                           .build()));
-      assertThat(TRANSCODE_EXECUTOR.awaitBlockedStart()).isTrue();
-      streamSessionId = TRANSCODE_EXECUTOR.blockedSessionId();
+      assertThat(TRANSCODE_WORKER.awaitBlockedStart()).isTrue();
+      streamSessionId = TRANSCODE_WORKER.blockedSessionId();
 
       sessionRevocationService.revoke(
           testIdentity.session().getId(), SessionRevocationReason.LOGOUT, clock.instant());
-      TRANSCODE_EXECUTOR.releaseStart();
+      TRANSCODE_WORKER.releaseStart();
 
       assertThatThrownBy(() -> creation.get(5, TimeUnit.SECONDS))
           .hasCauseInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
@@ -1423,7 +1503,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
             com.streamarr.server.jooq.generated.enums.StreamSessionTerminalReason.AUTH_REVOKED);
     assertThat(stateProbe.activeCount(streamSessionId)).isZero();
     assertThat(streamingService.getActiveSessionCount()).isZero();
-    assertThat(TRANSCODE_EXECUTOR.isRunning(streamSessionId)).isFalse();
+    assertThat(TRANSCODE_WORKER.isRunning(streamSessionId)).isFalse();
   }
 
   @Test
@@ -1510,7 +1590,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                             SessionRevocationReason.LOGOUT,
                             clock.instant());
                         revocationUpdated.countDown();
-                        ControllableTranscodeExecutor.await(allowRevocationCommit);
+                        await(allowRevocationCommit);
                       }));
       assertThat(revocationUpdated.await(5, TimeUnit.SECONDS)).isTrue();
       var activation =
@@ -1579,7 +1659,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
   @DisplayName("Should leave no playable runtime when media deletion starts during startup")
   void shouldLeaveNoPlayableRuntimeWhenMediaDeletionStartsDuringStartup() throws Exception {
     SEGMENT_STORE.failDeletion();
-    TRANSCODE_EXECUTOR.blockNextStart();
+    TRANSCODE_WORKER.blockNextStart();
     var identity = sourceIdentity();
 
     try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
@@ -1592,29 +1672,41 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                           .options(defaultOptions())
                           .sourceIdentity(identity)
                           .build()));
-      assertThat(TRANSCODE_EXECUTOR.awaitBlockedStart()).isTrue();
-      streamSessionId = TRANSCODE_EXECUTOR.blockedSessionId();
+      assertThat(TRANSCODE_WORKER.awaitBlockedStart()).isTrue();
+      streamSessionId = TRANSCODE_WORKER.blockedSessionId();
 
-      mediaParentDeletionService.deleteMediaFiles(libraryId, Set.of(mediaFileId));
-      TRANSCODE_EXECUTOR.releaseStart();
+      var deletion =
+          executor.submit(
+              () -> mediaParentDeletionService.deleteMediaFiles(libraryId, Set.of(mediaFileId)));
+      try {
+        org.awaitility.Awaitility.await()
+            .atMost(Duration.ofSeconds(5))
+            .untilAsserted(
+                () ->
+                    assertThat(new StreamSessionStateProbe(dsl).status(streamSessionId))
+                        .contains(StreamSessionStatus.TERMINATING));
+      } finally {
+        TRANSCODE_WORKER.releaseStart();
+      }
 
       assertThatThrownBy(() -> creation.get(5, TimeUnit.SECONDS))
           .hasCauseInstanceOf(com.streamarr.server.exceptions.SessionNotFoundException.class);
+      deletion.get(5, TimeUnit.SECONDS);
     }
 
     var stateProbe = new StreamSessionStateProbe(dsl);
     assertThat(stateProbe.status(streamSessionId)).contains(StreamSessionStatus.TERMINATING);
     assertThat(stateProbe.activeCount(streamSessionId)).isZero();
     assertThat(streamingService.getActiveSessionCount()).isZero();
-    assertThat(TRANSCODE_EXECUTOR.isRunning(streamSessionId)).isFalse();
+    assertThat(TRANSCODE_WORKER.isRunning(streamSessionId)).isFalse();
   }
 
   @Test
-  @DisplayName("Should stop partial ladder when a later variant fails to start")
-  void shouldStopPartialLadderWhenLaterVariantFailsToStart() {
+  @DisplayName("Should compensate whole job when worker startup fails")
+  void shouldCompensateWholeJobWhenWorkerStartupFails() {
     SEGMENT_STORE.failDeletion();
     FFPROBE_SERVICE.setDefaultProbe(defaultProbe("hevc"));
-    TRANSCODE_EXECUTOR.failOnStart(2, TRANSCODE_FAILURE);
+    TRANSCODE_WORKER.rejectNextStart(StartJobRejection.STARTUP_FAILED);
 
     assertThatThrownBy(
             () ->
@@ -1624,13 +1716,16 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
                         .options(defaultOptions())
                         .sourceIdentity(sourceIdentity())
                         .build()))
-        .isSameAs(TRANSCODE_FAILURE);
+        .isInstanceOf(TranscodeJobStartException.class);
 
-    streamSessionId = TRANSCODE_EXECUTOR.attemptedSessionId();
+    streamSessionId = TRANSCODE_WORKER.attemptedSessionId();
     var stateProbe = new StreamSessionStateProbe(dsl);
-    assertThat(TRANSCODE_EXECUTOR.startAttempts()).isEqualTo(2);
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).hasSize(1);
-    assertThat(TRANSCODE_EXECUTOR.isRunning(streamSessionId)).isFalse();
+    var submitted = TRANSCODE_WORKER.startCommands().getFirst();
+    assertThat(TRANSCODE_WORKER.startAttempts()).isEqualTo(1);
+    assertThat(TRANSCODE_WORKER.stopCommands())
+        .extracting(StopJobCommand::jobRef)
+        .containsExactly(submitted.specification().jobRef());
+    assertThat(TRANSCODE_WORKER.isRunning(streamSessionId)).isFalse();
     assertThat(streamingService.getActiveSessionCount()).isZero();
     assertThat(stateProbe.status(streamSessionId)).contains(StreamSessionStatus.TERMINATING);
   }
@@ -1824,7 +1919,7 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     assertThat(List.of(ordinaryApi.getStatus(), refusedCreation.getStatus()))
         .containsExactly(404, 200);
     assertThat(refusedCreation.getContentAsString()).contains("SESSION_NOT_FOUND");
-    assertThat(TRANSCODE_EXECUTOR.getStartedRequests()).isEmpty();
+    assertThat(TRANSCODE_WORKER.startCommands()).isEmpty();
     assertThat(new StreamSessionStateProbe(dsl).countForAuthSession(testIdentity.session().getId()))
         .isZero();
   }
@@ -1879,14 +1974,15 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
       RuntimeStreamSessionRegistry runtimeRegistry, SegmentStore restartSegmentStore) {
     return new HlsStreamingService(
         new FakeMediaFileRepository(),
-        new FakeTranscodeExecutor(),
         restartSegmentStore,
         new FakeFfprobeService(),
         new TranscodeDecisionService(),
         new QualityLadderService(),
         streamingProperties,
         runtimeRegistry,
-        new MutexFactory<>());
+        new MutexFactory<>(),
+        new com.streamarr.server.fakes.FakePlaybackTranscodeJobService(),
+        new com.streamarr.server.fakes.FakeMediaSourceCatalog());
   }
 
   private MediaFile saveMediaFile(UUID owningLibraryId) {
@@ -1904,6 +2000,23 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     return StreamingOptions.builder()
         .quality(VideoQuality.AUTO)
         .supportedCodecs(List.of("h264"))
+        .build();
+  }
+
+  private static List<RenditionSpec> completeLadder() {
+    return List.of(
+        rendition("1080p", 1920, 1080, 5_000_000L),
+        rendition("720p", 1280, 720, 3_000_000L),
+        rendition("480p", 854, 480, 1_500_000L),
+        rendition("360p", 640, 360, 800_000L));
+  }
+
+  private static RenditionSpec rendition(String label, int width, int height, long bitrate) {
+    return RenditionSpec.builder()
+        .label(label)
+        .width(width)
+        .height(height)
+        .videoBitrate(bitrate)
         .build();
   }
 
@@ -2081,47 +2194,63 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
     }
   }
 
-  private static final class ControllableTranscodeExecutor extends FakeTranscodeExecutor {
+  private static void await(CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while awaiting test coordination", exception);
+    }
+  }
 
+  private static final class ControllableTranscodeWorker implements TranscodeWorkerPort {
+
+    private final CopyOnWriteArrayList<StartJobCommand> startCommands =
+        new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<StopJobCommand> stopCommands = new CopyOnWriteArrayList<>();
+    private final ConcurrentHashMap<TranscodeJobRef, TranscodeJobObservation> runningJobs =
+        new ConcurrentHashMap<>();
     private volatile CountDownLatch startEntered;
     private volatile CountDownLatch allowStart;
-    private volatile UUID blockedSessionId;
-    private volatile UUID attemptedSessionId;
-    private volatile RuntimeException startFailure;
     private volatile Function<UUID, Boolean> firstStartObserver;
     private volatile boolean observedProvisioningAtFirstStart;
-    private volatile int failOnAttempt;
-    private int startAttempts;
+    private volatile StartJobRejection nextStartRejection;
 
     private void blockNextStart() {
       startEntered = new CountDownLatch(1);
       allowStart = new CountDownLatch(1);
-      blockedSessionId = null;
     }
 
     private boolean awaitBlockedStart() throws InterruptedException {
       return startEntered.await(5, TimeUnit.SECONDS);
     }
 
+    private StartJobCommand blockedStartCommand() {
+      return startCommands.getFirst();
+    }
+
     private UUID blockedSessionId() {
-      return blockedSessionId;
+      return blockedStartCommand().specification().sessionId();
     }
 
-    private void releaseStart() {
-      allowStart.countDown();
+    private List<StartJobCommand> startCommands() {
+      return List.copyOf(startCommands);
     }
 
-    private void failOnStart(int attempt, RuntimeException failure) {
-      failOnAttempt = attempt;
-      startFailure = failure;
+    private List<StopJobCommand> stopCommands() {
+      return List.copyOf(stopCommands);
     }
 
     private int startAttempts() {
-      return startAttempts;
+      return startCommands.size();
     }
 
     private UUID attemptedSessionId() {
-      return attemptedSessionId;
+      return startCommands.getLast().specification().sessionId();
+    }
+
+    private boolean isRunning(UUID sessionId) {
+      return runningJobs.keySet().stream().anyMatch(jobRef -> jobRef.jobId().equals(sessionId));
     }
 
     private void observeFirstStart(Function<UUID, Boolean> observer) {
@@ -2132,47 +2261,111 @@ class PlaybackSessionCreationServiceIT extends AbstractIntegrationTest {
       return observedProvisioningAtFirstStart;
     }
 
+    private void rejectNextStart(StartJobRejection rejection) {
+      nextStartRejection = rejection;
+    }
+
+    private void releaseStart() {
+      var release = allowStart;
+      if (release != null) {
+        release.countDown();
+      }
+    }
+
+    private void reset() {
+      releaseStart();
+      startCommands.clear();
+      stopCommands.clear();
+      runningJobs.clear();
+      startEntered = null;
+      allowStart = null;
+      firstStartObserver = null;
+      observedProvisioningAtFirstStart = false;
+      nextStartRejection = null;
+    }
+
     @Override
-    public TranscodeHandle start(RenditionRequest request) {
-      attemptedSessionId = request.sessionId();
-      startAttempts++;
-      if (startAttempts == 1 && firstStartObserver != null) {
-        observedProvisioningAtFirstStart = firstStartObserver.apply(request.sessionId());
+    public StartJobResult start(StartJobCommand command) {
+      startCommands.add(command);
+      if (startCommands.size() == 1 && firstStartObserver != null) {
+        observedProvisioningAtFirstStart =
+            firstStartObserver.apply(command.specification().sessionId());
       }
       var entered = startEntered;
       if (entered != null && entered.getCount() > 0) {
-        blockedSessionId = request.sessionId();
         entered.countDown();
         await(allowStart);
       }
-      if (startAttempts == failOnAttempt) {
-        throw startFailure;
+      var rejection = nextStartRejection;
+      if (rejection != null) {
+        nextStartRejection = null;
+        return new StartJobResult.Rejected(rejection);
       }
-      return super.start(request);
+      var accepted = accepted(command);
+      runningJobs.put(command.specification().jobRef(), accepted.observation());
+      return accepted;
     }
 
     @Override
-    public void reset() {
-      super.reset();
-      startEntered = null;
-      allowStart = null;
-      blockedSessionId = null;
-      attemptedSessionId = null;
-      startFailure = null;
-      firstStartObserver = null;
-      observedProvisioningAtFirstStart = false;
-      failOnAttempt = 0;
-      startAttempts = 0;
+    public StopJobResult stop(StopJobCommand command) {
+      stopCommands.add(command);
+      runningJobs.remove(command.jobRef());
+      return new StopJobResult.Stopped(command.jobRef());
     }
 
-    private static void await(CountDownLatch latch) {
-      try {
-        latch.await();
-      } catch (InterruptedException exception) {
-        Thread.currentThread().interrupt();
-        throw new IllegalStateException(
-            "Interrupted while controlling transcode startup", exception);
+    @Override
+    public InspectJobResult inspect(InspectJobQuery query) {
+      var running = runningJobs.get(query.jobRef());
+      if (running != null) {
+        return new InspectJobResult.Observed(running);
       }
+      return new InspectJobResult.Observed(
+          TranscodeJobObservation.builder()
+              .jobRef(query.jobRef())
+              .state(TranscodeJobState.ABSENT)
+              .renditions(List.of())
+              .build());
+    }
+
+    private static StartJobResult.Accepted accepted(StartJobCommand command) {
+      var specification = command.specification();
+      var runningRenditions =
+          specification.renditions().stream()
+              .map(rendition -> new RenditionObservation(rendition.label(), RenditionState.RUNNING))
+              .toList();
+      return new StartJobResult.Accepted(
+          TranscodeJobObservation.builder()
+              .jobRef(specification.jobRef())
+              .state(TranscodeJobState.RUNNING)
+              .renditions(runningRenditions)
+              .build());
+    }
+  }
+
+  private static final class FakeMediaSourceCatalog implements MediaSourceCatalog {
+
+    private UUID mediaFileId;
+    private MediaSourceRef source;
+
+    private void reset(UUID mediaFileId, UUID libraryId) {
+      this.mediaFileId = mediaFileId;
+      source = new MediaSourceRef(libraryId, "movies/test.mkv");
+    }
+
+    @Override
+    public MediaSourceRef referenceFor(UUID candidateMediaFileId) {
+      if (!candidateMediaFileId.equals(mediaFileId)) {
+        throw new MediaSourceUnavailableException();
+      }
+      return source;
+    }
+
+    @Override
+    public Path resolve(MediaSourceRef candidateSource) {
+      if (!candidateSource.equals(source)) {
+        throw new MediaSourceUnavailableException();
+      }
+      return Path.of("/library").resolve(candidateSource.relativeKey());
     }
   }
 

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
@@ -69,6 +69,31 @@ class SessionReaperTest {
   }
 
   @Test
+  @DisplayName("Should retain an idle session when suspension cleanup remains pending")
+  void shouldRetainIdleSessionWhenSuspensionCleanupRemainsPending() {
+    var session = idleSession();
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.RUNNING, 0);
+    transcodeJobs.returnSuspensionCleanup(RuntimeTranscodeCleanup.PENDING);
+    var logger = (Logger) LoggerFactory.getLogger(SessionReaper.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+
+    try {
+      reaper.reapSessions();
+    } finally {
+      logger.detachAppender(appender);
+    }
+
+    assertThat(transcodeJobs.suspensionAttempts()).containsExactly(session.getSessionId());
+    assertThat(streamingService.accessSession(session.getSessionId())).contains(session);
+    assertThat(appender.list)
+        .filteredOn(event -> event.getLevel() == Level.WARN)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .anyMatch(message -> message.contains(session.getSessionId().toString()));
+  }
+
+  @Test
   @DisplayName("Should not suspend a recently accessed running whole job")
   void shouldNotSuspendRecentlyAccessedRunningWholeJob() {
     var session = addSession(Instant.now().minusSeconds(10));

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/SessionReaperTest.java
@@ -2,13 +2,15 @@ package com.streamarr.server.services.streaming;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.streamarr.server.config.StreamingProperties;
 import com.streamarr.server.domain.streaming.StreamSession;
-import com.streamarr.server.domain.streaming.TranscodeHandle;
-import com.streamarr.server.domain.streaming.TranscodeStatus;
-import com.streamarr.server.fakes.FakeTranscodeExecutor;
+import com.streamarr.server.fakes.FakePlaybackTranscodeJobService;
 import com.streamarr.server.fixtures.StreamSessionFixture;
-import java.nio.file.Path;
+import com.streamarr.transcode.engine.model.TranscodeJobState;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -20,17 +22,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 @Tag("UnitTest")
+@DisplayName("Session Reaper Tests")
 class SessionReaperTest {
 
-  private FakeTranscodeExecutor executor;
+  private FakePlaybackTranscodeJobService transcodeJobs;
   private InMemoryStreamingService streamingService;
   private SessionReaper reaper;
 
   @BeforeEach
   void setUp() {
-    executor = new FakeTranscodeExecutor();
+    transcodeJobs = new FakePlaybackTranscodeJobService();
     streamingService = new InMemoryStreamingService();
     var properties =
         StreamingProperties.builder()
@@ -38,232 +42,115 @@ class SessionReaperTest {
             .sessionTimeout(Duration.ofSeconds(60))
             .sessionRetention(Duration.ofHours(24))
             .build();
-    reaper = new SessionReaper(streamingService, executor, properties);
+    reaper = new SessionReaper(streamingService, transcodeJobs, properties);
   }
 
   @Test
-  @DisplayName("Should mark handle as suspended when session is idle past timeout")
-  void shouldMarkHandleAsSuspendedWhenIdlePastTimeout() {
-    var session = buildSession(Instant.now().minusSeconds(120));
-    streamingService.addSession(session);
+  @DisplayName("Should suspend an idle running whole job without removing its session")
+  void shouldSuspendIdleRunningWholeJobWithoutRemovingItsSession() {
+    var session = idleSession();
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.RUNNING, 0);
 
     reaper.reapSessions();
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.SUSPENDED);
+    assertThat(transcodeJobs.suspensionAttempts()).containsExactly(session.getSessionId());
+    assertThat(streamingService.accessSession(session.getSessionId())).contains(session);
   }
 
   @Test
-  @DisplayName("Should preserve session when suspending idle session")
-  void shouldPreserveSessionWhenSuspendingIdleSession() {
-    var session = buildSession(Instant.now().minusSeconds(120));
-    streamingService.addSession(session);
+  @DisplayName("Should suspend an idle admitting whole job")
+  void shouldSuspendIdleAdmittingWholeJob() {
+    var session = idleSession();
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.ADMITTING, 0);
 
     reaper.reapSessions();
 
-    assertThat(streamingService.accessSession(session.getSessionId())).isPresent();
+    assertThat(transcodeJobs.suspensionAttempts()).containsExactly(session.getSessionId());
   }
 
   @Test
-  @DisplayName("Should preserve durable session for persistence retention reaper")
-  void shouldPreserveDurableSessionForPersistenceRetentionReaper() {
-    var session = buildSession(Instant.now().minusSeconds(90_000));
-    streamingService.addSession(session);
+  @DisplayName("Should not suspend a recently accessed running whole job")
+  void shouldNotSuspendRecentlyAccessedRunningWholeJob() {
+    var session = addSession(Instant.now().minusSeconds(10));
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.RUNNING, 0);
 
     reaper.reapSessions();
 
-    assertThat(streamingService.accessSession(session.getSessionId())).isPresent();
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.SUSPENDED);
+    assertThat(transcodeJobs.suspensionAttempts()).isEmpty();
   }
 
   @Test
-  @DisplayName("Should not suspend session when already suspended")
-  void shouldNotSuspendSessionWhenAlreadySuspended() {
-    var session = buildSession(Instant.now().minusSeconds(120));
-    session.setHandle(new TranscodeHandle(1L, TranscodeStatus.SUSPENDED));
-    streamingService.addSession(session);
+  @DisplayName("Should treat a completed whole job as terminal output rather than a dead process")
+  void shouldTreatCompletedWholeJobAsTerminalOutputRatherThanDeadProcess() {
+    var session = idleSession();
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.COMPLETED, 0);
 
     reaper.reapSessions();
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.SUSPENDED);
-    assertThat(streamingService.accessSession(session.getSessionId())).isPresent();
+    assertThat(transcodeJobs.suspensionAttempts()).isEmpty();
   }
 
   @Test
-  @DisplayName("Should not suspend session when handles are failed")
-  void shouldNotSuspendSessionWhenHandlesAreFailed() {
-    var session = buildSession(Instant.now().minusSeconds(120));
-    session.setHandle(new TranscodeHandle(1L, TranscodeStatus.FAILED));
-    streamingService.addSession(session);
+  @DisplayName("Should report a failed whole job without discarding replacement authority")
+  void shouldReportFailedWholeJobWithoutDiscardingReplacementAuthority() {
+    var session = addSession(Instant.now().minusSeconds(10));
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.FAILED, 0);
+    var logger = (Logger) LoggerFactory.getLogger(SessionReaper.class);
+    var appender = new ListAppender<ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
 
-    reaper.reapSessions();
+    try {
+      reaper.reapSessions();
+    } finally {
+      logger.detachAppender(appender);
+    }
 
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.FAILED);
-    assertThat(streamingService.accessSession(session.getSessionId())).isPresent();
+    assertThat(transcodeJobs.suspensionAttempts()).isEmpty();
+    assertThat(appender.list)
+        .filteredOn(event -> event.getLevel() == Level.WARN)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .anyMatch(message -> message.contains(session.getSessionId().toString()));
   }
 
   @Test
-  @DisplayName("Should stop executor when suspending idle session")
-  void shouldStopExecutorWhenSuspendingIdleSession() {
-    var session = buildSession(Instant.now().minusSeconds(120));
-    streamingService.addSession(session);
+  @DisplayName("Should fail closed when active whole-job inspection is unavailable")
+  void shouldFailClosedWhenActiveWholeJobInspectionIsUnavailable() {
+    var session = idleSession();
+    transcodeJobs.observe(session.getSessionId(), TranscodeJobState.RUNNING, 0);
+    transcodeJobs.makeInspectionUnavailable(session.getSessionId());
 
     reaper.reapSessions();
 
-    assertThat(executor.getStopped()).contains(session.getSessionId());
+    assertThat(transcodeJobs.suspensionAttempts()).isEmpty();
   }
 
   @Test
-  @DisplayName("Should preserve session when recently accessed")
-  void shouldPreserveSessionWhenRecentlyAccessed() {
-    var session = buildSession(Instant.now().minusSeconds(10));
-    streamingService.addSession(session);
+  @DisplayName("Should ignore a session with no active whole job")
+  void shouldIgnoreSessionWithNoActiveWholeJob() {
+    idleSession();
 
     reaper.reapSessions();
 
-    assertThat(streamingService.accessSession(session.getSessionId())).isPresent();
+    assertThat(transcodeJobs.suspensionAttempts()).isEmpty();
   }
 
-  @Test
-  @DisplayName("Should update handle to failed when FFmpeg process dies")
-  void shouldUpdateHandleToFailedWhenFfmpegProcessDies() {
-    var session = buildSession(Instant.now().minusSeconds(10));
-    session.setHandle(new TranscodeHandle(1234L, TranscodeStatus.ACTIVE));
-    streamingService.addSession(session);
-    executor.markDead(session.getSessionId());
-
-    reaper.reapSessions();
-
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.FAILED);
-    assertThat(session.getHandle().processId()).isEqualTo(1234L);
+  private StreamSession idleSession() {
+    return addSession(Instant.now().minusSeconds(120));
   }
 
-  @Test
-  @DisplayName("Should not change handle when FFmpeg process is running")
-  void shouldNotChangeHandleWhenFfmpegProcessIsRunning() {
-    var session = buildSession(Instant.now().minusSeconds(10));
-    session.setHandle(new TranscodeHandle(1234L, TranscodeStatus.ACTIVE));
-    streamingService.addSession(session);
-    executor.start(
-        com.streamarr.transcode.engine.model.RenditionRequest.builder()
-            .sessionId(session.getSessionId())
-            .sourcePath(Path.of("/media/movie.mkv"))
-            .seekPosition(0)
-            .segmentDuration(6)
-            .framerate(24.0)
-            .transcodeDecision(session.getTranscodeDecision())
-            .width(1920)
-            .height(1080)
-            .bitrate(5_000_000)
-            .build());
-
-    reaper.reapSessions();
-
-    assertThat(session.getHandle().status()).isEqualTo(TranscodeStatus.ACTIVE);
-  }
-
-  @Test
-  @DisplayName("Should mark specific variant as failed when only that process dies")
-  void shouldMarkSpecificVariantAsFailedWhenOnlyThatProcessDies() {
-    var session = buildAbrSession(Instant.now().minusSeconds(10));
-    streamingService.addSession(session);
-
-    executor.markDead(session.getSessionId(), "1080p");
-
-    reaper.reapSessions();
-
-    assertThat(session.getVariantHandle("1080p").status()).isEqualTo(TranscodeStatus.FAILED);
-    assertThat(session.getVariantHandle("720p").status()).isEqualTo(TranscodeStatus.ACTIVE);
-  }
-
-  @Test
-  @DisplayName("Should not change handles when all variants are running")
-  void shouldNotChangeHandlesWhenAllVariantsRunning() {
-    var session = buildAbrSession(Instant.now().minusSeconds(10));
-    streamingService.addSession(session);
-
-    reaper.reapSessions();
-
-    assertThat(session.getVariantHandle("1080p").status()).isEqualTo(TranscodeStatus.ACTIVE);
-    assertThat(session.getVariantHandle("720p").status()).isEqualTo(TranscodeStatus.ACTIVE);
-  }
-
-  @Test
-  @DisplayName("Should skip already failed handles when suspending idle session")
-  void shouldSkipAlreadyFailedHandlesWhenSuspendingIdleSession() {
-    var session = buildSession(Instant.now().minusSeconds(120));
-    session.setVariantHandle("1080p", new TranscodeHandle(100L, TranscodeStatus.ACTIVE));
-    session.setVariantHandle("720p", new TranscodeHandle(101L, TranscodeStatus.FAILED));
-
-    executor.start(
-        com.streamarr.transcode.engine.model.RenditionRequest.builder()
-            .sessionId(session.getSessionId())
-            .sourcePath(Path.of("/media/movie.mkv"))
-            .seekPosition(0)
-            .segmentDuration(6)
-            .framerate(24.0)
-            .transcodeDecision(session.getTranscodeDecision())
-            .width(1920)
-            .height(1080)
-            .bitrate(5_000_000)
-            .variantLabel("1080p")
-            .build());
-
-    streamingService.addSession(session);
-
-    reaper.reapSessions();
-
-    assertThat(session.getVariantHandle("1080p").status()).isEqualTo(TranscodeStatus.SUSPENDED);
-    assertThat(session.getVariantHandle("720p").status()).isEqualTo(TranscodeStatus.FAILED);
-  }
-
-  private StreamSession buildSession(Instant lastAccessedAt) {
+  private StreamSession addSession(Instant lastAccessedAt) {
     var session = StreamSessionFixture.buildMpegtsSession();
     session.setLastAccessedAt(lastAccessedAt);
+    streamingService.addSession(session);
     return session;
   }
 
-  private StreamSession buildAbrSession(Instant lastAccessedAt) {
-    var session = StreamSessionFixture.buildMpegtsSession();
-    session.setLastAccessedAt(lastAccessedAt);
-
-    session.setVariantHandle("1080p", new TranscodeHandle(100L, TranscodeStatus.ACTIVE));
-    session.setVariantHandle("720p", new TranscodeHandle(101L, TranscodeStatus.ACTIVE));
-
-    executor.start(
-        com.streamarr.transcode.engine.model.RenditionRequest.builder()
-            .sessionId(session.getSessionId())
-            .sourcePath(Path.of("/media/movie.mkv"))
-            .seekPosition(0)
-            .segmentDuration(6)
-            .framerate(24.0)
-            .transcodeDecision(session.getTranscodeDecision())
-            .width(1920)
-            .height(1080)
-            .bitrate(5_000_000)
-            .variantLabel("1080p")
-            .build());
-    executor.start(
-        com.streamarr.transcode.engine.model.RenditionRequest.builder()
-            .sessionId(session.getSessionId())
-            .sourcePath(Path.of("/media/movie.mkv"))
-            .seekPosition(0)
-            .segmentDuration(6)
-            .framerate(24.0)
-            .transcodeDecision(session.getTranscodeDecision())
-            .width(1280)
-            .height(720)
-            .bitrate(3_000_000)
-            .variantLabel("720p")
-            .build());
-
-    return session;
-  }
-
-  private static class InMemoryStreamingService implements StreamingService {
+  private static final class InMemoryStreamingService implements StreamingService {
 
     private final ConcurrentHashMap<UUID, StreamSession> sessions = new ConcurrentHashMap<>();
 
-    void addSession(StreamSession session) {
+    private void addSession(StreamSession session) {
       sessions.put(session.getSessionId(), session);
     }
 

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/StreamSessionCleanupServiceTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/StreamSessionCleanupServiceTest.java
@@ -7,11 +7,20 @@ import com.streamarr.server.config.StreamingProperties;
 import com.streamarr.server.domain.streaming.StreamSession;
 import com.streamarr.server.fakes.FakeFfprobeService;
 import com.streamarr.server.fakes.FakeMediaFileRepository;
+import com.streamarr.server.fakes.FakeMediaSourceCatalog;
 import com.streamarr.server.fakes.FakeSegmentStore;
-import com.streamarr.server.fakes.FakeTranscodeExecutor;
 import com.streamarr.server.services.concurrency.MutexFactory;
 import com.streamarr.server.services.concurrency.MutexFactoryProvider;
 import com.streamarr.server.services.streaming.local.InMemoryStreamSessionRepository;
+import com.streamarr.server.services.streaming.worker.InspectJobQuery;
+import com.streamarr.server.services.streaming.worker.InspectJobRejection;
+import com.streamarr.server.services.streaming.worker.InspectJobResult;
+import com.streamarr.server.services.streaming.worker.StartJobCommand;
+import com.streamarr.server.services.streaming.worker.StartJobResult;
+import com.streamarr.server.services.streaming.worker.StopJobCommand;
+import com.streamarr.server.services.streaming.worker.StopJobResult;
+import com.streamarr.server.services.streaming.worker.TranscodeWorkerPort;
+import com.streamarr.server.services.streaming.worker.WorkerTarget;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -20,6 +29,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -29,30 +41,35 @@ import org.junit.jupiter.api.Test;
 class StreamSessionCleanupServiceTest {
 
   @Test
-  @DisplayName("Should retain durable marker while runtime starter is in flight")
-  void shouldRetainDurableMarkerWhileRuntimeStarterIsInFlight() {
+  @DisplayName("Should retain durable marker and wait while runtime starter is in flight")
+  void shouldRetainDurableMarkerAndWaitWhileRuntimeStarterIsInFlight() throws Exception {
     var streamSessionId = UUID.randomUUID();
-    var runtimeRegistry = new InMemoryStreamSessionRepository();
+    var runtimeRegistry = new SignalingAwaitRegistry();
     var reservation = runtimeRegistry.reserve(streamSessionId).orElseThrow();
     var starter = runtimeRegistry.beginTranscodeStart(streamSessionId).orElseThrow();
     var lifecycle = new RecordingLifecycle();
     var segmentStore = new FakeSegmentStore();
+    var worker = new SignalingAbsentStopWorker();
     var cleanupService =
         new StreamSessionCleanupService(
-            runtimeService(runtimeRegistry, segmentStore),
+            runtimeService(runtimeRegistry, segmentStore, worker),
             lifecycle,
             segmentStore,
             new StreamSessionTransactionRetry(_ -> {}),
             new MutexFactoryProvider());
 
-    cleanupService.cleanup(streamSessionId);
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var cleanup = executor.submit(() -> cleanupService.cleanup(streamSessionId));
 
-    assertThat(lifecycle.deletedIds).isEmpty();
+      assertThat(worker.awaitStop()).isTrue();
+      assertThat(runtimeRegistry.awaitEntered()).isTrue();
+      assertThat(lifecycle.deletedIds).isEmpty();
 
-    runtimeRegistry.releaseReservation(reservation);
-    assertThat(runtimeRegistry.completeTranscodeStart(starter)).isFalse();
-    runtimeRegistry.finishRejectedTranscodeStart(starter, false);
-    cleanupService.cleanup(streamSessionId);
+      runtimeRegistry.releaseReservation(reservation);
+      assertThat(runtimeRegistry.completeTranscodeStart(starter)).isFalse();
+      runtimeRegistry.finishRejectedTranscodeStart(starter, false);
+      cleanup.get(5, TimeUnit.SECONDS);
+    }
 
     assertThat(lifecycle.deletedIds).containsExactly(streamSessionId);
   }
@@ -190,12 +207,13 @@ class StreamSessionCleanupServiceTest {
     var streamSessionId = UUID.randomUUID();
     var runtimeRegistry = new InMemoryStreamSessionRepository();
     runtimeRegistry.save(StreamSession.builder().sessionId(streamSessionId).build());
+    retainUncertainJob(runtimeRegistry, streamSessionId);
     var segmentStore = new FakeSegmentStore();
     segmentStore.addSegment(streamSessionId, "segment.ts", new byte[] {1});
-    var transcodeExecutor = new RetryableStopExecutor();
+    var transcodeWorker = new RetryableStopWorker();
     var cleanupService =
         new StreamSessionCleanupService(
-            runtimeService(runtimeRegistry, segmentStore, transcodeExecutor),
+            runtimeService(runtimeRegistry, segmentStore, transcodeWorker),
             new RecordingLifecycle(),
             segmentStore,
             new StreamSessionTransactionRetry(_ -> {}),
@@ -203,12 +221,12 @@ class StreamSessionCleanupServiceTest {
 
     cleanupService.reconcileUnbackedRuntimeAndStorage();
 
-    assertThat(transcodeExecutor.stopAttempts).isEqualTo(1);
+    assertThat(transcodeWorker.stopAttempts).isEqualTo(2);
     assertThat(segmentStore.segmentExists(streamSessionId, "segment.ts")).isTrue();
 
     cleanupService.reconcileUnbackedRuntimeAndStorage();
 
-    assertThat(transcodeExecutor.stopAttempts).isEqualTo(2);
+    assertThat(transcodeWorker.stopAttempts).isEqualTo(3);
     assertThat(segmentStore.segmentExists(streamSessionId, "segment.ts")).isFalse();
   }
 
@@ -218,11 +236,12 @@ class StreamSessionCleanupServiceTest {
     var streamSessionId = UUID.randomUUID();
     var runtimeRegistry = new InMemoryStreamSessionRepository();
     runtimeRegistry.save(StreamSession.builder().sessionId(streamSessionId).build());
+    retainUncertainJob(runtimeRegistry, streamSessionId);
     var segmentStore = new FakeSegmentStore();
-    var transcodeExecutor = new RetryableStopExecutor();
+    var transcodeWorker = new RetryableStopWorker();
     var cleanupService =
         new StreamSessionCleanupService(
-            runtimeService(runtimeRegistry, segmentStore, transcodeExecutor),
+            runtimeService(runtimeRegistry, segmentStore, transcodeWorker),
             new RecordingLifecycle(),
             segmentStore,
             new StreamSessionTransactionRetry(_ -> {}),
@@ -231,28 +250,42 @@ class StreamSessionCleanupServiceTest {
     cleanupService.reconcileUnbackedRuntimeAndStorage();
     cleanupService.reconcileUnbackedRuntimeAndStorage();
 
-    assertThat(transcodeExecutor.stopAttempts).isEqualTo(2);
+    assertThat(transcodeWorker.stopAttempts).isEqualTo(3);
   }
 
   private StreamingService runtimeService(
       RuntimeStreamSessionRegistry runtimeRegistry, SegmentStore segmentStore) {
-    return runtimeService(runtimeRegistry, segmentStore, new FakeTranscodeExecutor());
+    return runtimeService(runtimeRegistry, segmentStore, new AbsentStopWorker());
   }
 
   private StreamingService runtimeService(
       RuntimeStreamSessionRegistry runtimeRegistry,
       SegmentStore segmentStore,
-      TranscodeExecutor transcodeExecutor) {
+      TranscodeWorkerPort worker) {
+    var transcodeJobs =
+        DefaultPlaybackTranscodeJobService.builder()
+            .worker(worker)
+            .workerTarget(new WorkerTarget(UUID.randomUUID(), UUID.randomUUID()))
+            .runtimeRegistry(runtimeRegistry)
+            .sessionMutexes(new MutexFactory<>())
+            .build();
     return new HlsStreamingService(
         new FakeMediaFileRepository(),
-        transcodeExecutor,
         segmentStore,
         new FakeFfprobeService(),
         new TranscodeDecisionService(),
         new QualityLadderService(),
         StreamingProperties.builder().segmentDuration(Duration.ofSeconds(6)).build(),
         runtimeRegistry,
-        new MutexFactory<>());
+        new MutexFactory<>(),
+        transcodeJobs,
+        new FakeMediaSourceCatalog());
+  }
+
+  private static void retainUncertainJob(
+      RuntimeStreamSessionRegistry runtimeRegistry, UUID streamSessionId) {
+    var start = runtimeRegistry.beginTranscodeStart(streamSessionId).orElseThrow();
+    runtimeRegistry.abortTranscodeStart(start);
   }
 
   private static final class RecordingLifecycle
@@ -330,17 +363,65 @@ class StreamSessionCleanupServiceTest {
     }
   }
 
-  private static final class RetryableStopExecutor extends FakeTranscodeExecutor {
+  private static class AbsentStopWorker implements TranscodeWorkerPort {
+
+    @Override
+    public StartJobResult start(StartJobCommand command) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public StopJobResult stop(StopJobCommand command) {
+      return new StopJobResult.AlreadyAbsent(command.jobRef());
+    }
+
+    @Override
+    public InspectJobResult inspect(InspectJobQuery query) {
+      return new InspectJobResult.Rejected(InspectJobRejection.TARGET_MISMATCH);
+    }
+  }
+
+  private static final class RetryableStopWorker extends AbsentStopWorker {
 
     private int stopAttempts;
 
     @Override
-    public void stop(UUID sessionId) {
+    public StopJobResult stop(StopJobCommand command) {
       stopAttempts++;
-      if (stopAttempts == 1) {
-        throw new IllegalStateException("simulated runtime stop failure");
+      if (stopAttempts <= 2) {
+        return new StopJobResult.CleanupPending(command.jobRef());
       }
-      super.stop(sessionId);
+      return super.stop(command);
+    }
+  }
+
+  private static final class SignalingAbsentStopWorker extends AbsentStopWorker {
+
+    private final CountDownLatch stopEntered = new CountDownLatch(1);
+
+    @Override
+    public StopJobResult stop(StopJobCommand command) {
+      stopEntered.countDown();
+      return super.stop(command);
+    }
+
+    private boolean awaitStop() throws InterruptedException {
+      return stopEntered.await(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static final class SignalingAwaitRegistry extends InMemoryStreamSessionRepository {
+
+    private final CountDownLatch awaitEntered = new CountDownLatch(1);
+
+    @Override
+    public void awaitTranscodeStarts(UUID sessionId) {
+      awaitEntered.countDown();
+      super.awaitTranscodeStarts(sessionId);
+    }
+
+    private boolean awaitEntered() throws InterruptedException {
+      return awaitEntered.await(5, TimeUnit.SECONDS);
     }
   }
 

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/local/InMemoryStreamSessionRepositoryTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/local/InMemoryStreamSessionRepositoryTest.java
@@ -542,8 +542,8 @@ class InMemoryStreamSessionRepositoryTest {
   }
 
   @Test
-  @DisplayName("Should expose cleanup candidates without exposing an empty reservation")
-  void shouldExposeCleanupCandidatesWithoutExposingEmptyReservation() {
+  @DisplayName("Should expose only runtime sessions that still require cleanup")
+  void shouldExposeOnlyRuntimeSessionsThatStillRequireCleanup() {
     var session = StreamSessionFixture.buildMpegtsSession();
     var reservation = repository.reserve(session.getSessionId()).orElseThrow();
 
@@ -553,9 +553,6 @@ class InMemoryStreamSessionRepositoryTest {
     assertThat(repository.snapshotCleanupCandidateIds()).containsExactly(session.getSessionId());
 
     assertThat(repository.terminalize(session.getSessionId())).isTrue();
-    assertThat(repository.snapshotCleanupCandidateIds()).containsExactly(session.getSessionId());
-
-    repository.markRuntimeStopped(session.getSessionId());
     assertThat(repository.snapshotCleanupCandidateIds()).isEmpty();
   }
 


### PR DESCRIPTION
## Summary

- Cut playback over from per-rendition process control to the whole-job transcode service.
- Route startup, health inspection, suspension, resumption, destruction, and cleanup through exact fenced job ownership.
- Wire the local worker and trusted media-source catalog while preserving asynchronous playback-session creation.

This is the P5-A1g local-playback-cutover slice and targets the P5-A1f playback coordinator.

## Validation

- Clean full-reactor verification, including PostgreSQL integration tests, formatting, static checks, packaging, and aggregate coverage.
- Deterministic unit, integration, and smoke coverage for lifecycle transitions, cleanup, suspension, restart, and source resolution.
- Independent final review with no remaining validated findings.

Refs #76
