### PR TITLE
[P5-A2] Define the distributed transcode protobuf contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,41 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up Buf
+        uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
+        with:
+          version: '1.71.0'
+          setup_only: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify protobuf compatibility
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          buf format --diff --exit-code
+          buf lint --error-format github-actions
+
+          if [[ -z "${BASE_SHA}" ]]; then
+            echo "No pull-request base revision; skipping the breaking-change comparison."
+            exit 0
+          fi
+
+          if git cat-file -e "${BASE_SHA}:buf.yaml" 2>/dev/null; then
+            buf breaking \
+              --against "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git#format=git,commit=${BASE_SHA}" \
+              --error-format github-actions
+            exit 0
+          fi
+
+          if git ls-tree -r --name-only "${BASE_SHA}" \
+              -- streamarr-transcode-contract/src/main/protobuf | grep -q '\.proto$'; then
+            echo "::error::The base revision contains protobuf schemas without a Buf configuration"
+            exit 1
+          fi
+
+          echo "Initial protobuf baseline; no breaking comparison is required."
+
       - name: Set up JDK 25
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,9 @@
+version: v2
+modules:
+  - path: streamarr-transcode-contract/src/main/protobuf
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE

--- a/docs/adr/0018-direct-fenced-worker-control.adoc
+++ b/docs/adr/0018-direct-fenced-worker-control.adoc
@@ -10,6 +10,7 @@ Accepted
 * The former rendition-at-a-time, process-shaped `TranscodeExecutor` and its process-handle state have been removed from the server application.
 * No remote worker, worker listener, certificate authority, registration path, or distributed playback route is enabled yet.
 * The completed local extraction introduced the application boundary without introducing a remote transport.
+* The generated-only `streamarr-transcode-contract` module defines the versioned worker transport and compatibility gates; neither the server nor a worker runtime depends on it yet.
 * Distributed playback remains disabled until the durable command lifecycle and topology-A segment gate are complete.
 
 == Context
@@ -137,9 +138,10 @@ Maven downloads pinned platform-specific `protoc` and grpc-java generators; deve
 
 Evolution is additive within `v1`.
 Removed field names and numbers are reserved, unknown enum values are rejected at adapter boundaries, and compatibility ranges are advertised during registration.
+`ProtocolRevision.PROTOCOL_REVISION_V1` is the named value for numeric revision 1; range and negotiation fields remain numeric so a v1 peer can observe future revisions without understanding them.
 Buf format, lint, and breaking checks compare the proposed schema against the pull request's actual base revision.
 Generated sources are excluded from Sonar issue, duplication, and coverage analysis while the hand-written mappers remain covered.
-The protobuf service defines a typed `ReadSegment` request and bounded `SegmentChunk` stream after the byte-plane spike selected gRPC; media bytes remain data-plane payload while `MediaSourceRef` and every semantic command use the same versioned schema discipline.
+The protobuf service defines a typed `ReadSegment` request and a bounded stream of `ReadSegmentResponse` byte frames after the byte-plane spike selected gRPC; media bytes remain data-plane payload while `MediaSourceRef` and every semantic command use the same versioned schema discipline.
 
 === Service ownership and PostgreSQL
 
@@ -191,6 +193,7 @@ TLS validation always checks the installation chain, validity, EKU, revocation, 
 An endpoint becomes ready only after the control plane dials it and a nonce proof returns the registered worker identity, `boot_id`, and certificate.
 The controller persists a binding epoch over worker, boot, endpoint, and certificate.
 A new `boot_id`, endpoint replacement, certificate replacement, revocation, or incompatible protocol advertisement advances that epoch and invalidates the old channel and observations.
+Registration by a different boot is rejected while the current binding lease is live; this deliberately trades a short, database-clock-based failover delay for split-brain fencing, while exact same-boot retries remain idempotent.
 Reuse of the endpoint by another identity is rejected.
 
 The initial topology requires the media server to reach each worker's advertised endpoint.
@@ -210,16 +213,23 @@ Backups of distributed configuration must include this secret; losing it require
 Certificate issuance and issuer/root rotation use a PostgreSQL-backed singleton leadership lease so only one replica performs signing transitions at a time.
 
 An administrator mints a worker-specific 256-bit, single-use enrollment token whose digest and roughly ten-minute expiry are stored in PostgreSQL.
-The enrollment bundle contains the control endpoint, trust-bundle fingerprint, and token.
-The worker generates its private key locally, pins the supplied fingerprint before revealing the token, and submits a CSR containing its requested worker identity.
+The out-of-band enrollment bundle contains the control endpoint, a versioned public trust bundle, the SHA-256 fingerprint of its exact root DER, and the token.
+The public bundle distinguishes trust anchors, issuing certificates, and a dedicated revocation-signing leaf with a Streamarr-specific purpose; no private key is included.
+The worker verifies the supplied root fingerprint, installs that trust before revealing the token, generates its private key locally, and submits a CSR containing its requested worker identity.
+The worker reads the token from an owner-readable file and sends it only as lowercase gRPC `authorization` metadata with the exact value `Streamarr-Enrollment <token>`, where `<token>` is the unpadded base64url encoding of the 32 random bytes.
+It is never an ordinary Bearer credential or a protobuf field.
 The issuer ignores requested SAN authority and writes the worker identity bound to the grant.
-Issuance first durably claims the request and fixes its worker, public-key digest, serial, validity, and extensions; the leader signs without holding a database transaction, then atomically stores the certificate DER/chain and consumes the grant before returning any certificate.
-A retry after a lost response returns that stored certificate for the same request and key, while another key or worker is rejected; an expired in-progress claim may be safely re-signed from its fixed parameters because no certificate is delivered before the storing transaction commits.
+Issuance first durably claims the request and fixes its worker, public-key digest, serial, validity, extensions, and public-trust-bundle version; the leader signs without holding a database transaction, then atomically stores the certificate bundle and consumes the grant before returning any certificate.
+A retry after a lost response returns that exact stored certificate and trust-bundle version for the same request and key, while another key or worker is rejected; an expired in-progress claim may be safely re-signed from its fixed parameters because no certificate is delivered before the storing transaction commits.
+Old public bundle versions remain available until every retained issuance result and certificate that references them has expired.
 
 Worker certificates initially live seven days and rotate near half-life with jitter through an RPC authenticated by the current certificate; lifetime remains configurable after outage/recovery testing.
 Rotation permits a bounded overlap while the control plane replaces channels.
 Revocation marks the worker in authoritative control-plane state, rejects future registration/rotation, invalidates channels, and denies the certificate serial even before its natural expiry.
 Workers receive a signed revocation update so a revoked control certificate is denied per RPC without worker database access, including on an already-open channel.
+The active issuing intermediate issues a dedicated digital-signature-only revocation signer; its certificate is carried in the pinned public bundle, and each update identifies that signer by SHA-256 of its exact DER.
+Protocol revision 1 signs the exact serialized update bytes with `SHA256withECDSA` and carries the resulting ASN.1 DER signature.
+The CA intermediate key never signs arbitrary revocation-feed bytes.
 CA rotation and trust-domain replacement use explicit overlap and worker re-enrollment; they are never silent in-place key replacement.
 grpc-java credential-manager reload APIs are experimental, so live leaf reload, peer-identity verification, channel drain, and revocation are executable P5-B gates before remote mutation is enabled.
 
@@ -315,7 +325,8 @@ The server authorizes the request against link:0017-playback-enforcement-lifecyc
 A request admitted before revocation may finish; the first gate after committed revocation denies.
 
 The measured initial byte transport is gRPC server streaming on the worker's existing mTLS channel.
-A typed `ReadSegment` request names target worker/boot, job, generation, rendition, and segment; each `SegmentChunk` carries at most 64 KiB.
+A typed `ReadSegment` request names target worker/boot, job, generation, rendition, and segment.
+The first `ReadSegmentResponse` declares the exact content length and content type; each subsequent data frame carries at most 64 KiB, and their combined size must equal the declaration.
 Mutual TLS authenticates the exact control and worker identities, and the worker rejects stale or unknown ownership before opening the file.
 Rendition and segment identifiers must belong to that job's published manifest and are never treated as unchecked filesystem paths.
 HTTP/2 flow control, bounded reads, and response readiness limit queued data, cancellation stops disk reads promptly, and neither endpoint buffers the whole segment.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -161,9 +161,9 @@ signing material never cross the boundary.
 Sources use a logical mount/library id plus normalized relative key. Shared source mounts are
 read-only from Streamarr's perspective and are trusted not to change path identity between
 resolution and FFmpeg open; real-path checks reject escape at each resolution but are not
-filesystem capability handles. Segments remain worker-local
-and return as bounded protobuf `SegmentChunk` streams over the selected worker's existing mTLS
-gRPC channel only after the authoritative playback gate succeeds. Streamarr translates that
+filesystem capability handles. Segments remain worker-local and return as bounded protobuf
+`ReadSegmentResponse` streams over the selected worker's existing mTLS gRPC channel only after the
+authoritative playback gate succeeds. Streamarr translates that
 internal stream to the client's HLS HTTP response; workers expose no second byte-serving listener.
 NATS/JetStream is deferred until outbound-only or intermittently connected workers, remote leaf
 sites, or durable broker backlog become real requirements; Kafka and Redpanda are not part of this

