### PR TITLE
P5-B2a: define installation trust certificate profiles

### DIFF
--- a/docs/adr/0018-direct-fenced-worker-control.adoc
+++ b/docs/adr/0018-direct-fenced-worker-control.adoc
@@ -8,7 +8,7 @@ Accepted
 
 * Streamarr still executes every transcode in the media-server process through `PlaybackTranscodeJobService`, the application-owned `TranscodeWorkerPort`, `LocalTranscodeWorkerAdapter`, and the extracted `LocalTranscodeEngine`.
 * The former rendition-at-a-time, process-shaped `TranscodeExecutor` and its process-handle state have been removed from the server application.
-* No enrolled remote worker, worker listener, certificate authority, registration path, or distributed playback route is enabled yet.
+* The server now contains inert trust-material primitives for the P-256 root, issuer, dedicated revocation signer, and exact certificate-profile validation. No certificate-authority storage or bootstrap, signing lease, enrolled remote worker, worker listener, registration path, or distributed playback route is enabled yet.
 * The completed local extraction introduced the application boundary without introducing a remote transport.
 * The generated-only `streamarr-transcode-contract` module defines the versioned worker transport and compatibility gates. The narrow worker executable depends on it and the engine; the server still depends on neither the contract nor the worker.
 * The worker packages Boot's official gRPC server and shaded Netty, but its unenrolled configuration disables the server, reflection, health service, health scheduler, and all application executors. It exposes no control service until the trust and enrollment slice can enable one with valid credentials.
@@ -212,6 +212,12 @@ Every control-plane replica mounts that same secret, verifies it against the rec
 The private CA key is never stored in PostgreSQL, logged, exported through the API, reused for JWT signing, or copied to a worker.
 Backups of distributed configuration must include this secret; losing it requires explicitly re-enrolling workers under a new trust domain.
 Certificate issuance and issuer/root rotation use a PostgreSQL-backed singleton leadership lease so only one replica performs signing transitions at a time.
+
+The root, online issuing intermediate, and revocation signer use P-256 and `SHA256withECDSA`.
+All three use distinct keys, exact critical and non-critical extension sets, and validated SKI/AKI linkage from each child to its issuer.
+The root is a path-length-one signing CA, the intermediate is path-length zero, and both carry the exact canonical `spiffe://<installation-id>` trust domain.
+The revocation signer is not a TLS identity: it has digital-signature usage only and the critical UUID-derived Streamarr purpose OID `2.25.191220049025548712607526882177286901536`.
+The UUID-derived `2.25` arc avoids claiming an unassigned private-enterprise number.
 
 An administrator mints a worker-specific 256-bit, single-use enrollment token whose digest and roughly ten-minute expiry are stored in PostgreSQL.
 The out-of-band enrollment bundle contains the control endpoint, a versioned public trust bundle, the SHA-256 fingerprint of its exact root DER, and the token.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -125,9 +125,12 @@ link:adr/0013-stream-decision-architecture.adoc[ADR 0013].
 link:adr/0018-direct-fenced-worker-control.adoc[ADR 0018] accepts an optional distributed
 control plane, but the current implementation remains local-only and opens no worker listener.
 A narrow worker executable now packages the engine, protobuf contract, and shaded gRPC runtime;
-until trust and enrollment land, its server, reflection, health service, health scheduler, and all
-executors are disabled. The media-server artifact contains neither the worker nor its protobuf
-contract, so an ordinary local installation gains no distributed runtime resource.
+until enrollment lands, its server, reflection, health service, health scheduler, and all executors
+are disabled. The control plane now has inert P-256 installation trust-material generation and
+exact certificate-profile, identity, and key-separation validation. Durable secret storage,
+bootstrap, public persistence, and database-clock-fenced signing leadership land in following
+trust slices. The media-server artifact contains neither the worker nor its protobuf contract, so
+an ordinary local installation still gains no distributed transport runtime resource.
 The extraction preserves the local path as the default:
 
 ----