--- a/docs/spikes/0018-segment-and-source-data-planes.adoc
+++ b/docs/spikes/0018-segment-and-source-data-planes.adoc
@@ -9,7 +9,7 @@ Disposable decision input, 2026-07-11. The executable harness lives only under
 == Decision taken from this spike
 
 Use typed protobuf/gRPC for control messages and topology-A segment bytes. P5-A2 defines a
-`ReadSegment` server-streaming RPC whose `SegmentChunk` payload is bounded to 64 KiB.
+`ReadSegment` server-streaming RPC whose `ReadSegmentResponse` payload is bounded to 64 KiB.
 
 Both measured transports exceeded the 1 GbE payload budget. Raw HTTP was faster at ordinary
 concurrency, but gRPC allocated less, stopped server read-ahead sooner after cancellation, had far
@@ -126,8 +126,9 @@ job/generation-scoped capability only if TLS is later terminated by an intermedi
 client class is allowed onto the endpoint. Never reuse an account, refresh, playback, worker, or
 enrollment token.
 
-Each `SegmentChunk` carries at most 64 KiB. Streamarr forwards those bytes into the existing HLS
-HTTP response without materializing a whole segment. A disconnected or cancelled downstream
+The first `ReadSegmentResponse` carries exact length/content-type metadata; each later response
+carries at most 64 KiB of data. Streamarr forwards those bytes into the existing HLS HTTP response
+without materializing a whole segment. A disconnected or cancelled downstream
 client cancels the worker stream and closes the file. Range support is not required for the first
 complete-segment path; add it only with an end-to-end client Range contract and tests.
 
@@ -271,7 +272,7 @@ benchmark with authenticated raw HTTP and amend ADR 0018 before changing transpo
 * Client and server shared a JVM, so CPU/allocation/RSS are combined and JIT work can leak into a
   scenario.
 * The gRPC method used real HTTP/2/TLS/flow control but raw 64 KiB response marshalling rather than
-  a generated protobuf `SegmentChunk`; generated-message allocation/copy cost may be higher.
+  a generated protobuf response frame; generated-message allocation/copy cost may be higher.
 * The HTTP implementation was JDK `HttpsServer`/`HttpClient` HTTP/1.1, not the eventual worker and
   Spring/Tomcat (or Netty) proxy stack.
 * The test proves bounded application reads, not zero buffering in TLS, HTTP/2, kernel socket, or

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>streamarr-transcode-engine</module>
+        <module>streamarr-transcode-contract</module>
         <module>streamarr-server</module>
         <module>streamarr-coverage</module>
     </modules>
@@ -29,9 +30,12 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${maven.multiModuleProjectDirectory}/streamarr-coverage/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.coverage.exclusions>**/pom.xml, **/StreamarrServerApplication.java</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>
+            **/pom.xml, **/StreamarrServerApplication.java, **/target/generated-sources/**
+        </sonar.coverage.exclusions>
         <sonar.test.inclusions>**/src/test/**</sonar.test.inclusions>
-        <sonar.exclusions>**/jooq/generated/**</sonar.exclusions>
+        <sonar.exclusions>**/jooq/generated/**, **/target/generated-sources/**</sonar.exclusions>
+        <sonar.cpd.exclusions>**/target/generated-sources/**</sonar.cpd.exclusions>
         <sonar.issue.ignore.multicriteria>e1,e2,e3,e4</sonar.issue.ignore.multicriteria>
         <!-- Google Java Format puts static imports first; S8445 wants them last -->
         <sonar.issue.ignore.multicriteria.e1.ruleKey>java:S8445</sonar.issue.ignore.multicriteria.e1.ruleKey>
@@ -141,6 +145,7 @@
                         <excludes>
                             <exclude>**/com/streamarr/server/jooq/generated/**</exclude>
                             <exclude>**/com/streamarr/server/config/DevDataInitializer.class</exclude>
+                            <exclude>**/com/streamarr/transcode/v1/**</exclude>
                         </excludes>
                     </configuration>
                 </plugin>

--- a/streamarr-transcode-contract/pom.xml
+++ b/streamarr-transcode-contract/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.streamarr</groupId>
+        <artifactId>streamarr-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>streamarr-transcode-contract</artifactId>
+    <name>Streamarr Transcode Contract</name>
+    <description>Versioned protobuf and gRPC transport contract for transcode workers.</description>
+
+    <properties>
+        <contract.descriptor.file>
+            ${project.build.directory}/protobuf/streamarr-transcode-v1.binpb
+        </contract.descriptor.file>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-contract-dependency-boundary</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <searchTransitive>false</searchTransitive>
+                                    <message>
+                                        The transcode contract may depend only on protobuf and gRPC
+                                        schema runtimes.
+                                    </message>
+                                    <excludes>
+                                        <exclude>*:*:*:*:compile</exclude>
+                                        <exclude>*:*:*:*:runtime</exclude>
+                                        <exclude>*:*:*:*:provided</exclude>
+                                        <exclude>*:*:*:*:system</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>com.google.protobuf:protobuf-java</include>
+                                        <include>io.grpc:grpc-protobuf</include>
+                                        <include>io.grpc:grpc-stub</include>
+                                    </includes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>checkstyle-check</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <contract.descriptor.file>
+                            ${contract.descriptor.file}
+                        </contract.descriptor.file>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/streamarr-transcode-contract/pom.xml
+++ b/streamarr-transcode-contract/pom.xml
@@ -47,15 +47,26 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+                <groupId>io.github.ascopes</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <configuration>
+                    <protoc kind="binary-maven">
+                        <version>${protobuf-java.version}</version>
+                    </protoc>
+                    <plugins>
+                        <plugin kind="binary-maven">
+                            <groupId>io.grpc</groupId>
+                            <artifactId>protoc-gen-grpc-java</artifactId>
+                            <version>${grpc-java.version}</version>
+                        </plugin>
+                    </plugins>
+                    <outputDescriptorFile>${contract.descriptor.file}</outputDescriptorFile>
+                    <outputDescriptorIncludeImports>true</outputDescriptorIncludeImports>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <skipIfEmpty>true</skipIfEmpty>
-                </configuration>
+                <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/common.proto
+++ b/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/common.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package streamarr.transcode.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "CommonProto";
+option java_package = "com.streamarr.transcode.v1";
+
+// Range and negotiation fields stay numeric so future revisions remain observable to v1 peers.
+enum ProtocolRevision {
+  PROTOCOL_REVISION_UNSPECIFIED = 0;
+  PROTOCOL_REVISION_V1 = 1;
+}
+
+// UUID bits use the same most-significant/least-significant layout as java.util.UUID.
+message Uuid {
+  fixed64 most_significant_bits = 1;
+  fixed64 least_significant_bits = 2;
+}
+
+message WorkerTarget {
+  Uuid worker_id = 1;
+  Uuid boot_id = 2;
+}
+
+// Host contains no scheme or path. Port is in the inclusive range 1..65535.
+message WorkerEndpoint {
+  string host = 1;
+  uint32 port = 2;
+}
+
+message ProtocolRange {
+  uint32 minimum_revision = 1;
+  uint32 maximum_revision = 2;
+}
+
+// The operator pins SHA-256 of the exact root DER out of band before enrollment. A retained
+// enrollment result always returns the same version, even if a newer bundle becomes active.
+message PublicTrustBundle {
+  uint64 version = 1;
+  repeated bytes trust_anchor_certificates_der = 2;
+  repeated bytes issuer_certificates_der = 3;
+  repeated bytes revocation_signer_certificates_der = 4;
+}
+
+message CertificateBundle {
+  Uuid worker_id = 1;
+  bytes leaf_certificate_der = 2;
+  PublicTrustBundle trust_bundle = 3;
+}
+
+message RevokedCertificate {
+  // SHA-256 of the issuer certificate DER. Exactly 32 bytes.
+  bytes issuer_certificate_sha256 = 1;
+  // Unsigned big-endian certificate serial number.
+  bytes serial_number = 2;
+  google.protobuf.Timestamp revoked_at = 3;
+}
+
+message RevocationUpdate {
+  uint64 sequence = 1;
+  google.protobuf.Timestamp issued_at = 2;
+  google.protobuf.Timestamp expires_at = 3;
+  repeated RevokedCertificate revoked_certificates = 4;
+}
+
+// Verify the signature over serialized_update before parsing it. Protobuf serialization is not a
+// canonical encoding, so receivers must not reserialize the update before verification. V1 uses
+// SHA256withECDSA and the ASN.1 DER signature encoding produced by that algorithm.
+message SignedRevocationUpdate {
+  bytes serialized_update = 1;
+  bytes signature = 2;
+  // SHA-256 of the signing certificate DER. Exactly 32 bytes.
+  bytes signer_certificate_sha256 = 3;
+}

--- a/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/transcode.proto
+++ b/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/transcode.proto
@@ -1,0 +1,136 @@
+syntax = "proto3";
+
+package streamarr.transcode.v1;
+
+import "google/protobuf/duration.proto";
+import "streamarr/transcode/v1/common.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "TranscodeProto";
+option java_package = "com.streamarr.transcode.v1";
+
+enum TranscodeMode {
+  TRANSCODE_MODE_UNSPECIFIED = 0;
+  TRANSCODE_MODE_REMUX = 1;
+  TRANSCODE_MODE_AUDIO_TRANSCODE = 2;
+  TRANSCODE_MODE_VIDEO_TRANSCODE = 3;
+  TRANSCODE_MODE_FULL_TRANSCODE = 4;
+}
+
+enum AudioMode {
+  AUDIO_MODE_UNSPECIFIED = 0;
+  AUDIO_MODE_COPY = 1;
+  AUDIO_MODE_TRANSCODE = 2;
+  AUDIO_MODE_NONE = 3;
+}
+
+enum SubtitleMode {
+  SUBTITLE_MODE_UNSPECIFIED = 0;
+  SUBTITLE_MODE_EXCLUDE = 1;
+  SUBTITLE_MODE_BURN_IN = 2;
+  SUBTITLE_MODE_SIDECAR = 3;
+  SUBTITLE_MODE_HLS = 4;
+  SUBTITLE_MODE_EMBED = 5;
+}
+
+enum ContainerFormat {
+  CONTAINER_FORMAT_UNSPECIFIED = 0;
+  CONTAINER_FORMAT_MPEG_TS = 1;
+  CONTAINER_FORMAT_FMP4 = 2;
+}
+
+enum TranscodeJobState {
+  TRANSCODE_JOB_STATE_UNSPECIFIED = 0;
+  TRANSCODE_JOB_STATE_ADMITTING = 1;
+  TRANSCODE_JOB_STATE_RUNNING = 2;
+  TRANSCODE_JOB_STATE_COMPLETED = 3;
+  TRANSCODE_JOB_STATE_FAILED = 4;
+  TRANSCODE_JOB_STATE_STOPPED = 5;
+  TRANSCODE_JOB_STATE_ABSENT = 6;
+}
+
+enum RenditionState {
+  RENDITION_STATE_UNSPECIFIED = 0;
+  RENDITION_STATE_STARTING = 1;
+  RENDITION_STATE_RUNNING = 2;
+  RENDITION_STATE_COMPLETED = 3;
+  RENDITION_STATE_FAILED = 4;
+  RENDITION_STATE_STOPPED = 5;
+  RENDITION_STATE_ABSENT = 6;
+}
+
+// The namespace is installation-defined; relative_key never contains a host-local absolute path.
+message MediaSourceRef {
+  Uuid source_namespace_id = 1;
+  string relative_key = 2;
+}
+
+message TranscodeJobRef {
+  Uuid job_id = 1;
+  uint64 generation = 2;
+}
+
+message AudioDecision {
+  AudioMode mode = 1;
+  optional string codec = 2;
+  uint32 channels = 3;
+  uint64 bitrate_bits_per_second = 4;
+}
+
+message SubtitleDecision {
+  SubtitleMode mode = 1;
+  optional string codec = 2;
+  optional uint32 stream_index = 3;
+  optional string language = 4;
+}
+
+message TranscodeDecision {
+  TranscodeMode transcode_mode = 1;
+  string video_codec_family = 2;
+  AudioDecision audio = 3;
+  SubtitleDecision subtitle = 4;
+  ContainerFormat container = 5;
+  bool force_keyframes_at_segment_boundaries = 6;
+}
+
+message TranscodeExecutionParameters {
+  uint32 seek_position_seconds = 1;
+  uint32 segment_duration_seconds = 2;
+  double framerate = 3;
+  uint32 start_number = 4;
+  google.protobuf.Duration startup_timeout = 5;
+}
+
+message RenditionSpec {
+  string label = 1;
+  uint32 width = 2;
+  uint32 height = 3;
+  uint64 bitrate_bits_per_second = 4;
+}
+
+message TranscodeJobSpec {
+  Uuid session_id = 1;
+  TranscodeJobRef job_ref = 2;
+  MediaSourceRef source = 3;
+  TranscodeDecision decision = 4;
+  TranscodeExecutionParameters execution = 5;
+  repeated RenditionSpec renditions = 6;
+}
+
+message RenditionObservation {
+  string label = 1;
+  RenditionState state = 2;
+}
+
+message TranscodeJobObservation {
+  TranscodeJobRef job_ref = 1;
+  TranscodeJobState state = 2;
+  repeated RenditionObservation renditions = 3;
+}
+
+message JobSnapshot {
+  oneof snapshot {
+    TranscodeJobObservation observation = 1;
+    TranscodeJobRef cleanup_pending = 2;
+  }
+}

--- a/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/worker_control.proto
+++ b/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/worker_control.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package streamarr.transcode.v1;
+
+import "streamarr/transcode/v1/common.proto";
+import "streamarr/transcode/v1/transcode.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "WorkerControlProto";
+option java_package = "com.streamarr.transcode.v1";
+
+enum StartJobRejection {
+  START_JOB_REJECTION_UNSPECIFIED = 0;
+  START_JOB_REJECTION_TARGET_MISMATCH = 1;
+  START_JOB_REJECTION_STALE_GENERATION = 2;
+  START_JOB_REJECTION_COMMAND_CONFLICT = 3;
+  START_JOB_REJECTION_JOB_CONFLICT = 4;
+  START_JOB_REJECTION_CAPACITY_EXHAUSTED = 5;
+  START_JOB_REJECTION_SOURCE_UNAVAILABLE = 6;
+  START_JOB_REJECTION_INVALID_SPECIFICATION = 7;
+  START_JOB_REJECTION_STARTUP_FAILED = 8;
+  START_JOB_REJECTION_SHUTTING_DOWN = 9;
+}
+
+enum StopJobRejection {
+  STOP_JOB_REJECTION_UNSPECIFIED = 0;
+  STOP_JOB_REJECTION_TARGET_MISMATCH = 1;
+  STOP_JOB_REJECTION_STALE_GENERATION = 2;
+  STOP_JOB_REJECTION_COMMAND_CONFLICT = 3;
+}
+
+enum InspectJobRejection {
+  INSPECT_JOB_REJECTION_UNSPECIFIED = 0;
+  INSPECT_JOB_REJECTION_TARGET_MISMATCH = 1;
+}
+
+enum SegmentContentType {
+  SEGMENT_CONTENT_TYPE_UNSPECIFIED = 0;
+  SEGMENT_CONTENT_TYPE_VIDEO_MP2T = 1;
+  SEGMENT_CONTENT_TYPE_VIDEO_MP4 = 2;
+}
+
+message ProveEndpointRequest {
+  WorkerTarget target = 1;
+  // Exactly 32 unpredictable bytes supplied by the control plane.
+  bytes nonce = 2;
+}
+
+message ProveEndpointResponse {
+  WorkerTarget target = 1;
+  bytes nonce = 2;
+  bytes leaf_certificate_der = 3;
+}
+
+message StartJobRequest {
+  Uuid command_id = 1;
+  WorkerTarget target = 2;
+  TranscodeJobSpec job_spec = 3;
+}
+
+message StartJobResponse {
+  oneof result {
+    TranscodeJobObservation accepted = 1;
+    StartJobRejection rejection = 2;
+    TranscodeJobRef cleanup_pending = 3;
+  }
+}
+
+message StopJobRequest {
+  Uuid command_id = 1;
+  WorkerTarget target = 2;
+  TranscodeJobRef job_ref = 3;
+}
+
+message StopJobResponse {
+  oneof result {
+    TranscodeJobRef stopped = 1;
+    TranscodeJobRef already_absent = 2;
+    TranscodeJobRef cleanup_pending = 3;
+    StopJobRejection rejection = 4;
+  }
+}
+
+message InspectJobRequest {
+  WorkerTarget target = 1;
+  TranscodeJobRef job_ref = 2;
+}
+
+message InspectJobResponse {
+  oneof result {
+    TranscodeJobObservation observation = 1;
+    TranscodeJobRef cleanup_pending = 2;
+    InspectJobRejection rejection = 3;
+  }
+}
+
+message ListJobsRequest {
+  WorkerTarget target = 1;
+  // Inclusive range 1..256.
+  uint32 page_size = 2;
+  bytes continuation = 3;
+}
+
+message ListJobsResponse {
+  repeated JobSnapshot jobs = 1;
+  bytes next_continuation = 2;
+}
+
+message InitializationSegment {}
+
+message SegmentRef {
+  oneof segment {
+    InitializationSegment initialization = 1;
+    uint64 media_sequence = 2;
+  }
+}
+
+message ReadSegmentRequest {
+  WorkerTarget target = 1;
+  TranscodeJobRef job_ref = 2;
+  string rendition_label = 3;
+  SegmentRef segment = 4;
+}
+
+message SegmentMetadata {
+  uint64 content_length_bytes = 1;
+  SegmentContentType content_type = 2;
+}
+
+// The first frame contains metadata exactly once. Every later frame contains between 1 byte and 64
+// KiB of data, and their combined size equals metadata.content_length_bytes.
+message ReadSegmentResponse {
+  oneof frame {
+    SegmentMetadata metadata = 1;
+    bytes data = 2;
+  }
+}
+
+service WorkerControlService {
+  rpc ProveEndpoint(ProveEndpointRequest) returns (ProveEndpointResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc StartJob(StartJobRequest) returns (StartJobResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  rpc StopJob(StopJobRequest) returns (StopJobResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  rpc InspectJob(InspectJobRequest) returns (InspectJobResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc ListJobs(ListJobsRequest) returns (ListJobsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+  rpc ReadSegment(ReadSegmentRequest) returns (stream ReadSegmentResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
+}

--- a/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/worker_enrollment.proto
+++ b/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/worker_enrollment.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package streamarr.transcode.v1;
+
+import "streamarr/transcode/v1/common.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "WorkerEnrollmentProto";
+option java_package = "com.streamarr.transcode.v1";
+
+enum EnrollWorkerRejection {
+  ENROLL_WORKER_REJECTION_UNSPECIFIED = 0;
+  ENROLL_WORKER_REJECTION_INVALID_OR_EXPIRED_GRANT = 1;
+  ENROLL_WORKER_REJECTION_REQUEST_CONFLICT = 2;
+  ENROLL_WORKER_REJECTION_INVALID_CERTIFICATE_REQUEST = 3;
+  ENROLL_WORKER_REJECTION_WORKER_REVOKED = 4;
+  ENROLL_WORKER_REJECTION_SIGNING_UNAVAILABLE = 5;
+}
+
+enum RotateWorkerCertificateRejection {
+  ROTATE_WORKER_CERTIFICATE_REJECTION_UNSPECIFIED = 0;
+  ROTATE_WORKER_CERTIFICATE_REJECTION_IDENTITY_MISMATCH = 1;
+  ROTATE_WORKER_CERTIFICATE_REJECTION_REQUEST_CONFLICT = 2;
+  ROTATE_WORKER_CERTIFICATE_REJECTION_INVALID_CERTIFICATE_REQUEST = 3;
+  ROTATE_WORKER_CERTIFICATE_REJECTION_WORKER_REVOKED = 4;
+  ROTATE_WORKER_CERTIFICATE_REJECTION_SIGNING_UNAVAILABLE = 5;
+}
+
+// The single-use enrollment token is carried under the lowercase `authorization` metadata key as
+// `Streamarr-Enrollment <token>`, where token is the unpadded base64url encoding of exactly 32
+// random bytes. Generated messages can never render it through toString(). The server interceptor
+// consumes and digests it synchronously.
+message EnrollWorkerRequest {
+  Uuid request_id = 1;
+  Uuid worker_id = 2;
+  bytes certificate_signing_request_der = 3;
+}
+
+message EnrollWorkerResponse {
+  oneof result {
+    CertificateBundle certificate = 1;
+    EnrollWorkerRejection rejection = 2;
+  }
+}
+
+// Rotation is authenticated exclusively by the worker's current mTLS identity.
+message RotateWorkerCertificateRequest {
+  Uuid request_id = 1;
+  Uuid worker_id = 2;
+  bytes certificate_signing_request_der = 3;
+}
+
+message RotateWorkerCertificateResponse {
+  oneof result {
+    CertificateBundle certificate = 1;
+    RotateWorkerCertificateRejection rejection = 2;
+  }
+}
+
+service WorkerEnrollmentService {
+  rpc EnrollWorker(EnrollWorkerRequest) returns (EnrollWorkerResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  rpc RotateWorkerCertificate(RotateWorkerCertificateRequest) returns (RotateWorkerCertificateResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+}

--- a/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/worker_registry.proto
+++ b/streamarr-transcode-contract/src/main/protobuf/streamarr/transcode/v1/worker_registry.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package streamarr.transcode.v1;
+
+import "google/protobuf/duration.proto";
+import "streamarr/transcode/v1/common.proto";
+import "streamarr/transcode/v1/transcode.proto";
+
+option java_multiple_files = true;
+option java_outer_classname = "WorkerRegistryProto";
+option java_package = "com.streamarr.transcode.v1";
+
+enum DrainState {
+  DRAIN_STATE_UNSPECIFIED = 0;
+  DRAIN_STATE_ACCEPTING = 1;
+  DRAIN_STATE_DRAINING = 2;
+  DRAIN_STATE_DRAINED = 3;
+}
+
+enum RegisterWorkerRejection {
+  REGISTER_WORKER_REJECTION_UNSPECIFIED = 0;
+  REGISTER_WORKER_REJECTION_IDENTITY_MISMATCH = 1;
+  REGISTER_WORKER_REJECTION_INCOMPATIBLE_PROTOCOL = 2;
+  REGISTER_WORKER_REJECTION_ENDPOINT_CONFLICT = 3;
+  REGISTER_WORKER_REJECTION_WORKER_REVOKED = 4;
+  REGISTER_WORKER_REJECTION_ACTIVE_BINDING = 5;
+}
+
+message WorkerCapabilities {
+  repeated string video_codec_families = 1;
+  repeated string encoders = 2;
+  repeated string hardware_accelerators = 3;
+  repeated Uuid source_namespace_ids = 4;
+  repeated ContainerFormat container_formats = 5;
+}
+
+message WorkerCapacity {
+  uint32 total_slots = 1;
+  uint32 occupied_slots = 2;
+}
+
+message RegisterWorkerRequest {
+  WorkerTarget target = 1;
+  WorkerEndpoint endpoint = 2;
+  ProtocolRange supported_protocol = 3;
+}
+
+message RegisterWorkerAccepted {
+  uint64 binding_epoch = 1;
+  uint32 protocol_revision = 2;
+  google.protobuf.Duration heartbeat_interval = 3;
+  SignedRevocationUpdate revocation_update = 4;
+}
+
+message RegisterWorkerResponse {
+  oneof result {
+    RegisterWorkerAccepted accepted = 1;
+    RegisterWorkerRejection rejection = 2;
+  }
+}
+
+message HeartbeatRequest {
+  WorkerTarget target = 1;
+  uint64 binding_epoch = 2;
+  uint64 sequence = 3;
+  uint32 protocol_revision = 4;
+  WorkerCapabilities capabilities = 5;
+  DrainState drain_state = 6;
+  WorkerCapacity capacity = 7;
+  repeated TranscodeJobObservation jobs = 8;
+}
+
+message HeartbeatResponse {
+  uint64 accepted_sequence = 1;
+  uint64 binding_epoch = 2;
+  SignedRevocationUpdate revocation_update = 3;
+}
+
+service WorkerRegistryService {
+  rpc RegisterWorker(RegisterWorkerRequest) returns (RegisterWorkerResponse) {
+    option idempotency_level = IDEMPOTENT;
+  }
+  // A heartbeat is superseded by the next sequence and is never replayed automatically.
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse) {}
+}

--- a/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractDescriptorTest.java
+++ b/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractDescriptorTest.java
@@ -1,0 +1,103 @@
+package com.streamarr.transcode.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class ContractDescriptorTest {
+
+  private static final String PACKAGE = "streamarr.transcode.v1";
+
+  @Test
+  @DisplayName("Should publish the complete v1 service surface when generating the descriptor")
+  void shouldPublishCompleteV1ServiceSurfaceWhenGeneratingDescriptor() throws Exception {
+    var descriptor = readDescriptor();
+    var contractFiles =
+        descriptor.getFileList().stream()
+            .filter(file -> PACKAGE.equals(file.getPackage()))
+            .toList();
+
+    assertThat(contractFiles)
+        .extracting(FileDescriptorProto::getName)
+        .containsExactlyInAnyOrder(
+            "streamarr/transcode/v1/common.proto",
+            "streamarr/transcode/v1/transcode.proto",
+            "streamarr/transcode/v1/worker_control.proto",
+            "streamarr/transcode/v1/worker_registry.proto",
+            "streamarr/transcode/v1/worker_enrollment.proto");
+
+    var services =
+        contractFiles.stream()
+            .flatMap(file -> file.getServiceList().stream())
+            .collect(Collectors.toMap(service -> service.getName(), Function.identity()));
+
+    assertThat(services)
+        .containsOnlyKeys(
+            "WorkerControlService", "WorkerRegistryService", "WorkerEnrollmentService");
+    assertMethods(
+        services.get("WorkerControlService").getMethodList(),
+        Map.of(
+            "ProveEndpoint", method("ProveEndpointRequest", "ProveEndpointResponse", false),
+            "StartJob", method("StartJobRequest", "StartJobResponse", false),
+            "StopJob", method("StopJobRequest", "StopJobResponse", false),
+            "InspectJob", method("InspectJobRequest", "InspectJobResponse", false),
+            "ListJobs", method("ListJobsRequest", "ListJobsResponse", false),
+            "ReadSegment", method("ReadSegmentRequest", "ReadSegmentResponse", true)));
+    assertMethods(
+        services.get("WorkerRegistryService").getMethodList(),
+        Map.of(
+            "RegisterWorker", method("RegisterWorkerRequest", "RegisterWorkerResponse", false),
+            "Heartbeat", method("HeartbeatRequest", "HeartbeatResponse", false)));
+    assertMethods(
+        services.get("WorkerEnrollmentService").getMethodList(),
+        Map.of(
+            "EnrollWorker", method("EnrollWorkerRequest", "EnrollWorkerResponse", false),
+            "RotateWorkerCertificate",
+                method(
+                    "RotateWorkerCertificateRequest", "RotateWorkerCertificateResponse", false)));
+  }
+
+  private static void assertMethods(
+      java.util.List<MethodDescriptorProto> methods, Map<String, MethodContract> expected) {
+    var actual =
+        methods.stream()
+            .collect(
+                Collectors.toMap(
+                    MethodDescriptorProto::getName,
+                    method ->
+                        new MethodContract(
+                            simpleName(method.getInputType()),
+                            simpleName(method.getOutputType()),
+                            method.getServerStreaming())));
+
+    assertThat(actual).isEqualTo(expected);
+    assertThat(methods).allSatisfy(method -> assertThat(method.getClientStreaming()).isFalse());
+  }
+
+  private static MethodContract method(String input, String output, boolean serverStreaming) {
+    return new MethodContract(input, output, serverStreaming);
+  }
+
+  private static String simpleName(String qualifiedName) {
+    return qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
+  }
+
+  private static FileDescriptorSet readDescriptor() throws Exception {
+    var descriptorPath = Path.of(System.getProperty("contract.descriptor.file"));
+    assertThat(descriptorPath).isRegularFile();
+    return FileDescriptorSet.parseFrom(Files.readAllBytes(descriptorPath));
+  }
+
+  private record MethodContract(String input, String output, boolean serverStreaming) {}
+}

--- a/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractPolicyTest.java
+++ b/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractPolicyTest.java
@@ -47,6 +47,7 @@ class ContractPolicyTest {
     var files = contractFiles();
 
     assertThat(files)
+        .isNotEmpty()
         .allSatisfy(
             file -> {
               assertThat(file.getOptions().getJavaPackage()).isEqualTo(JAVA_PACKAGE);
@@ -59,10 +60,13 @@ class ContractPolicyTest {
   @DisplayName("Should expose only typed bounded transport fields when describing the contract")
   void shouldExposeOnlyTypedBoundedTransportFieldsWhenDescribingContract() throws Exception {
     var messages = messagesByName(contractFiles());
-    var fields = messages.values().stream().flatMap(ContractPolicyTest::fields);
+    var fields = messages.values().stream().flatMap(ContractPolicyTest::fields).toList();
 
-    assertThat(messages.values()).noneMatch(message -> message.getOptions().getMapEntry());
+    assertThat(messages.values())
+        .isNotEmpty()
+        .noneMatch(message -> message.getOptions().getMapEntry());
     assertThat(fields)
+        .isNotEmpty()
         .allSatisfy(
             field -> {
               assertThat(field.getTypeName())
@@ -127,8 +131,8 @@ class ContractPolicyTest {
             .flatMap(file -> Stream.concat(file.getEnumTypeList().stream(), nestedEnums(file)))
             .toList();
 
-    assertThat(enums).isNotEmpty();
     assertThat(enums)
+        .isNotEmpty()
         .allSatisfy(
             descriptor -> {
               var zero =

--- a/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractPolicyTest.java
+++ b/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractPolicyTest.java
@@ -1,0 +1,205 @@
+package com.streamarr.transcode.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.DescriptorProtos.MethodOptions.IdempotencyLevel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class ContractPolicyTest {
+
+  private static final String PACKAGE = "streamarr.transcode.v1";
+  private static final String JAVA_PACKAGE = "com.streamarr.transcode.v1";
+  private static final Set<String> ALLOWED_BYTES_FIELDS =
+      Set.of(
+          "certificate_signing_request_der",
+          "continuation",
+          "data",
+          "issuer_certificate_sha256",
+          "issuer_certificates_der",
+          "leaf_certificate_der",
+          "next_continuation",
+          "nonce",
+          "serial_number",
+          "serialized_update",
+          "signature",
+          "signer_certificate_sha256",
+          "revocation_signer_certificates_der",
+          "trust_anchor_certificates_der");
+
+  @Test
+  @DisplayName("Should keep generated Java types isolated in the versioned transport package")
+  void shouldKeepGeneratedJavaTypesIsolatedInVersionedTransportPackage() throws Exception {
+    var files = contractFiles();
+
+    assertThat(files)
+        .allSatisfy(
+            file -> {
+              assertThat(file.getOptions().getJavaPackage()).isEqualTo(JAVA_PACKAGE);
+              assertThat(file.getOptions().getJavaMultipleFiles()).isTrue();
+              assertThat(file.getOptions().getJavaOuterClassname()).endsWith("Proto");
+            });
+  }
+
+  @Test
+  @DisplayName("Should expose only typed bounded transport fields when describing the contract")
+  void shouldExposeOnlyTypedBoundedTransportFieldsWhenDescribingContract() throws Exception {
+    var messages = messagesByName(contractFiles());
+    var fields = messages.values().stream().flatMap(ContractPolicyTest::fields);
+
+    assertThat(messages.values()).noneMatch(message -> message.getOptions().getMapEntry());
+    assertThat(fields)
+        .allSatisfy(
+            field -> {
+              assertThat(field.getTypeName())
+                  .isNotIn(
+                      ".google.protobuf.Any", ".google.protobuf.Struct", ".google.protobuf.Value");
+              assertThat(field.getName())
+                  .doesNotContainIgnoringCase("argv")
+                  .doesNotContainIgnoringCase("password")
+                  .doesNotContainIgnoringCase("pid")
+                  .doesNotContainIgnoringCase("secret")
+                  .doesNotContainIgnoringCase("token");
+              if (field.getType() == FieldDescriptorProto.Type.TYPE_BYTES) {
+                assertThat(field.getName()).isIn(ALLOWED_BYTES_FIELDS);
+              }
+            });
+
+    assertThat(messages.get("ReadSegmentResponse").getFieldList())
+        .extracting(FieldDescriptorProto::getName)
+        .containsExactly("metadata", "data");
+    assertThat(messages.get("SegmentMetadata").getFieldList())
+        .extracting(FieldDescriptorProto::getName)
+        .containsExactly("content_length_bytes", "content_type");
+    assertThat(
+            messages.get("SegmentMetadata").getFieldList().stream()
+                .collect(
+                    Collectors.toMap(FieldDescriptorProto::getName, FieldDescriptorProto::getType)))
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "content_length_bytes", FieldDescriptorProto.Type.TYPE_UINT64,
+                "content_type", FieldDescriptorProto.Type.TYPE_ENUM));
+    assertThat(messages.get("EnrollWorkerRequest").getFieldList())
+        .extracting(FieldDescriptorProto::getName)
+        .containsExactly("request_id", "worker_id", "certificate_signing_request_der");
+    assertThat(messages.get("PublicTrustBundle").getFieldList())
+        .extracting(FieldDescriptorProto::getName)
+        .containsExactly(
+            "version",
+            "trust_anchor_certificates_der",
+            "issuer_certificates_der",
+            "revocation_signer_certificates_der");
+    assertThat(messages.get("CertificateBundle").getFieldList())
+        .extracting(FieldDescriptorProto::getName)
+        .containsExactly("worker_id", "leaf_certificate_der", "trust_bundle");
+    assertThat(
+            messages.get("TranscodeExecutionParameters").getFieldList().stream()
+                .collect(
+                    Collectors.toMap(FieldDescriptorProto::getName, FieldDescriptorProto::getType)))
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "seek_position_seconds", FieldDescriptorProto.Type.TYPE_UINT32,
+                "segment_duration_seconds", FieldDescriptorProto.Type.TYPE_UINT32,
+                "framerate", FieldDescriptorProto.Type.TYPE_DOUBLE,
+                "start_number", FieldDescriptorProto.Type.TYPE_UINT32,
+                "startup_timeout", FieldDescriptorProto.Type.TYPE_MESSAGE));
+  }
+
+  @Test
+  @DisplayName("Should reserve zero as an explicitly unspecified value for every enum")
+  void shouldReserveZeroAsExplicitlyUnspecifiedValueForEveryEnum() throws Exception {
+    var enums =
+        contractFiles().stream()
+            .flatMap(file -> Stream.concat(file.getEnumTypeList().stream(), nestedEnums(file)))
+            .toList();
+
+    assertThat(enums).isNotEmpty();
+    assertThat(enums)
+        .allSatisfy(
+            descriptor -> {
+              var zero =
+                  descriptor.getValueList().stream()
+                      .filter(value -> value.getNumber() == 0)
+                      .toList();
+              assertThat(zero).singleElement();
+              assertThat(zero.getFirst().getName())
+                  .isEqualTo(toUpperSnakeCase(descriptor.getName()) + "_UNSPECIFIED");
+            });
+  }
+
+  @Test
+  @DisplayName("Should declare retry semantics for every remote operation")
+  void shouldDeclareRetrySemanticsForEveryRemoteOperation() throws Exception {
+    var methods =
+        contractFiles().stream()
+            .flatMap(file -> file.getServiceList().stream())
+            .flatMap(service -> service.getMethodList().stream())
+            .collect(
+                Collectors.toMap(
+                    method -> method.getName(),
+                    method -> method.getOptions().getIdempotencyLevel()));
+
+    assertThat(methods)
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.ofEntries(
+                Map.entry("ProveEndpoint", IdempotencyLevel.NO_SIDE_EFFECTS),
+                Map.entry("StartJob", IdempotencyLevel.IDEMPOTENT),
+                Map.entry("StopJob", IdempotencyLevel.IDEMPOTENT),
+                Map.entry("InspectJob", IdempotencyLevel.NO_SIDE_EFFECTS),
+                Map.entry("ListJobs", IdempotencyLevel.NO_SIDE_EFFECTS),
+                Map.entry("ReadSegment", IdempotencyLevel.NO_SIDE_EFFECTS),
+                Map.entry("RegisterWorker", IdempotencyLevel.IDEMPOTENT),
+                Map.entry("Heartbeat", IdempotencyLevel.IDEMPOTENCY_UNKNOWN),
+                Map.entry("EnrollWorker", IdempotencyLevel.IDEMPOTENT),
+                Map.entry("RotateWorkerCertificate", IdempotencyLevel.IDEMPOTENT)));
+  }
+
+  private static java.util.List<FileDescriptorProto> contractFiles() throws Exception {
+    var descriptorPath = Path.of(System.getProperty("contract.descriptor.file"));
+    assertThat(descriptorPath).isRegularFile();
+    return FileDescriptorSet.parseFrom(Files.readAllBytes(descriptorPath)).getFileList().stream()
+        .filter(file -> PACKAGE.equals(file.getPackage()))
+        .toList();
+  }
+
+  private static Map<String, DescriptorProto> messagesByName(
+      java.util.List<FileDescriptorProto> files) {
+    return files.stream()
+        .flatMap(file -> file.getMessageTypeList().stream())
+        .collect(Collectors.toMap(DescriptorProto::getName, Function.identity()));
+  }
+
+  private static Stream<FieldDescriptorProto> fields(DescriptorProto message) {
+    return Stream.concat(
+        message.getFieldList().stream(),
+        message.getNestedTypeList().stream().flatMap(ContractPolicyTest::fields));
+  }
+
+  private static Stream<EnumDescriptorProto> nestedEnums(FileDescriptorProto file) {
+    return file.getMessageTypeList().stream().flatMap(ContractPolicyTest::nestedEnums);
+  }
+
+  private static Stream<EnumDescriptorProto> nestedEnums(DescriptorProto message) {
+    return Stream.concat(
+        message.getEnumTypeList().stream(),
+        message.getNestedTypeList().stream().flatMap(ContractPolicyTest::nestedEnums));
+  }
+
+  private static String toUpperSnakeCase(String value) {
+    return value.replaceAll("([a-z0-9])([A-Z])", "$1_$2").toUpperCase(java.util.Locale.ROOT);
+  }
+}

--- a/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractRoundTripTest.java
+++ b/streamarr-transcode-contract/src/test/java/com/streamarr/transcode/contract/ContractRoundTripTest.java
@@ -1,0 +1,471 @@
+package com.streamarr.transcode.contract;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import com.google.protobuf.Timestamp;
+import com.streamarr.transcode.v1.AudioDecision;
+import com.streamarr.transcode.v1.AudioMode;
+import com.streamarr.transcode.v1.CertificateBundle;
+import com.streamarr.transcode.v1.ContainerFormat;
+import com.streamarr.transcode.v1.DrainState;
+import com.streamarr.transcode.v1.EnrollWorkerRejection;
+import com.streamarr.transcode.v1.EnrollWorkerRequest;
+import com.streamarr.transcode.v1.EnrollWorkerResponse;
+import com.streamarr.transcode.v1.HeartbeatRequest;
+import com.streamarr.transcode.v1.HeartbeatResponse;
+import com.streamarr.transcode.v1.InitializationSegment;
+import com.streamarr.transcode.v1.InspectJobRejection;
+import com.streamarr.transcode.v1.InspectJobRequest;
+import com.streamarr.transcode.v1.InspectJobResponse;
+import com.streamarr.transcode.v1.JobSnapshot;
+import com.streamarr.transcode.v1.ListJobsRequest;
+import com.streamarr.transcode.v1.ListJobsResponse;
+import com.streamarr.transcode.v1.MediaSourceRef;
+import com.streamarr.transcode.v1.ProtocolRange;
+import com.streamarr.transcode.v1.ProtocolRevision;
+import com.streamarr.transcode.v1.ProveEndpointRequest;
+import com.streamarr.transcode.v1.ProveEndpointResponse;
+import com.streamarr.transcode.v1.PublicTrustBundle;
+import com.streamarr.transcode.v1.ReadSegmentRequest;
+import com.streamarr.transcode.v1.ReadSegmentResponse;
+import com.streamarr.transcode.v1.RegisterWorkerAccepted;
+import com.streamarr.transcode.v1.RegisterWorkerRejection;
+import com.streamarr.transcode.v1.RegisterWorkerRequest;
+import com.streamarr.transcode.v1.RegisterWorkerResponse;
+import com.streamarr.transcode.v1.RenditionObservation;
+import com.streamarr.transcode.v1.RenditionSpec;
+import com.streamarr.transcode.v1.RenditionState;
+import com.streamarr.transcode.v1.RevocationUpdate;
+import com.streamarr.transcode.v1.RevokedCertificate;
+import com.streamarr.transcode.v1.RotateWorkerCertificateRejection;
+import com.streamarr.transcode.v1.RotateWorkerCertificateRequest;
+import com.streamarr.transcode.v1.RotateWorkerCertificateResponse;
+import com.streamarr.transcode.v1.SegmentContentType;
+import com.streamarr.transcode.v1.SegmentMetadata;
+import com.streamarr.transcode.v1.SegmentRef;
+import com.streamarr.transcode.v1.SignedRevocationUpdate;
+import com.streamarr.transcode.v1.StartJobRejection;
+import com.streamarr.transcode.v1.StartJobRequest;
+import com.streamarr.transcode.v1.StartJobResponse;
+import com.streamarr.transcode.v1.StopJobRejection;
+import com.streamarr.transcode.v1.StopJobRequest;
+import com.streamarr.transcode.v1.StopJobResponse;
+import com.streamarr.transcode.v1.SubtitleDecision;
+import com.streamarr.transcode.v1.SubtitleMode;
+import com.streamarr.transcode.v1.TranscodeDecision;
+import com.streamarr.transcode.v1.TranscodeExecutionParameters;
+import com.streamarr.transcode.v1.TranscodeJobObservation;
+import com.streamarr.transcode.v1.TranscodeJobRef;
+import com.streamarr.transcode.v1.TranscodeJobSpec;
+import com.streamarr.transcode.v1.TranscodeJobState;
+import com.streamarr.transcode.v1.TranscodeMode;
+import com.streamarr.transcode.v1.Uuid;
+import com.streamarr.transcode.v1.WorkerCapabilities;
+import com.streamarr.transcode.v1.WorkerCapacity;
+import com.streamarr.transcode.v1.WorkerEndpoint;
+import com.streamarr.transcode.v1.WorkerTarget;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class ContractRoundTripTest {
+
+  @Test
+  @DisplayName("Should round trip a complete typed transcode job specification")
+  void shouldRoundTripCompleteTypedTranscodeJobSpecification() throws Exception {
+    var jobSpec = completeJobSpec();
+
+    assertRoundTrips(jobSpec, TranscodeJobSpec.parser());
+    assertThat(jobSpec.getDecision().hasAudio()).isTrue();
+    assertThat(jobSpec.getDecision().getAudio().hasCodec()).isTrue();
+    assertThat(jobSpec.getDecision().getSubtitle().hasStreamIndex()).isTrue();
+    assertThat(jobSpec.getRenditionsList())
+        .extracting(RenditionSpec::getLabel)
+        .containsExactly("1080p", "720p");
+  }
+
+  @Test
+  @DisplayName("Should round trip every command result without losing its oneof case")
+  void shouldRoundTripEveryCommandResultWithoutLosingOneofCase() throws Exception {
+    var jobRef = jobRef();
+    var observation = observation();
+
+    var startResults =
+        List.of(
+            StartJobResponse.newBuilder().setAccepted(observation).build(),
+            StartJobResponse.newBuilder()
+                .setRejection(StartJobRejection.START_JOB_REJECTION_CAPACITY_EXHAUSTED)
+                .build(),
+            StartJobResponse.newBuilder().setCleanupPending(jobRef).build());
+    var stopResults =
+        List.of(
+            StopJobResponse.newBuilder().setStopped(jobRef).build(),
+            StopJobResponse.newBuilder().setAlreadyAbsent(jobRef).build(),
+            StopJobResponse.newBuilder().setCleanupPending(jobRef).build(),
+            StopJobResponse.newBuilder()
+                .setRejection(StopJobRejection.STOP_JOB_REJECTION_STALE_GENERATION)
+                .build());
+    var inspectResults =
+        List.of(
+            InspectJobResponse.newBuilder().setObservation(observation).build(),
+            InspectJobResponse.newBuilder().setCleanupPending(jobRef).build(),
+            InspectJobResponse.newBuilder()
+                .setRejection(InspectJobRejection.INSPECT_JOB_REJECTION_TARGET_MISMATCH)
+                .build());
+
+    for (var response : startResults) {
+      assertRoundTrips(response, StartJobResponse.parser());
+    }
+    for (var response : stopResults) {
+      assertRoundTrips(response, StopJobResponse.parser());
+    }
+    for (var response : inspectResults) {
+      assertRoundTrips(response, InspectJobResponse.parser());
+    }
+
+    var replaced =
+        StartJobResponse.newBuilder()
+            .setAccepted(observation)
+            .setRejection(StartJobRejection.START_JOB_REJECTION_JOB_CONFLICT)
+            .build();
+    assertThat(replaced.hasAccepted()).isFalse();
+    assertThat(replaced.getResultCase()).isEqualTo(StartJobResponse.ResultCase.REJECTION);
+  }
+
+  @Test
+  @DisplayName("Should round trip every targeted worker control request")
+  void shouldRoundTripEveryTargetedWorkerControlRequest() throws Exception {
+    var nonce = ByteString.copyFrom(new byte[32]);
+    var proofRequest =
+        ProveEndpointRequest.newBuilder().setTarget(target()).setNonce(nonce).build();
+    var proofResponse =
+        ProveEndpointResponse.newBuilder()
+            .setTarget(target())
+            .setNonce(nonce)
+            .setLeafCertificateDer(ByteString.copyFromUtf8("leaf"))
+            .build();
+    var start =
+        StartJobRequest.newBuilder()
+            .setCommandId(uuid(51, 52))
+            .setTarget(target())
+            .setJobSpec(completeJobSpec())
+            .build();
+    var stop =
+        StopJobRequest.newBuilder()
+            .setCommandId(uuid(53, 54))
+            .setTarget(target())
+            .setJobRef(jobRef())
+            .build();
+    var inspect = InspectJobRequest.newBuilder().setTarget(target()).setJobRef(jobRef()).build();
+    var list =
+        ListJobsRequest.newBuilder()
+            .setTarget(target())
+            .setPageSize(256)
+            .setContinuation(ByteString.copyFromUtf8("page"))
+            .build();
+    var read =
+        ReadSegmentRequest.newBuilder()
+            .setTarget(target())
+            .setJobRef(jobRef())
+            .setRenditionLabel("1080p")
+            .setSegment(SegmentRef.newBuilder().setMediaSequence(37))
+            .build();
+
+    assertRoundTrips(proofRequest, ProveEndpointRequest.parser());
+    assertRoundTrips(proofResponse, ProveEndpointResponse.parser());
+    assertRoundTrips(start, StartJobRequest.parser());
+    assertRoundTrips(stop, StopJobRequest.parser());
+    assertRoundTrips(inspect, InspectJobRequest.parser());
+    assertRoundTrips(list, ListJobsRequest.parser());
+    assertRoundTrips(read, ReadSegmentRequest.parser());
+  }
+
+  @Test
+  @DisplayName("Should round trip worker observation enrollment and revocation state")
+  void shouldRoundTripWorkerObservationEnrollmentAndRevocationState() throws Exception {
+    var revocation = signedRevocationUpdate();
+    var capabilities =
+        WorkerCapabilities.newBuilder()
+            .addVideoCodecFamilies("h264")
+            .addEncoders("h264_nvenc")
+            .addHardwareAccelerators("cuda")
+            .addSourceNamespaceIds(uuid(31, 32))
+            .addContainerFormats(ContainerFormat.CONTAINER_FORMAT_FMP4)
+            .build();
+    var heartbeat =
+        HeartbeatRequest.newBuilder()
+            .setTarget(target())
+            .setBindingEpoch(9)
+            .setSequence(11)
+            .setProtocolRevision(1)
+            .setCapabilities(capabilities)
+            .setDrainState(DrainState.DRAIN_STATE_ACCEPTING)
+            .setCapacity(WorkerCapacity.newBuilder().setTotalSlots(8).setOccupiedSlots(3))
+            .addJobs(observation())
+            .build();
+    var heartbeatResponse =
+        HeartbeatResponse.newBuilder()
+            .setAcceptedSequence(11)
+            .setBindingEpoch(9)
+            .setRevocationUpdate(revocation)
+            .build();
+    var registrationRequest =
+        RegisterWorkerRequest.newBuilder()
+            .setTarget(target())
+            .setEndpoint(endpoint())
+            .setSupportedProtocol(protocolRange())
+            .build();
+    var registration =
+        RegisterWorkerResponse.newBuilder()
+            .setAccepted(
+                RegisterWorkerAccepted.newBuilder()
+                    .setBindingEpoch(9)
+                    .setProtocolRevision(1)
+                    .setHeartbeatInterval(Duration.newBuilder().setSeconds(15))
+                    .setRevocationUpdate(revocation))
+            .build();
+    var rejectedRegistration =
+        RegisterWorkerResponse.newBuilder()
+            .setRejection(RegisterWorkerRejection.REGISTER_WORKER_REJECTION_ACTIVE_BINDING)
+            .build();
+    var enrollmentRequest =
+        EnrollWorkerRequest.newBuilder()
+            .setRequestId(uuid(41, 42))
+            .setWorkerId(target().getWorkerId())
+            .setCertificateSigningRequestDer(ByteString.copyFromUtf8("csr"))
+            .build();
+    var certificate = certificateBundle();
+    var enrollment = EnrollWorkerResponse.newBuilder().setCertificate(certificate).build();
+    var rejectedEnrollment =
+        EnrollWorkerResponse.newBuilder()
+            .setRejection(EnrollWorkerRejection.ENROLL_WORKER_REJECTION_INVALID_OR_EXPIRED_GRANT)
+            .build();
+    var rotationRequest =
+        RotateWorkerCertificateRequest.newBuilder()
+            .setRequestId(uuid(43, 44))
+            .setWorkerId(target().getWorkerId())
+            .setCertificateSigningRequestDer(ByteString.copyFromUtf8("rotated-csr"))
+            .build();
+    var rotation = RotateWorkerCertificateResponse.newBuilder().setCertificate(certificate).build();
+    var rejectedRotation =
+        RotateWorkerCertificateResponse.newBuilder()
+            .setRejection(
+                RotateWorkerCertificateRejection
+                    .ROTATE_WORKER_CERTIFICATE_REJECTION_IDENTITY_MISMATCH)
+            .build();
+
+    assertRoundTrips(heartbeat, HeartbeatRequest.parser());
+    assertRoundTrips(heartbeatResponse, HeartbeatResponse.parser());
+    assertRoundTrips(registrationRequest, RegisterWorkerRequest.parser());
+    assertRoundTrips(registration, RegisterWorkerResponse.parser());
+    assertRoundTrips(rejectedRegistration, RegisterWorkerResponse.parser());
+    assertThat(ProtocolRevision.PROTOCOL_REVISION_V1_VALUE).isEqualTo(1);
+    assertRoundTrips(enrollmentRequest, EnrollWorkerRequest.parser());
+    assertRoundTrips(enrollment, EnrollWorkerResponse.parser());
+    assertRoundTrips(rejectedEnrollment, EnrollWorkerResponse.parser());
+    assertRoundTrips(rotationRequest, RotateWorkerCertificateRequest.parser());
+    assertRoundTrips(rotation, RotateWorkerCertificateResponse.parser());
+    assertRoundTrips(rejectedRotation, RotateWorkerCertificateResponse.parser());
+  }
+
+  @Test
+  @DisplayName("Should preserve bounded segment variants and unknown enum values")
+  void shouldPreserveBoundedSegmentVariantsAndUnknownEnumValues() throws Exception {
+    var initialization =
+        SegmentRef.newBuilder()
+            .setInitialization(InitializationSegment.getDefaultInstance())
+            .build();
+    var media = SegmentRef.newBuilder().setMediaSequence(37).build();
+    var metadata =
+        ReadSegmentResponse.newBuilder()
+            .setMetadata(
+                SegmentMetadata.newBuilder()
+                    .setContentLengthBytes(65_536)
+                    .setContentType(SegmentContentType.SEGMENT_CONTENT_TYPE_VIDEO_MP4))
+            .build();
+    var chunk =
+        ReadSegmentResponse.newBuilder().setData(ByteString.copyFrom(new byte[65_536])).build();
+    var unknown =
+        TranscodeJobObservation.newBuilder().setJobRef(jobRef()).setStateValue(999).build();
+
+    assertRoundTrips(initialization, SegmentRef.parser());
+    assertRoundTrips(media, SegmentRef.parser());
+    assertRoundTrips(metadata, ReadSegmentResponse.parser());
+    assertRoundTrips(chunk, ReadSegmentResponse.parser());
+    assertThat(chunk.getData()).hasSize(65_536);
+    assertThat(metadata.getFrameCase()).isEqualTo(ReadSegmentResponse.FrameCase.METADATA);
+
+    var replaced =
+        ReadSegmentResponse.newBuilder()
+            .setMetadata(metadata.getMetadata())
+            .setData(ByteString.copyFromUtf8("data"))
+            .build();
+    assertThat(replaced.hasMetadata()).isFalse();
+    assertThat(replaced.getFrameCase()).isEqualTo(ReadSegmentResponse.FrameCase.DATA);
+
+    var decoded = TranscodeJobObservation.parseFrom(unknown.toByteArray());
+    assertThat(decoded.getState()).isEqualTo(TranscodeJobState.UNRECOGNIZED);
+    assertThat(decoded.getStateValue()).isEqualTo(999);
+  }
+
+  @Test
+  @DisplayName("Should round trip list snapshots for observed and cleanup-pending jobs")
+  void shouldRoundTripListSnapshotsForObservedAndCleanupPendingJobs() throws Exception {
+    var response =
+        ListJobsResponse.newBuilder()
+            .addJobs(JobSnapshot.newBuilder().setObservation(observation()))
+            .addJobs(JobSnapshot.newBuilder().setCleanupPending(jobRef()))
+            .setNextContinuation(ByteString.copyFromUtf8("next"))
+            .build();
+
+    assertRoundTrips(response, ListJobsResponse.parser());
+    assertThat(response.getJobs(0).getSnapshotCase())
+        .isEqualTo(JobSnapshot.SnapshotCase.OBSERVATION);
+    assertThat(response.getJobs(1).getSnapshotCase())
+        .isEqualTo(JobSnapshot.SnapshotCase.CLEANUP_PENDING);
+  }
+
+  private static TranscodeJobSpec completeJobSpec() {
+    var audio =
+        AudioDecision.newBuilder()
+            .setMode(AudioMode.AUDIO_MODE_TRANSCODE)
+            .setCodec("aac")
+            .setChannels(6)
+            .setBitrateBitsPerSecond(384_000)
+            .build();
+    var subtitle =
+        SubtitleDecision.newBuilder()
+            .setMode(SubtitleMode.SUBTITLE_MODE_BURN_IN)
+            .setCodec("ass")
+            .setStreamIndex(2)
+            .setLanguage("eng")
+            .build();
+    var decision =
+        TranscodeDecision.newBuilder()
+            .setTranscodeMode(TranscodeMode.TRANSCODE_MODE_FULL_TRANSCODE)
+            .setVideoCodecFamily("h264")
+            .setAudio(audio)
+            .setSubtitle(subtitle)
+            .setContainer(ContainerFormat.CONTAINER_FORMAT_FMP4)
+            .setForceKeyframesAtSegmentBoundaries(true)
+            .build();
+    var execution =
+        TranscodeExecutionParameters.newBuilder()
+            .setSeekPositionSeconds(12)
+            .setSegmentDurationSeconds(6)
+            .setFramerate(23.976)
+            .setStartNumber(4)
+            .setStartupTimeout(Duration.newBuilder().setSeconds(30))
+            .build();
+
+    return TranscodeJobSpec.newBuilder()
+        .setSessionId(uuid(1, 2))
+        .setJobRef(jobRef())
+        .setSource(
+            MediaSourceRef.newBuilder()
+                .setSourceNamespaceId(uuid(3, 4))
+                .setRelativeKey("movies/example.mkv"))
+        .setDecision(decision)
+        .setExecution(execution)
+        .addRenditions(
+            renditionBuilder("1080p")
+                .setWidth(1920)
+                .setHeight(1080)
+                .setBitrateBitsPerSecond(8_000_000))
+        .addRenditions(
+            renditionBuilder("720p")
+                .setWidth(1280)
+                .setHeight(720)
+                .setBitrateBitsPerSecond(4_000_000))
+        .build();
+  }
+
+  private static RenditionSpec.Builder renditionBuilder(String label) {
+    return RenditionSpec.newBuilder().setLabel(label);
+  }
+
+  private static TranscodeJobObservation observation() {
+    return TranscodeJobObservation.newBuilder()
+        .setJobRef(jobRef())
+        .setState(TranscodeJobState.TRANSCODE_JOB_STATE_RUNNING)
+        .addRenditions(
+            RenditionObservation.newBuilder()
+                .setLabel("1080p")
+                .setState(RenditionState.RENDITION_STATE_RUNNING))
+        .addRenditions(
+            RenditionObservation.newBuilder()
+                .setLabel("720p")
+                .setState(RenditionState.RENDITION_STATE_RUNNING))
+        .build();
+  }
+
+  private static SignedRevocationUpdate signedRevocationUpdate() {
+    var revoked =
+        RevokedCertificate.newBuilder()
+            .setIssuerCertificateSha256(ByteString.copyFrom(new byte[32]))
+            .setSerialNumber(ByteString.copyFrom(new byte[] {1, 2, 3}))
+            .setRevokedAt(Timestamp.newBuilder().setSeconds(1_786_000_000))
+            .build();
+    var update =
+        RevocationUpdate.newBuilder()
+            .setSequence(7)
+            .setIssuedAt(Timestamp.newBuilder().setSeconds(1_786_000_000))
+            .setExpiresAt(Timestamp.newBuilder().setSeconds(1_786_003_600))
+            .addRevokedCertificates(revoked)
+            .build();
+    return SignedRevocationUpdate.newBuilder()
+        .setSerializedUpdate(update.toByteString())
+        .setSignature(ByteString.copyFromUtf8("signature"))
+        .setSignerCertificateSha256(ByteString.copyFrom(new byte[32]))
+        .build();
+  }
+
+  private static CertificateBundle certificateBundle() {
+    var trustBundle =
+        PublicTrustBundle.newBuilder()
+            .setVersion(7)
+            .addTrustAnchorCertificatesDer(ByteString.copyFromUtf8("root"))
+            .addIssuerCertificatesDer(ByteString.copyFromUtf8("issuer"))
+            .addRevocationSignerCertificatesDer(ByteString.copyFromUtf8("revocation-signer"))
+            .build();
+    return CertificateBundle.newBuilder()
+        .setWorkerId(target().getWorkerId())
+        .setLeafCertificateDer(ByteString.copyFromUtf8("leaf"))
+        .setTrustBundle(trustBundle)
+        .build();
+  }
+
+  private static WorkerTarget target() {
+    return WorkerTarget.newBuilder().setWorkerId(uuid(11, 12)).setBootId(uuid(21, 22)).build();
+  }
+
+  private static TranscodeJobRef jobRef() {
+    return TranscodeJobRef.newBuilder().setJobId(uuid(5, 6)).setGeneration(3).build();
+  }
+
+  private static Uuid uuid(long mostSignificantBits, long leastSignificantBits) {
+    return Uuid.newBuilder()
+        .setMostSignificantBits(mostSignificantBits)
+        .setLeastSignificantBits(leastSignificantBits)
+        .build();
+  }
+
+  private static <T extends Message> void assertRoundTrips(T message, Parser<T> parser)
+      throws Exception {
+    assertThat(parser.parseFrom(message.toByteArray())).isEqualTo(message);
+  }
+
+  private static WorkerEndpoint endpoint() {
+    return WorkerEndpoint.newBuilder().setHost("worker.internal").setPort(8443).build();
+  }
+
+  private static ProtocolRange protocolRange() {
+    return ProtocolRange.newBuilder().setMinimumRevision(1).setMaximumRevision(1).build();
+  }
+}


### PR DESCRIPTION
## Summary

- define the versioned protobuf and gRPC contract for worker control, registration, enrollment, trust, observations, and bounded segment streaming
- generate transport types in an isolated contract module with strict dependency and analysis boundaries
- add Buf format, lint, and base-aware breaking-change checks
- preserve local-only execution with no remote listener, client, configuration, or runtime path

## Validation

- full clean Maven verification
- Buf format and lint
- temporary mutations confirmed response naming, secret exclusion, trust-bundle identity, protocol revision, active-binding rejection, execution field types, and segment metadata safeguards

Part of #76