--- a/streamarr-server/pom.xml
+++ b/streamarr-server/pom.xml
@@ -57,6 +57,11 @@
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jooq</artifactId>
         </dependency>

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthority.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthority.java
@@ -1,0 +1,233 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+public final class BuiltInCertificateAuthority {
+
+  static final String REVOCATION_SIGNING_EKU_OID = "2.25.191220049025548712607526882177286901536";
+
+  private static final String SIGNATURE_ALGORITHM = "SHA256withECDSA";
+  static final Duration VALIDITY_BACKDATE = Duration.ofMinutes(5);
+  static final Duration ROOT_VALIDITY = Duration.ofDays(3650);
+  static final Duration ISSUER_VALIDITY = Duration.ofDays(365);
+  static final Duration REVOCATION_SIGNER_VALIDITY = Duration.ofDays(30);
+
+  private final SecureRandom secureRandom;
+
+  public BuiltInCertificateAuthority() {
+    this(new SecureRandom());
+  }
+
+  BuiltInCertificateAuthority(SecureRandom secureRandom) {
+    this.secureRandom = secureRandom;
+  }
+
+  public void validate(
+      CertificateAuthorityMaterial material, UUID installationId, Instant databaseTime) {
+    new CertificateAuthorityValidator().validate(material, installationId, databaseTime);
+  }
+
+  public CertificateAuthorityMaterial create(UUID installationId, Instant issuedAt) {
+    try {
+      var rootKeyPair = generateKeyPair();
+      var root = createRoot(installationId, rootKeyPair, issuedAt);
+      var issuerKeyPair = generateKeyPair();
+      var issuer = createIssuer(installationId, issuerKeyPair, rootKeyPair, root, issuedAt);
+      var signerKeyPair = generateKeyPair();
+      var revocationSigner =
+          createRevocationSigner(installationId, signerKeyPair, issuerKeyPair, issuer, issuedAt);
+
+      root.verify(root.getPublicKey());
+      issuer.verify(root.getPublicKey());
+      revocationSigner.verify(issuer.getPublicKey());
+
+      var material =
+          new CertificateAuthorityMaterial(
+              installationId,
+              new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                  new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                      rootKeyPair.getPrivate(), root),
+                  new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                      issuerKeyPair.getPrivate(), issuer),
+                  new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                      signerKeyPair.getPrivate(), revocationSigner)));
+      validate(material, installationId, issuedAt);
+      return material;
+    } catch (GeneralSecurityException | OperatorCreationException | CertIOException e) {
+      throw new IllegalStateException("Failed to create the installation certificate authority", e);
+    }
+  }
+
+  private X509Certificate createRoot(UUID installationId, KeyPair keyPair, Instant issuedAt)
+      throws GeneralSecurityException, OperatorCreationException, CertIOException {
+    var subject = subject(installationId, "Root CA");
+    var builder =
+        certificateBuilder(subject, subject, keyPair, issuedAt, issuedAt.plus(ROOT_VALIDITY));
+    var extensionUtils = extensionUtils();
+    addSigningExtensions(
+        builder,
+        new BasicConstraints(1),
+        extensionUtils.createAuthorityKeyIdentifier(keyPair.getPublic()),
+        extensionUtils.createSubjectKeyIdentifier(keyPair.getPublic()),
+        installationId);
+    return sign(builder, keyPair);
+  }
+
+  private X509Certificate createIssuer(
+      UUID installationId,
+      KeyPair keyPair,
+      KeyPair rootKeyPair,
+      X509Certificate root,
+      Instant issuedAt)
+      throws GeneralSecurityException, OperatorCreationException, CertIOException {
+    var builder =
+        certificateBuilder(
+            new X500Name(root.getSubjectX500Principal().getName()),
+            subject(installationId, "Issuing CA"),
+            keyPair,
+            issuedAt,
+            issuedAt.plus(ISSUER_VALIDITY));
+    var extensionUtils = extensionUtils();
+    addSigningExtensions(
+        builder,
+        new BasicConstraints(0),
+        extensionUtils.createAuthorityKeyIdentifier(root),
+        extensionUtils.createSubjectKeyIdentifier(keyPair.getPublic()),
+        installationId);
+    return sign(builder, rootKeyPair);
+  }
+
+  private X509Certificate createRevocationSigner(
+      UUID installationId,
+      KeyPair keyPair,
+      KeyPair issuerKeyPair,
+      X509Certificate issuer,
+      Instant issuedAt)
+      throws GeneralSecurityException, OperatorCreationException, CertIOException {
+    var builder =
+        certificateBuilder(
+            new X500Name(issuer.getSubjectX500Principal().getName()),
+            subject(installationId, "Revocation Signer"),
+            keyPair,
+            issuedAt,
+            issuedAt.plus(REVOCATION_SIGNER_VALIDITY));
+    var extensionUtils = extensionUtils();
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+    builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+    builder.addExtension(
+        Extension.subjectKeyIdentifier,
+        false,
+        extensionUtils.createSubjectKeyIdentifier(keyPair.getPublic()));
+    builder.addExtension(
+        Extension.authorityKeyIdentifier,
+        false,
+        extensionUtils.createAuthorityKeyIdentifier(issuer));
+    builder.addExtension(
+        Extension.extendedKeyUsage,
+        true,
+        new ExtendedKeyUsage(
+            KeyPurposeId.getInstance(new ASN1ObjectIdentifier(REVOCATION_SIGNING_EKU_OID))));
+    return sign(builder, issuerKeyPair);
+  }
+
+  private void addSigningExtensions(
+      JcaX509v3CertificateBuilder builder,
+      BasicConstraints basicConstraints,
+      org.bouncycastle.asn1.x509.AuthorityKeyIdentifier authorityKeyIdentifier,
+      org.bouncycastle.asn1.x509.SubjectKeyIdentifier subjectKeyIdentifier,
+      UUID installationId)
+      throws CertIOException {
+    builder.addExtension(Extension.basicConstraints, true, basicConstraints);
+    builder.addExtension(
+        Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+    builder.addExtension(Extension.subjectKeyIdentifier, false, subjectKeyIdentifier);
+    builder.addExtension(Extension.authorityKeyIdentifier, false, authorityKeyIdentifier);
+    builder.addExtension(
+        Extension.subjectAlternativeName,
+        false,
+        new GeneralNames(
+            new GeneralName(
+                GeneralName.uniformResourceIdentifier, trustDomain(installationId).toString())));
+  }
+
+  private JcaX509v3CertificateBuilder certificateBuilder(
+      X500Name issuer,
+      X500Name subject,
+      KeyPair subjectKeyPair,
+      Instant issuedAt,
+      Instant expiresAt) {
+    return new JcaX509v3CertificateBuilder(
+        issuer,
+        positiveSerial(),
+        Date.from(issuedAt.minus(VALIDITY_BACKDATE)),
+        Date.from(expiresAt),
+        subject,
+        subjectKeyPair.getPublic());
+  }
+
+  private X509Certificate sign(JcaX509v3CertificateBuilder builder, KeyPair signingKeyPair)
+      throws OperatorCreationException, CertificateException {
+    var signer =
+        new JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
+            .setSecureRandom(secureRandom)
+            .build(signingKeyPair.getPrivate());
+    return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+  }
+
+  private KeyPair generateKeyPair() throws GeneralSecurityException {
+    var generator = KeyPairGenerator.getInstance("EC");
+    generator.initialize(new ECGenParameterSpec("secp256r1"), secureRandom);
+    return generator.generateKeyPair();
+  }
+
+  private BigInteger positiveSerial() {
+    BigInteger serial;
+    do {
+      serial = new BigInteger(128, secureRandom);
+    } while (serial.signum() <= 0);
+    return serial;
+  }
+
+  private JcaX509ExtensionUtils extensionUtils() throws GeneralSecurityException {
+    return new JcaX509ExtensionUtils();
+  }
+
+  private static X500Name subject(UUID installationId, String role) {
+    return new X500Name(subjectName(installationId, role));
+  }
+
+  static String subjectName(UUID installationId, String role) {
+    return "CN=Streamarr Installation " + installationId + " " + role;
+  }
+
+  private static URI trustDomain(UUID installationId) {
+    return URI.create("spiffe://" + installationId.toString().toLowerCase(java.util.Locale.ROOT));
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityMaterial.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityMaterial.java
@@ -1,0 +1,70 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.UUID;
+
+public final class CertificateAuthorityMaterial {
+
+  private final UUID installationId;
+  private final AuthorityChainMaterial authorityChain;
+
+  CertificateAuthorityMaterial(UUID installationId, AuthorityChainMaterial authorityChain) {
+    this.installationId = installationId;
+    this.authorityChain = authorityChain;
+  }
+
+  public UUID installationId() {
+    return installationId;
+  }
+
+  public PrivateKey rootPrivateKey() {
+    return authorityChain.root().privateKey();
+  }
+
+  public X509Certificate rootCertificate() {
+    return authorityChain.root().certificate();
+  }
+
+  public PrivateKey issuerPrivateKey() {
+    return authorityChain.issuer().privateKey();
+  }
+
+  public X509Certificate issuerCertificate() {
+    return authorityChain.issuer().certificate();
+  }
+
+  public PrivateKey revocationSignerPrivateKey() {
+    return authorityChain.revocationSigner().privateKey();
+  }
+
+  public X509Certificate revocationSignerCertificate() {
+    return authorityChain.revocationSigner().certificate();
+  }
+
+  @Override
+  public String toString() {
+    return "CertificateAuthorityMaterial[installationId="
+        + installationId
+        + ", privateKeys=REDACTED]";
+  }
+
+  record AuthorityChainMaterial(
+      AuthorityKeyMaterial root,
+      AuthorityKeyMaterial issuer,
+      AuthorityKeyMaterial revocationSigner) {
+
+    @Override
+    public String toString() {
+      return "AuthorityChainMaterial[privateKeys=REDACTED]";
+    }
+  }
+
+  record AuthorityKeyMaterial(PrivateKey privateKey, X509Certificate certificate) {
+
+    @Override
+    public String toString() {
+      return "AuthorityKeyMaterial[privateKey=REDACTED]";
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityValidator.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityValidator.java
@@ -1,0 +1,315 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.security.AlgorithmParameters;
+import java.security.MessageDigest;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+
+final class CertificateAuthorityValidator {
+
+  private static final String SIGNATURE_ALGORITHM = "SHA256withECDSA";
+  private static final String NORMALIZED_SIGNATURE_ALGORITHM =
+      SIGNATURE_ALGORITHM.toUpperCase(Locale.ROOT);
+  private static final byte[] KEY_MATCH_CHALLENGE =
+      "streamarr-ca-key-pair-validation-v1".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+  void validate(
+      CertificateAuthorityMaterial material, UUID expectedInstallationId, Instant databaseTime) {
+    if (!material.installationId().equals(expectedInstallationId)) {
+      throw new InstallationTrustException(
+          "Certificate authority belongs to a different installation");
+    }
+
+    try {
+      var root = material.rootCertificate();
+      var issuer = material.issuerCertificate();
+      var revocationSigner = material.revocationSignerCertificate();
+      root.verify(root.getPublicKey());
+      issuer.verify(root.getPublicKey());
+      revocationSigner.verify(issuer.getPublicKey());
+      root.checkValidity(Date.from(databaseTime));
+      issuer.checkValidity(Date.from(databaseTime));
+      revocationSigner.checkValidity(Date.from(databaseTime));
+
+      requireSigningCertificate(root, 1, expectedInstallationId);
+      requireSigningCertificate(issuer, 0, expectedInstallationId);
+      requireRevocationSigner(revocationSigner);
+      requireKeyIdentifiers(root, issuer, revocationSigner);
+      requireEqual(root.getSerialNumber().equals(issuer.getSerialNumber()), false);
+      requireP256(material.rootPrivateKey(), root);
+      requireP256(material.issuerPrivateKey(), issuer);
+      requireP256(material.revocationSignerPrivateKey(), revocationSigner);
+      requireDistinctAuthorityKeys(root, issuer, revocationSigner);
+      requireMatchingKey(material.rootPrivateKey(), root);
+      requireMatchingKey(material.issuerPrivateKey(), issuer);
+      requireMatchingKey(material.revocationSignerPrivateKey(), revocationSigner);
+      requireValidityNesting(root, issuer, revocationSigner);
+      requireMaximumValidity(
+          root,
+          BuiltInCertificateAuthority.ROOT_VALIDITY.plus(
+              BuiltInCertificateAuthority.VALIDITY_BACKDATE));
+      requireMaximumValidity(
+          issuer,
+          BuiltInCertificateAuthority.ISSUER_VALIDITY.plus(
+              BuiltInCertificateAuthority.VALIDITY_BACKDATE));
+      requireMaximumValidity(
+          revocationSigner,
+          BuiltInCertificateAuthority.REVOCATION_SIGNER_VALIDITY.plus(
+              BuiltInCertificateAuthority.VALIDITY_BACKDATE));
+
+      var rootSubject = expectedSubject(expectedInstallationId, "Root CA");
+      var issuerSubject = expectedSubject(expectedInstallationId, "Issuing CA");
+      var revocationSubject = expectedSubject(expectedInstallationId, "Revocation Signer");
+      requireEqual(root.getSubjectX500Principal(), rootSubject);
+      requireEqual(root.getIssuerX500Principal(), rootSubject);
+      requireEqual(issuer.getSubjectX500Principal(), issuerSubject);
+      requireEqual(issuer.getIssuerX500Principal(), rootSubject);
+      requireEqual(revocationSigner.getSubjectX500Principal(), revocationSubject);
+      requireEqual(revocationSigner.getIssuerX500Principal(), issuerSubject);
+    } catch (InstallationTrustException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new InstallationTrustException("Certificate authority profile is invalid", e);
+    }
+  }
+
+  private void requireSigningCertificate(
+      X509Certificate certificate, int pathLength, UUID installationId) throws Exception {
+    requireEqual(certificate.getBasicConstraints(), pathLength);
+    requireEqual(certificate.getKeyUsage(), keyUsages(5, 6));
+    requireEqual(certificate.getExtendedKeyUsage(), null);
+    requireEqual(
+        certificate.getSigAlgName().toUpperCase(Locale.ROOT), NORMALIZED_SIGNATURE_ALGORITHM);
+    requireEqual(
+        certificate.getCriticalExtensionOIDs(),
+        Set.of(Extension.basicConstraints.getId(), Extension.keyUsage.getId()));
+    requireEqual(
+        certificate.getNonCriticalExtensionOIDs(),
+        Set.of(
+            Extension.subjectKeyIdentifier.getId(),
+            Extension.authorityKeyIdentifier.getId(),
+            Extension.subjectAlternativeName.getId()));
+    requireEqual(uriSubjectAlternativeNames(certificate), List.of("spiffe://" + installationId));
+    requireCommonExtensions(certificate);
+  }
+
+  private void requireRevocationSigner(X509Certificate certificate) throws Exception {
+    requireEqual(certificate.getBasicConstraints(), -1);
+    requireEqual(certificate.getKeyUsage(), keyUsages(0));
+    requireEqual(certificate.getSubjectAlternativeNames(), null);
+    requireEqual(
+        certificate.getExtendedKeyUsage(),
+        List.of(BuiltInCertificateAuthority.REVOCATION_SIGNING_EKU_OID));
+    requireEqual(
+        certificate.getSigAlgName().toUpperCase(Locale.ROOT), NORMALIZED_SIGNATURE_ALGORITHM);
+    requireEqual(
+        certificate.getCriticalExtensionOIDs(),
+        Set.of(
+            Extension.basicConstraints.getId(),
+            Extension.keyUsage.getId(),
+            Extension.extendedKeyUsage.getId()));
+    requireEqual(
+        certificate.getNonCriticalExtensionOIDs(),
+        Set.of(Extension.subjectKeyIdentifier.getId(), Extension.authorityKeyIdentifier.getId()));
+    requireCommonExtensions(certificate);
+  }
+
+  private void requireCommonExtensions(X509Certificate certificate) {
+    Objects.requireNonNull(certificate.getExtensionValue(Extension.subjectKeyIdentifier.getId()));
+    Objects.requireNonNull(certificate.getExtensionValue(Extension.authorityKeyIdentifier.getId()));
+    requireEqual(certificate.getSerialNumber().signum(), 1);
+    requireMaximum(certificate.getSerialNumber().bitLength(), 128);
+  }
+
+  private void requireP256(java.security.PrivateKey privateKey, X509Certificate certificate)
+      throws Exception {
+    var ecPrivateKey = requireEcPrivateKey(privateKey);
+    var ecPublicKey = requireEcPublicKey(certificate);
+    var expected = expectedP256Parameters();
+    requireP256Parameters(ecPrivateKey.getParams(), expected);
+    requireP256Parameters(ecPublicKey.getParams(), expected);
+  }
+
+  private void requireKeyIdentifiers(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner)
+      throws Exception {
+    var extensionUtils = new JcaX509ExtensionUtils();
+    var rootIdentifier =
+        extensionUtils.createSubjectKeyIdentifier(root.getPublicKey()).getKeyIdentifier();
+    var issuerIdentifier =
+        extensionUtils.createSubjectKeyIdentifier(issuer.getPublicKey()).getKeyIdentifier();
+    var revocationSignerIdentifier =
+        extensionUtils
+            .createSubjectKeyIdentifier(revocationSigner.getPublicKey())
+            .getKeyIdentifier();
+    var rootAuthorityIdentifier = extensionUtils.createAuthorityKeyIdentifier(root.getPublicKey());
+    var issuerAuthorityIdentifier = extensionUtils.createAuthorityKeyIdentifier(root);
+    var revocationAuthorityIdentifier = extensionUtils.createAuthorityKeyIdentifier(issuer);
+
+    requireIdentifier(subjectKeyIdentifier(root), rootIdentifier);
+    requireAuthorityIdentifier(authorityKeyIdentifier(root), rootAuthorityIdentifier);
+    requireIdentifier(subjectKeyIdentifier(issuer), issuerIdentifier);
+    requireAuthorityIdentifier(authorityKeyIdentifier(issuer), issuerAuthorityIdentifier);
+    requireIdentifier(subjectKeyIdentifier(revocationSigner), revocationSignerIdentifier);
+    requireAuthorityIdentifier(
+        authorityKeyIdentifier(revocationSigner), revocationAuthorityIdentifier);
+  }
+
+  private byte[] subjectKeyIdentifier(X509Certificate certificate) throws Exception {
+    return SubjectKeyIdentifier.getInstance(
+            decodedExtensionValue(certificate, Extension.subjectKeyIdentifier.getId()))
+        .getKeyIdentifier();
+  }
+
+  private AuthorityKeyIdentifier authorityKeyIdentifier(X509Certificate certificate)
+      throws Exception {
+    return AuthorityKeyIdentifier.getInstance(
+        decodedExtensionValue(certificate, Extension.authorityKeyIdentifier.getId()));
+  }
+
+  private ASN1Primitive decodedExtensionValue(X509Certificate certificate, String oid)
+      throws Exception {
+    var encoded = ASN1OctetString.getInstance(certificate.getExtensionValue(oid)).getOctets();
+    return ASN1Primitive.fromByteArray(encoded);
+  }
+
+  private void requireIdentifier(byte[] actual, byte[] expected) {
+    if (!MessageDigest.isEqual(actual, expected)) {
+      throw invalidProfile();
+    }
+  }
+
+  private void requireAuthorityIdentifier(
+      AuthorityKeyIdentifier actual, AuthorityKeyIdentifier expected) throws Exception {
+    requireIdentifier(actual.getEncoded(), expected.getEncoded());
+  }
+
+  private void requireDistinctAuthorityKeys(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner) {
+    var rootPoint = ((ECPublicKey) root.getPublicKey()).getW();
+    var issuerPoint = ((ECPublicKey) issuer.getPublicKey()).getW();
+    var revocationSignerPoint = ((ECPublicKey) revocationSigner.getPublicKey()).getW();
+    requireEqual(rootPoint.equals(issuerPoint), false);
+    requireEqual(rootPoint.equals(revocationSignerPoint), false);
+    requireEqual(issuerPoint.equals(revocationSignerPoint), false);
+  }
+
+  private void requireMatchingKey(java.security.PrivateKey privateKey, X509Certificate certificate)
+      throws Exception {
+    var signer = Signature.getInstance(SIGNATURE_ALGORITHM);
+    signer.initSign(privateKey);
+    signer.update(KEY_MATCH_CHALLENGE);
+    var signature = signer.sign();
+
+    var verifier = Signature.getInstance(SIGNATURE_ALGORITHM);
+    verifier.initVerify(certificate.getPublicKey());
+    verifier.update(KEY_MATCH_CHALLENGE);
+    if (!verifier.verify(signature)) {
+      throw new InstallationTrustException(
+          "Certificate authority contains a mismatched private key");
+    }
+  }
+
+  private void requireValidityNesting(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner) {
+    requireEqual(root.getNotBefore(), issuer.getNotBefore());
+    requireEqual(root.getNotBefore(), revocationSigner.getNotBefore());
+    requireEqual(issuer.getNotAfter().after(root.getNotAfter()), false);
+    requireEqual(revocationSigner.getNotAfter().after(issuer.getNotAfter()), false);
+  }
+
+  private void requireMaximumValidity(X509Certificate certificate, Duration maximum) {
+    var actual =
+        Duration.between(
+            certificate.getNotBefore().toInstant(), certificate.getNotAfter().toInstant());
+    if (actual.compareTo(maximum) > 0) {
+      throw invalidProfile();
+    }
+  }
+
+  private X500Principal expectedSubject(UUID installationId, String role) {
+    return new X500Principal(BuiltInCertificateAuthority.subjectName(installationId, role));
+  }
+
+  private ECParameterSpec expectedP256Parameters() throws Exception {
+    var parameters = AlgorithmParameters.getInstance("EC");
+    parameters.init(new ECGenParameterSpec("secp256r1"));
+    return parameters.getParameterSpec(ECParameterSpec.class);
+  }
+
+  private ECPrivateKey requireEcPrivateKey(java.security.PrivateKey privateKey) {
+    if (privateKey instanceof ECPrivateKey ecPrivateKey) {
+      return ecPrivateKey;
+    }
+    throw invalidProfile();
+  }
+
+  private ECPublicKey requireEcPublicKey(X509Certificate certificate) {
+    if (certificate.getPublicKey() instanceof ECPublicKey ecPublicKey) {
+      return ecPublicKey;
+    }
+    throw invalidProfile();
+  }
+
+  private void requireP256Parameters(ECParameterSpec actual, ECParameterSpec expected) {
+    requireEqual(actual.getCurve(), expected.getCurve());
+    requireEqual(actual.getGenerator(), expected.getGenerator());
+    requireEqual(actual.getOrder(), expected.getOrder());
+    requireEqual(actual.getCofactor(), expected.getCofactor());
+  }
+
+  private List<String> uriSubjectAlternativeNames(X509Certificate certificate) throws Exception {
+    return Optional.ofNullable(certificate.getSubjectAlternativeNames()).orElse(List.of()).stream()
+        .map(this::uriSubjectAlternativeName)
+        .toList();
+  }
+
+  private String uriSubjectAlternativeName(List<?> entry) {
+    requireEqual(entry.getFirst(), 6);
+    return (String) entry.get(1);
+  }
+
+  private boolean[] keyUsages(int... enabledIndexes) {
+    var usages = new boolean[9];
+    for (var index : enabledIndexes) {
+      usages[index] = true;
+    }
+    return usages;
+  }
+
+  private void requireEqual(Object actual, Object expected) {
+    if (!Objects.deepEquals(actual, expected)) {
+      throw invalidProfile();
+    }
+  }
+
+  private void requireMaximum(int actual, int maximum) {
+    if (actual > maximum) {
+      throw invalidProfile();
+    }
+  }
+
+  private InstallationTrustException invalidProfile() {
+    return new InstallationTrustException("Certificate authority profile is invalid");
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityValidator.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityValidator.java
@@ -1,8 +1,11 @@
 package com.streamarr.server.services.streaming.trust;
 
+import java.io.IOException;
 import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.Signature;
+import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
@@ -94,7 +97,8 @@ final class CertificateAuthorityValidator {
   }
 
   private void requireSigningCertificate(
-      X509Certificate certificate, int pathLength, UUID installationId) throws Exception {
+      X509Certificate certificate, int pathLength, UUID installationId)
+      throws CertificateParsingException {
     requireEqual(certificate.getBasicConstraints(), pathLength);
     requireEqual(certificate.getKeyUsage(), keyUsages(5, 6));
     requireEqual(certificate.getExtendedKeyUsage(), null);
@@ -113,7 +117,8 @@ final class CertificateAuthorityValidator {
     requireCommonExtensions(certificate);
   }
 
-  private void requireRevocationSigner(X509Certificate certificate) throws Exception {
+  private void requireRevocationSigner(X509Certificate certificate)
+      throws CertificateParsingException {
     requireEqual(certificate.getBasicConstraints(), -1);
     requireEqual(certificate.getKeyUsage(), keyUsages(0));
     requireEqual(certificate.getSubjectAlternativeNames(), null);
@@ -142,7 +147,7 @@ final class CertificateAuthorityValidator {
   }
 
   private void requireP256(java.security.PrivateKey privateKey, X509Certificate certificate)
-      throws Exception {
+      throws GeneralSecurityException {
     var ecPrivateKey = requireEcPrivateKey(privateKey);
     var ecPublicKey = requireEcPublicKey(certificate);
     var expected = expectedP256Parameters();
@@ -152,7 +157,7 @@ final class CertificateAuthorityValidator {
 
   private void requireKeyIdentifiers(
       X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner)
-      throws Exception {
+      throws GeneralSecurityException, IOException {
     var extensionUtils = new JcaX509ExtensionUtils();
     var rootIdentifier =
         extensionUtils.createSubjectKeyIdentifier(root.getPublicKey()).getKeyIdentifier();
@@ -175,20 +180,20 @@ final class CertificateAuthorityValidator {
         authorityKeyIdentifier(revocationSigner), revocationAuthorityIdentifier);
   }
 
-  private byte[] subjectKeyIdentifier(X509Certificate certificate) throws Exception {
+  private byte[] subjectKeyIdentifier(X509Certificate certificate) throws IOException {
     return SubjectKeyIdentifier.getInstance(
             decodedExtensionValue(certificate, Extension.subjectKeyIdentifier.getId()))
         .getKeyIdentifier();
   }
 
   private AuthorityKeyIdentifier authorityKeyIdentifier(X509Certificate certificate)
-      throws Exception {
+      throws IOException {
     return AuthorityKeyIdentifier.getInstance(
         decodedExtensionValue(certificate, Extension.authorityKeyIdentifier.getId()));
   }
 
   private ASN1Primitive decodedExtensionValue(X509Certificate certificate, String oid)
-      throws Exception {
+      throws IOException {
     var encoded = ASN1OctetString.getInstance(certificate.getExtensionValue(oid)).getOctets();
     return ASN1Primitive.fromByteArray(encoded);
   }
@@ -200,7 +205,7 @@ final class CertificateAuthorityValidator {
   }
 
   private void requireAuthorityIdentifier(
-      AuthorityKeyIdentifier actual, AuthorityKeyIdentifier expected) throws Exception {
+      AuthorityKeyIdentifier actual, AuthorityKeyIdentifier expected) throws IOException {
     requireIdentifier(actual.getEncoded(), expected.getEncoded());
   }
 
@@ -215,7 +220,7 @@ final class CertificateAuthorityValidator {
   }
 
   private void requireMatchingKey(java.security.PrivateKey privateKey, X509Certificate certificate)
-      throws Exception {
+      throws GeneralSecurityException {
     var signer = Signature.getInstance(SIGNATURE_ALGORITHM);
     signer.initSign(privateKey);
     signer.update(KEY_MATCH_CHALLENGE);
@@ -251,7 +256,7 @@ final class CertificateAuthorityValidator {
     return new X500Principal(BuiltInCertificateAuthority.subjectName(installationId, role));
   }
 
-  private ECParameterSpec expectedP256Parameters() throws Exception {
+  private ECParameterSpec expectedP256Parameters() throws GeneralSecurityException {
     var parameters = AlgorithmParameters.getInstance("EC");
     parameters.init(new ECGenParameterSpec("secp256r1"));
     return parameters.getParameterSpec(ECParameterSpec.class);
@@ -278,7 +283,8 @@ final class CertificateAuthorityValidator {
     requireEqual(actual.getCofactor(), expected.getCofactor());
   }
 
-  private List<String> uriSubjectAlternativeNames(X509Certificate certificate) throws Exception {
+  private List<String> uriSubjectAlternativeNames(X509Certificate certificate)
+      throws CertificateParsingException {
     return Optional.ofNullable(certificate.getSubjectAlternativeNames()).orElse(List.of()).stream()
         .map(this::uriSubjectAlternativeName)
         .toList();

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/InstallationTrustException.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/InstallationTrustException.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.trust;
+
+public final class InstallationTrustException extends RuntimeException {
+
+  public InstallationTrustException(String message) {
+    super(message);
+  }
+
+  public InstallationTrustException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/ArchitectureTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/ArchitectureTest.java
@@ -89,6 +89,16 @@ class ArchitectureTest {
           .resideInAPackage("org.jooq..")
           .as("Auth services must not depend on jOOQ; DSLContext stays in repositories");
 
+  @ArchTest
+  static final ArchRule trustServicesMustNotDependOnPersistenceOrGraphql =
+      noClasses()
+          .that()
+          .resideInAPackage("..services.streaming.trust..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAnyPackage("org.jooq..", "..graphql..")
+          .as("Trust services must keep persistence DSL and GraphQL in their outer adapters");
+
   // Transaction boundaries belong in services. A transactional controller/resolver would run
   // several service calls in one persistence context, where a JPA read can return Hibernate's
   // stale first-level-cache copy of a row a jOOQ write already changed (see AGENTS.md,

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthorityTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthorityTest.java
@@ -1,0 +1,633 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Built-in Certificate Authority Tests")
+class BuiltInCertificateAuthorityTest {
+
+  private static final UUID INSTALLATION_ID =
+      UUID.fromString("7afbbbed-3492-4b71-909d-8acb50ffdcc2");
+  private static final Instant ISSUED_AT = Instant.parse("2026-07-12T12:00:00Z");
+
+  @Test
+  @DisplayName("Should create the exact installation trust profiles when material is generated")
+  void shouldCreateExactInstallationTrustProfilesWhenMaterialIsGenerated() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var material = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var root = material.rootCertificate();
+    var issuer = material.issuerCertificate();
+    var revocationSigner = material.revocationSignerCertificate();
+
+    root.verify(root.getPublicKey());
+    issuer.verify(root.getPublicKey());
+    revocationSigner.verify(issuer.getPublicKey());
+
+    assertThat(material.rootPrivateKey()).isInstanceOf(ECPrivateKey.class);
+    assertThat(material.issuerPrivateKey()).isInstanceOf(ECPrivateKey.class);
+    assertThat(material.revocationSignerPrivateKey()).isInstanceOf(ECPrivateKey.class);
+    assertThat((ECPublicKey) root.getPublicKey())
+        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
+        .isEqualTo(256);
+    assertThat((ECPublicKey) issuer.getPublicKey())
+        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
+        .isEqualTo(256);
+    assertThat((ECPublicKey) revocationSigner.getPublicKey())
+        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
+        .isEqualTo(256);
+
+    assertThat(root.getBasicConstraints()).isEqualTo(1);
+    assertThat(issuer.getBasicConstraints()).isZero();
+    assertThat(revocationSigner.getBasicConstraints()).isEqualTo(-1);
+    assertThat(root.getSubjectX500Principal().getName())
+        .isEqualTo("CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Root CA");
+    assertThat(issuer.getSubjectX500Principal().getName())
+        .isEqualTo("CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Issuing CA");
+    assertThat(revocationSigner.getSubjectX500Principal().getName())
+        .isEqualTo(
+            "CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Revocation Signer");
+    assertThat(root.getKeyUsage()).containsExactly(keyUsages(5, 6));
+    assertThat(issuer.getKeyUsage()).containsExactly(keyUsages(5, 6));
+    assertThat(revocationSigner.getKeyUsage()).containsExactly(keyUsages(0));
+
+    assertThat(root.getCriticalExtensionOIDs())
+        .contains(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
+    assertThat(issuer.getCriticalExtensionOIDs())
+        .contains(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
+    assertThat(revocationSigner.getCriticalExtensionOIDs())
+        .contains(
+            Extension.basicConstraints.getId(),
+            Extension.keyUsage.getId(),
+            Extension.extendedKeyUsage.getId());
+
+    var trustDomain = URI.create("spiffe://" + INSTALLATION_ID);
+    assertThat(uriSubjectAlternativeNames(root)).containsExactly(trustDomain);
+    assertThat(uriSubjectAlternativeNames(issuer)).containsExactly(trustDomain);
+    assertThat(revocationSigner.getSubjectAlternativeNames()).isNull();
+    assertThat(root.getExtendedKeyUsage()).isNull();
+    assertThat(issuer.getExtendedKeyUsage()).isNull();
+    assertThat(revocationSigner.getExtendedKeyUsage())
+        .containsExactly(BuiltInCertificateAuthority.REVOCATION_SIGNING_EKU_OID);
+
+    assertThat(root.getNotBefore().toInstant()).isBefore(ISSUED_AT);
+    assertThat(issuer.getNotBefore()).isEqualTo(root.getNotBefore());
+    assertThat(revocationSigner.getNotBefore()).isEqualTo(root.getNotBefore());
+    assertThat(issuer.getNotAfter()).isBeforeOrEqualTo(root.getNotAfter());
+    assertThat(revocationSigner.getNotAfter()).isBeforeOrEqualTo(issuer.getNotAfter());
+
+    assertThat(sha256(root.getEncoded())).hasSize(32);
+    assertThat(sha256(issuer.getEncoded())).hasSize(32);
+    assertThat(sha256(revocationSigner.getEncoded())).hasSize(32);
+    authority.validate(material, INSTALLATION_ID, ISSUED_AT);
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a private key mismatches its certificate")
+  void shouldRejectAuthorityMaterialWhenPrivateKeyMismatchesCertificate() {
+    var authority = new BuiltInCertificateAuthority();
+    var expected = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var other =
+        authority.create(UUID.fromString("43b81699-381f-44f8-b675-aa326a44fa7c"), ISSUED_AT);
+    var mismatched =
+        new CertificateAuthorityMaterial(
+            INSTALLATION_ID,
+            new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    other.rootPrivateKey(), expected.rootCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    expected.issuerPrivateKey(), expected.issuerCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    expected.revocationSignerPrivateKey(),
+                    expected.revocationSignerCertificate())));
+
+    assertThatThrownBy(() -> authority.validate(mismatched, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("mismatched private key");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a private key is not EC")
+  void shouldRejectAuthorityMaterialWhenPrivateKeyIsNotEc() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var expected = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var generator = KeyPairGenerator.getInstance("RSA");
+    generator.initialize(2048);
+    var malformed = withRootPrivateKey(expected, generator.generateKeyPair().getPrivate());
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a private key is outside P-256")
+  void shouldRejectAuthorityMaterialWhenPrivateKeyIsOutsideP256() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var expected = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var generator = KeyPairGenerator.getInstance("EC");
+    generator.initialize(new ECGenParameterSpec("secp384r1"));
+    var malformed = withRootPrivateKey(expected, generator.generateKeyPair().getPrivate());
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when it belongs to another installation")
+  void shouldRejectAuthorityMaterialWhenItBelongsToAnotherInstallation() {
+    var authority = new BuiltInCertificateAuthority();
+    var material = authority.create(INSTALLATION_ID, ISSUED_AT);
+
+    assertThatThrownBy(() -> authority.validate(material, UUID.randomUUID(), ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("different installation");
+  }
+
+  @Test
+  @DisplayName("Should reject a certificate chain when it is relabeled for this installation")
+  void shouldRejectCertificateChainWhenRelabeledForThisInstallation() {
+    var authority = new BuiltInCertificateAuthority();
+    var foreign =
+        authority.create(UUID.fromString("9da8e0fd-cd00-407a-a3be-44f79ce8357d"), ISSUED_AT);
+    var relabeled = withInstallationId(foreign, INSTALLATION_ID);
+
+    assertThatThrownBy(() -> authority.validate(relabeled, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when its certificates have expired")
+  void shouldRejectAuthorityMaterialWhenCertificatesHaveExpired() {
+    var authority = new BuiltInCertificateAuthority();
+    var material = authority.create(INSTALLATION_ID, ISSUED_AT);
+
+    assertThatThrownBy(
+            () ->
+                authority.validate(
+                    material, INSTALLATION_ID, ISSUED_AT.plus(Duration.ofDays(4_000))))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid")
+        .hasCauseInstanceOf(CertificateExpiredException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a subject key identifier is incorrect")
+  void shouldRejectAuthorityMaterialWhenSubjectKeyIdentifierIsIncorrect() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed = withMismatchedRootKeyIdentifiers(original);
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when two roles reuse one key")
+  void shouldRejectAuthorityMaterialWhenRolesReuseOneKey() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed = withIssuerKeyReusedForRevocationSigning(original);
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when an unexpected extension is present")
+  void shouldRejectAuthorityMaterialWhenUnexpectedExtensionIsPresent() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed = withUnexpectedRootExtension(original);
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a serial number exceeds 128 bits")
+  void shouldRejectAuthorityMaterialWhenSerialNumberExceeds128Bits() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed =
+        withRevocationSignerProfile(
+            original,
+            defaultRevocationSignerProfile(original)
+                .withShape(
+                    new CertificateShape(
+                        BigInteger.ONE.shiftLeft(128),
+                        original.revocationSignerCertificate().getNotAfter())));
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when root and issuer serial numbers collide")
+  void shouldRejectAuthorityMaterialWhenRootAndIssuerSerialNumbersCollide() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed =
+        withIssuerProfile(
+            original,
+            new IssuerProfile(
+                original.rootCertificate().getSerialNumber(),
+                new X500Name(original.issuerCertificate().getSubjectX500Principal().getName())));
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a trust-domain URI is not canonical")
+  void shouldRejectAuthorityMaterialWhenTrustDomainUriIsNotCanonical() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var exact = exactRootExtensions(original.rootCertificate());
+    var malformed =
+        withRootExtensions(
+            original,
+            new RootExtensions(
+                exact.subjectKeyIdentifier(),
+                exact.authorityKeyIdentifier(),
+                "SPIFFE://" + INSTALLATION_ID));
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when an authority key identifier is ambiguous")
+  void shouldRejectAuthorityMaterialWhenAuthorityKeyIdentifierIsAmbiguous() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var exact = exactRootExtensions(original.rootCertificate());
+    var ambiguousIdentifier =
+        new AuthorityKeyIdentifier(
+            exact.authorityKeyIdentifier().getKeyIdentifier(),
+            new GeneralNames(
+                new GeneralName(GeneralName.directoryName, new X500Name("CN=Conflicting Root"))),
+            BigInteger.ONE);
+    var malformed =
+        withRootExtensions(
+            original,
+            new RootExtensions(
+                exact.subjectKeyIdentifier(), ambiguousIdentifier, exact.trustDomain()));
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when an authority role has an ambiguous subject")
+  void shouldRejectAuthorityMaterialWhenAuthorityRoleHasAmbiguousSubject() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed =
+        withIssuerProfile(
+            original,
+            new IssuerProfile(
+                original.issuerCertificate().getSerialNumber(),
+                new X500Name(original.rootCertificate().getSubjectX500Principal().getName())));
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when a role validity exceeds its profile")
+  void shouldRejectAuthorityMaterialWhenRoleValidityExceedsProfile() throws Exception {
+    var authority = new BuiltInCertificateAuthority();
+    var original = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var malformed =
+        withRevocationSignerProfile(
+            original,
+            defaultRevocationSignerProfile(original)
+                .withShape(
+                    new CertificateShape(
+                        original.revocationSignerCertificate().getSerialNumber(),
+                        original.issuerCertificate().getNotAfter())));
+
+    assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("invalid");
+  }
+
+  private static CertificateAuthorityMaterial withUnexpectedRootExtension(
+      CertificateAuthorityMaterial original) throws Exception {
+    var root = original.rootCertificate();
+    var builder = rootBuilder(original, root.getSerialNumber());
+    addExactRootExtensions(builder, root);
+    builder.addExtension(
+        new ASN1ObjectIdentifier("1.3.6.1.4.1.55555.1"), false, new DERUTF8String("unexpected"));
+    return withRootCertificate(original, signRoot(builder, original));
+  }
+
+  private static CertificateAuthorityMaterial withIssuerKeyReusedForRevocationSigning(
+      CertificateAuthorityMaterial original) throws Exception {
+    var issuer = original.issuerCertificate();
+    var originalSigner = original.revocationSignerCertificate();
+    var identity =
+        new SigningIdentity(
+            original.issuerPrivateKey(),
+            issuer.getPublicKey(),
+            new X500Name(originalSigner.getSubjectX500Principal().getName()));
+    return withRevocationSignerProfile(
+        original, defaultRevocationSignerProfile(original).withIdentity(identity));
+  }
+
+  private static CertificateAuthorityMaterial withMismatchedRootKeyIdentifiers(
+      CertificateAuthorityMaterial original) throws Exception {
+    var exact = exactRootExtensions(original.rootCertificate());
+    return withRootExtensions(
+        original,
+        new RootExtensions(
+            new SubjectKeyIdentifier(new byte[] {1, 2, 3, 4}),
+            exact.authorityKeyIdentifier(),
+            exact.trustDomain()));
+  }
+
+  private static CertificateAuthorityMaterial withRootExtensions(
+      CertificateAuthorityMaterial original, RootExtensions profile) throws Exception {
+    var builder = rootBuilder(original, original.rootCertificate().getSerialNumber());
+    addRootExtensions(builder, profile);
+    return withRootCertificate(original, signRoot(builder, original));
+  }
+
+  private static JcaX509v3CertificateBuilder rootBuilder(
+      CertificateAuthorityMaterial original, BigInteger serialNumber) {
+    var root = original.rootCertificate();
+    var subject = new X500Name(root.getSubjectX500Principal().getName());
+    return new JcaX509v3CertificateBuilder(
+        subject,
+        serialNumber,
+        root.getNotBefore(),
+        root.getNotAfter(),
+        subject,
+        root.getPublicKey());
+  }
+
+  private static void addExactRootExtensions(
+      JcaX509v3CertificateBuilder builder, X509Certificate root) throws Exception {
+    addRootExtensions(builder, exactRootExtensions(root));
+  }
+
+  private static RootExtensions exactRootExtensions(X509Certificate root) throws Exception {
+    var extensions = new JcaX509ExtensionUtils();
+    return new RootExtensions(
+        extensions.createSubjectKeyIdentifier(root.getPublicKey()),
+        extensions.createAuthorityKeyIdentifier(root.getPublicKey()),
+        "spiffe://" + INSTALLATION_ID);
+  }
+
+  private static void addRootExtensions(JcaX509v3CertificateBuilder builder, RootExtensions profile)
+      throws Exception {
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(1));
+    builder.addExtension(
+        Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+    builder.addExtension(Extension.subjectKeyIdentifier, false, profile.subjectKeyIdentifier());
+    builder.addExtension(Extension.authorityKeyIdentifier, false, profile.authorityKeyIdentifier());
+    addTrustDomain(builder, profile.trustDomain());
+  }
+
+  private static void addTrustDomain(JcaX509v3CertificateBuilder builder, String trustDomain)
+      throws Exception {
+    builder.addExtension(
+        Extension.subjectAlternativeName,
+        false,
+        new GeneralNames(new GeneralName(GeneralName.uniformResourceIdentifier, trustDomain)));
+  }
+
+  private static CertificateAuthorityMaterial withIssuerProfile(
+      CertificateAuthorityMaterial original, IssuerProfile profile) throws Exception {
+    var root = original.rootCertificate();
+    var issuer = original.issuerCertificate();
+    var builder =
+        new JcaX509v3CertificateBuilder(
+            new X500Name(root.getSubjectX500Principal().getName()),
+            profile.serialNumber(),
+            issuer.getNotBefore(),
+            issuer.getNotAfter(),
+            profile.subject(),
+            issuer.getPublicKey());
+    addIssuerExtensions(builder, issuer.getPublicKey(), root);
+    var signer = new JcaContentSignerBuilder("SHA256withECDSA").build(original.rootPrivateKey());
+    var rebuiltIssuer = new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    var intermediate =
+        new CertificateAuthorityMaterial(
+            INSTALLATION_ID,
+            new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    original.rootPrivateKey(), root),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    original.issuerPrivateKey(), rebuiltIssuer),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    original.revocationSignerPrivateKey(),
+                    original.revocationSignerCertificate())));
+    return withRevocationSignerProfile(intermediate, defaultRevocationSignerProfile(intermediate));
+  }
+
+  private static void addIssuerExtensions(
+      JcaX509v3CertificateBuilder builder, PublicKey publicKey, X509Certificate root)
+      throws Exception {
+    var extensions = new JcaX509ExtensionUtils();
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(0));
+    builder.addExtension(
+        Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+    builder.addExtension(
+        Extension.subjectKeyIdentifier, false, extensions.createSubjectKeyIdentifier(publicKey));
+    builder.addExtension(
+        Extension.authorityKeyIdentifier, false, extensions.createAuthorityKeyIdentifier(root));
+    addTrustDomain(builder, "spiffe://" + INSTALLATION_ID);
+  }
+
+  private static RevocationSignerProfile defaultRevocationSignerProfile(
+      CertificateAuthorityMaterial original) {
+    var certificate = original.revocationSignerCertificate();
+    return new RevocationSignerProfile(
+        new SigningIdentity(
+            original.revocationSignerPrivateKey(),
+            certificate.getPublicKey(),
+            new X500Name(certificate.getSubjectX500Principal().getName())),
+        original.issuerCertificate(),
+        new CertificateShape(certificate.getSerialNumber(), certificate.getNotAfter()));
+  }
+
+  private static CertificateAuthorityMaterial withRevocationSignerProfile(
+      CertificateAuthorityMaterial original, RevocationSignerProfile profile) throws Exception {
+    var originalSigner = original.revocationSignerCertificate();
+    var builder =
+        new JcaX509v3CertificateBuilder(
+            new X500Name(profile.issuerCertificate().getSubjectX500Principal().getName()),
+            profile.shape().serialNumber(),
+            originalSigner.getNotBefore(),
+            profile.shape().notAfter(),
+            profile.identity().subject(),
+            profile.identity().publicKey());
+    addRevocationSignerExtensions(
+        builder, profile.identity().publicKey(), profile.issuerCertificate());
+    var signer = new JcaContentSignerBuilder("SHA256withECDSA").build(original.issuerPrivateKey());
+    var rebuiltSigner = new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    return new CertificateAuthorityMaterial(
+        INSTALLATION_ID,
+        new CertificateAuthorityMaterial.AuthorityChainMaterial(
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.rootPrivateKey(), original.rootCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.issuerPrivateKey(), profile.issuerCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                profile.identity().privateKey(), rebuiltSigner)));
+  }
+
+  private static void addRevocationSignerExtensions(
+      JcaX509v3CertificateBuilder builder, PublicKey publicKey, X509Certificate issuer)
+      throws Exception {
+    var extensions = new JcaX509ExtensionUtils();
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+    builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+    builder.addExtension(
+        Extension.subjectKeyIdentifier, false, extensions.createSubjectKeyIdentifier(publicKey));
+    builder.addExtension(
+        Extension.authorityKeyIdentifier, false, extensions.createAuthorityKeyIdentifier(issuer));
+    builder.addExtension(
+        Extension.extendedKeyUsage,
+        true,
+        new ExtendedKeyUsage(
+            KeyPurposeId.getInstance(
+                new ASN1ObjectIdentifier(BuiltInCertificateAuthority.REVOCATION_SIGNING_EKU_OID))));
+  }
+
+  private static X509Certificate signRoot(
+      JcaX509v3CertificateBuilder builder, CertificateAuthorityMaterial original) throws Exception {
+    var signer = new JcaContentSignerBuilder("SHA256withECDSA").build(original.rootPrivateKey());
+    return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+  }
+
+  private static CertificateAuthorityMaterial withRootCertificate(
+      CertificateAuthorityMaterial original, X509Certificate rootCertificate) {
+    return new CertificateAuthorityMaterial(
+        INSTALLATION_ID,
+        new CertificateAuthorityMaterial.AuthorityChainMaterial(
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.rootPrivateKey(), rootCertificate),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.issuerPrivateKey(), original.issuerCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.revocationSignerPrivateKey(), original.revocationSignerCertificate())));
+  }
+
+  private static CertificateAuthorityMaterial withRootPrivateKey(
+      CertificateAuthorityMaterial original, java.security.PrivateKey rootPrivateKey) {
+    return new CertificateAuthorityMaterial(
+        INSTALLATION_ID,
+        new CertificateAuthorityMaterial.AuthorityChainMaterial(
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                rootPrivateKey, original.rootCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.issuerPrivateKey(), original.issuerCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.revocationSignerPrivateKey(), original.revocationSignerCertificate())));
+  }
+
+  private static CertificateAuthorityMaterial withInstallationId(
+      CertificateAuthorityMaterial original, UUID installationId) {
+    return new CertificateAuthorityMaterial(
+        installationId,
+        new CertificateAuthorityMaterial.AuthorityChainMaterial(
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.rootPrivateKey(), original.rootCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.issuerPrivateKey(), original.issuerCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.revocationSignerPrivateKey(), original.revocationSignerCertificate())));
+  }
+
+  private static boolean[] keyUsages(int... enabledIndexes) {
+    var usages = new boolean[9];
+    for (var index : enabledIndexes) {
+      usages[index] = true;
+    }
+    return usages;
+  }
+
+  private static List<URI> uriSubjectAlternativeNames(java.security.cert.X509Certificate cert)
+      throws Exception {
+    return cert.getSubjectAlternativeNames().stream()
+        .filter(entry -> entry.getFirst().equals(6))
+        .map(entry -> URI.create((String) entry.get(1)))
+        .toList();
+  }
+
+  private static byte[] sha256(byte[] value) throws Exception {
+    return MessageDigest.getInstance("SHA-256").digest(value);
+  }
+
+  private record RootExtensions(
+      SubjectKeyIdentifier subjectKeyIdentifier,
+      AuthorityKeyIdentifier authorityKeyIdentifier,
+      String trustDomain) {}
+
+  private record IssuerProfile(BigInteger serialNumber, X500Name subject) {}
+
+  private record CertificateShape(BigInteger serialNumber, Date notAfter) {}
+
+  private record SigningIdentity(PrivateKey privateKey, PublicKey publicKey, X500Name subject) {}
+
+  private record RevocationSignerProfile(
+      SigningIdentity identity, X509Certificate issuerCertificate, CertificateShape shape) {
+
+    private RevocationSignerProfile withIdentity(SigningIdentity replacement) {
+      return new RevocationSignerProfile(replacement, issuerCertificate, shape);
+    }
+
+    private RevocationSignerProfile withShape(CertificateShape replacement) {
+      return new RevocationSignerProfile(identity, issuerCertificate, replacement);
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthorityTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthorityTest.java
@@ -56,65 +56,14 @@ class BuiltInCertificateAuthorityTest {
     var issuer = material.issuerCertificate();
     var revocationSigner = material.revocationSignerCertificate();
 
-    root.verify(root.getPublicKey());
-    issuer.verify(root.getPublicKey());
-    revocationSigner.verify(issuer.getPublicKey());
-
-    assertThat(material.rootPrivateKey()).isInstanceOf(ECPrivateKey.class);
-    assertThat(material.issuerPrivateKey()).isInstanceOf(ECPrivateKey.class);
-    assertThat(material.revocationSignerPrivateKey()).isInstanceOf(ECPrivateKey.class);
-    assertThat((ECPublicKey) root.getPublicKey())
-        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
-        .isEqualTo(256);
-    assertThat((ECPublicKey) issuer.getPublicKey())
-        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
-        .isEqualTo(256);
-    assertThat((ECPublicKey) revocationSigner.getPublicKey())
-        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
-        .isEqualTo(256);
-
-    assertThat(root.getBasicConstraints()).isEqualTo(1);
-    assertThat(issuer.getBasicConstraints()).isZero();
-    assertThat(revocationSigner.getBasicConstraints()).isEqualTo(-1);
-    assertThat(root.getSubjectX500Principal().getName())
-        .isEqualTo("CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Root CA");
-    assertThat(issuer.getSubjectX500Principal().getName())
-        .isEqualTo("CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Issuing CA");
-    assertThat(revocationSigner.getSubjectX500Principal().getName())
-        .isEqualTo(
-            "CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Revocation Signer");
-    assertThat(root.getKeyUsage()).containsExactly(keyUsages(5, 6));
-    assertThat(issuer.getKeyUsage()).containsExactly(keyUsages(5, 6));
-    assertThat(revocationSigner.getKeyUsage()).containsExactly(keyUsages(0));
-
-    assertThat(root.getCriticalExtensionOIDs())
-        .contains(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
-    assertThat(issuer.getCriticalExtensionOIDs())
-        .contains(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
-    assertThat(revocationSigner.getCriticalExtensionOIDs())
-        .contains(
-            Extension.basicConstraints.getId(),
-            Extension.keyUsage.getId(),
-            Extension.extendedKeyUsage.getId());
-
-    var trustDomain = URI.create("spiffe://" + INSTALLATION_ID);
-    assertThat(uriSubjectAlternativeNames(root)).containsExactly(trustDomain);
-    assertThat(uriSubjectAlternativeNames(issuer)).containsExactly(trustDomain);
-    assertThat(revocationSigner.getSubjectAlternativeNames()).isNull();
-    assertThat(root.getExtendedKeyUsage()).isNull();
-    assertThat(issuer.getExtendedKeyUsage()).isNull();
-    assertThat(revocationSigner.getExtendedKeyUsage())
-        .containsExactly(BuiltInCertificateAuthority.REVOCATION_SIGNING_EKU_OID);
-
-    assertThat(root.getNotBefore().toInstant()).isBefore(ISSUED_AT);
-    assertThat(issuer.getNotBefore()).isEqualTo(root.getNotBefore());
-    assertThat(revocationSigner.getNotBefore()).isEqualTo(root.getNotBefore());
-    assertThat(issuer.getNotAfter()).isBeforeOrEqualTo(root.getNotAfter());
-    assertThat(revocationSigner.getNotAfter()).isBeforeOrEqualTo(issuer.getNotAfter());
-
-    assertThat(sha256(root.getEncoded())).hasSize(32);
-    assertThat(sha256(issuer.getEncoded())).hasSize(32);
-    assertThat(sha256(revocationSigner.getEncoded())).hasSize(32);
+    verifyCertificateSignatures(root, issuer, revocationSigner);
+    verifyPrivateKeyProfiles(material);
+    verifyPublicKeyProfiles(root, issuer, revocationSigner);
+    verifyAuthorityRoleProfiles(root, issuer, revocationSigner);
+    verifyExtensionProfiles(root, issuer, revocationSigner);
+    verifyTrustDomainProfiles(root, issuer, revocationSigner);
+    verifyValidityProfiles(root, issuer, revocationSigner);
+    verifyCertificateDigests(root, issuer, revocationSigner);
     authority.validate(material, INSTALLATION_ID, ISSUED_AT);
   }
 
@@ -175,8 +124,9 @@ class BuiltInCertificateAuthorityTest {
   void shouldRejectAuthorityMaterialWhenItBelongsToAnotherInstallation() {
     var authority = new BuiltInCertificateAuthority();
     var material = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var otherInstallation = UUID.randomUUID();
 
-    assertThatThrownBy(() -> authority.validate(material, UUID.randomUUID(), ISSUED_AT))
+    assertThatThrownBy(() -> authority.validate(material, otherInstallation, ISSUED_AT))
         .isInstanceOf(InstallationTrustException.class)
         .hasMessageContaining("different installation");
   }
@@ -199,11 +149,9 @@ class BuiltInCertificateAuthorityTest {
   void shouldRejectAuthorityMaterialWhenCertificatesHaveExpired() {
     var authority = new BuiltInCertificateAuthority();
     var material = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var expiredAt = ISSUED_AT.plus(Duration.ofDays(4_000));
 
-    assertThatThrownBy(
-            () ->
-                authority.validate(
-                    material, INSTALLATION_ID, ISSUED_AT.plus(Duration.ofDays(4_000))))
+    assertThatThrownBy(() -> authority.validate(material, INSTALLATION_ID, expiredAt))
         .isInstanceOf(InstallationTrustException.class)
         .hasMessageContaining("invalid")
         .hasCauseInstanceOf(CertificateExpiredException.class);
@@ -357,6 +305,93 @@ class BuiltInCertificateAuthorityTest {
     assertThatThrownBy(() -> authority.validate(malformed, INSTALLATION_ID, ISSUED_AT))
         .isInstanceOf(InstallationTrustException.class)
         .hasMessageContaining("invalid");
+  }
+
+  private static void verifyCertificateSignatures(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner)
+      throws Exception {
+    root.verify(root.getPublicKey());
+    issuer.verify(root.getPublicKey());
+    revocationSigner.verify(issuer.getPublicKey());
+  }
+
+  private static void verifyPrivateKeyProfiles(CertificateAuthorityMaterial material) {
+    assertThat(material.rootPrivateKey()).isInstanceOf(ECPrivateKey.class);
+    assertThat(material.issuerPrivateKey()).isInstanceOf(ECPrivateKey.class);
+    assertThat(material.revocationSignerPrivateKey()).isInstanceOf(ECPrivateKey.class);
+  }
+
+  private static void verifyPublicKeyProfiles(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner) {
+    assertThat((ECPublicKey) root.getPublicKey())
+        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
+        .isEqualTo(256);
+    assertThat((ECPublicKey) issuer.getPublicKey())
+        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
+        .isEqualTo(256);
+    assertThat((ECPublicKey) revocationSigner.getPublicKey())
+        .extracting(key -> key.getParams().getCurve().getField().getFieldSize())
+        .isEqualTo(256);
+  }
+
+  private static void verifyAuthorityRoleProfiles(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner) {
+    assertThat(root.getBasicConstraints()).isEqualTo(1);
+    assertThat(issuer.getBasicConstraints()).isZero();
+    assertThat(revocationSigner.getBasicConstraints()).isEqualTo(-1);
+    assertThat(root.getSubjectX500Principal().getName())
+        .isEqualTo("CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Root CA");
+    assertThat(issuer.getSubjectX500Principal().getName())
+        .isEqualTo("CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Issuing CA");
+    assertThat(revocationSigner.getSubjectX500Principal().getName())
+        .isEqualTo(
+            "CN=Streamarr Installation 7afbbbed-3492-4b71-909d-8acb50ffdcc2 Revocation Signer");
+    assertThat(root.getKeyUsage()).containsExactly(keyUsages(5, 6));
+    assertThat(issuer.getKeyUsage()).containsExactly(keyUsages(5, 6));
+    assertThat(revocationSigner.getKeyUsage()).containsExactly(keyUsages(0));
+  }
+
+  private static void verifyExtensionProfiles(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner) {
+    assertThat(root.getCriticalExtensionOIDs())
+        .contains(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
+    assertThat(issuer.getCriticalExtensionOIDs())
+        .contains(Extension.basicConstraints.getId(), Extension.keyUsage.getId());
+    assertThat(revocationSigner.getCriticalExtensionOIDs())
+        .contains(
+            Extension.basicConstraints.getId(),
+            Extension.keyUsage.getId(),
+            Extension.extendedKeyUsage.getId());
+  }
+
+  private static void verifyTrustDomainProfiles(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner)
+      throws Exception {
+    var trustDomain = URI.create("spiffe://" + INSTALLATION_ID);
+    assertThat(uriSubjectAlternativeNames(root)).containsExactly(trustDomain);
+    assertThat(uriSubjectAlternativeNames(issuer)).containsExactly(trustDomain);
+    assertThat(revocationSigner.getSubjectAlternativeNames()).isNull();
+    assertThat(root.getExtendedKeyUsage()).isNull();
+    assertThat(issuer.getExtendedKeyUsage()).isNull();
+    assertThat(revocationSigner.getExtendedKeyUsage())
+        .containsExactly(BuiltInCertificateAuthority.REVOCATION_SIGNING_EKU_OID);
+  }
+
+  private static void verifyValidityProfiles(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner) {
+    assertThat(root.getNotBefore().toInstant()).isBefore(ISSUED_AT);
+    assertThat(issuer.getNotBefore()).isEqualTo(root.getNotBefore());
+    assertThat(revocationSigner.getNotBefore()).isEqualTo(root.getNotBefore());
+    assertThat(issuer.getNotAfter()).isBeforeOrEqualTo(root.getNotAfter());
+    assertThat(revocationSigner.getNotAfter()).isBeforeOrEqualTo(issuer.getNotAfter());
+  }
+
+  private static void verifyCertificateDigests(
+      X509Certificate root, X509Certificate issuer, X509Certificate revocationSigner)
+      throws Exception {
+    assertThat(sha256(root.getEncoded())).hasSize(32);
+    assertThat(sha256(issuer.getEncoded())).hasSize(32);
+    assertThat(sha256(revocationSigner.getEncoded())).hasSize(32);
   }
 
   private static CertificateAuthorityMaterial withUnexpectedRootExtension(


### PR DESCRIPTION
## Summary

- Generate distinct P-256 root, issuing, and revocation-signing keys for one installation.
- Validate exact certificate roles, identities, extensions, SKI/AKI linkage, lifetimes, serials, and canonical SPIFFE trust domains.
- Keep the authority inert: this slice adds no bootstrap, persistence, listener, or distributed execution path.

## Validation

- Clean full reactor verification passes.
- Adversarial regressions cover malformed identities, key reuse, incorrect identifiers, profile extensions, serial collisions, overlong validity, and foreign installation material.

## Stack

- Builds on #234.
- Durable owner-only authority storage follows in the next slice.

Part of #76