### PR TITLE
Enforce installation trust storage boundaries

### DIFF
--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityPathResolver.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityPathResolver.java
@@ -1,0 +1,103 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+final class CertificateAuthorityPathResolver {
+
+  private static final int MAXIMUM_SYMBOLIC_LINKS = 40;
+
+  private final PosixOwnerValidator posixOwnerValidator;
+  private final MacOsExtendedAclValidator macOsAclValidator;
+
+  CertificateAuthorityPathResolver(
+      PosixOwnerValidator posixOwnerValidator, MacOsExtendedAclValidator macOsAclValidator) {
+    this.posixOwnerValidator = posixOwnerValidator;
+    this.macOsAclValidator = macOsAclValidator;
+  }
+
+  Path resolve(Path requestedSecretPath) {
+    if (requestedSecretPath == null) {
+      throw new CertificateAuthorityStoreException("Certificate authority secret path is required");
+    }
+    requireNoParentTraversal(requestedSecretPath);
+    var absolute = requestedSecretPath.toAbsolutePath().normalize();
+    var requestedParent = absolute.getParent();
+    if (absolute.getFileName() == null
+        || requestedParent == null
+        || requestedParent.getFileName() == null
+        || requestedParent.getParent() == null) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority secret path requires a dedicated parent and final filename");
+    }
+    var resolvedContainer = resolveDirectory(requestedParent.getParent(), new HashSet<>()).path();
+    return resolvedContainer.resolve(requestedParent.getFileName()).resolve(absolute.getFileName());
+  }
+
+  private ProtectedDirectory resolveDirectory(
+      Path requestedDirectory, Set<Path> resolvedSymbolicLinks) {
+    requireNoParentTraversal(requestedDirectory);
+    var absolute = requestedDirectory.toAbsolutePath().normalize();
+    var root = absolute.getRoot();
+    if (root == null) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority protected ancestors require an absolute filesystem root");
+    }
+    var resolved = inspectDirectory(root);
+    for (var component : root.relativize(absolute)) {
+      var entry = resolved.path().resolve(component);
+      if (!Files.exists(entry, LinkOption.NOFOLLOW_LINKS)) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority protected ancestor does not exist: " + entry);
+      }
+      if (resolved.sticky()) {
+        posixOwnerValidator.requireTrustedEntry(entry);
+      }
+      resolved = resolveEntry(entry, resolved.path(), resolvedSymbolicLinks);
+    }
+    return resolved;
+  }
+
+  private ProtectedDirectory resolveEntry(
+      Path entry, Path containingDirectory, Set<Path> resolvedSymbolicLinks) {
+    if (!Files.isSymbolicLink(entry)) {
+      return inspectDirectory(entry);
+    }
+    posixOwnerValidator.requireTrustedEntry(entry);
+    if (resolvedSymbolicLinks.size() >= MAXIMUM_SYMBOLIC_LINKS
+        || !resolvedSymbolicLinks.add(entry)) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority protected ancestor exceeds symbolic-link depth or cycle: "
+              + entry);
+    }
+    try {
+      var target = Files.readSymbolicLink(entry);
+      var resolvedTarget = target.isAbsolute() ? target : containingDirectory.resolve(target);
+      return resolveDirectory(resolvedTarget, resolvedSymbolicLinks);
+    } catch (IOException | SecurityException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to resolve certificate authority protected ancestor: " + entry, e);
+    }
+  }
+
+  private ProtectedDirectory inspectDirectory(Path directory) {
+    var sticky = posixOwnerValidator.requireProtectedDirectory(directory);
+    macOsAclValidator.requireNoAccessGrants(directory);
+    return new ProtectedDirectory(directory, sticky);
+  }
+
+  private static void requireNoParentTraversal(Path path) {
+    for (var component : path) {
+      if (component.toString().equals("..")) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority path must not contain parent traversal: " + path);
+      }
+    }
+  }
+
+  private record ProtectedDirectory(Path path, boolean sticky) {}
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStoreException.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStoreException.java
@@ -1,0 +1,12 @@
+package com.streamarr.server.services.streaming.trust;
+
+public final class CertificateAuthorityStoreException extends RuntimeException {
+
+  public CertificateAuthorityStoreException(String message) {
+    super(message);
+  }
+
+  public CertificateAuthorityStoreException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspector.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspector.java
@@ -77,9 +77,7 @@ final class MacOsAclCommandInspector {
     } catch (IOException e) {
       throw inspectionFailure(path, e);
     } catch (InterruptedException e) {
-      if (process != null) {
-        terminate(process);
-      }
+      terminate(process);
       Thread.currentThread().interrupt();
       throw inspectionFailure(path, e);
     } finally {

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspector.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspector.java
@@ -1,0 +1,193 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+final class MacOsAclCommandInspector {
+
+  private static final List<String> SYSTEM_COMMAND = List.of("/bin/ls", "-ldeb", "--");
+  private static final List<String> MODE_CHARACTERS =
+      List.of("r-", "w-", "xsS-", "r-", "w-", "xsS-", "r-", "w-", "xtT-");
+  private static final Set<PosixFilePermission> OWNER_ONLY_FILE_PERMISSIONS =
+      PosixFilePermissions.fromString("rw-------");
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+  private final List<String> commandPrefix;
+  private final Duration timeout;
+  private final CommandStarter commandStarter;
+
+  MacOsAclCommandInspector() {
+    this(SYSTEM_COMMAND, DEFAULT_TIMEOUT, MacOsAclCommandInspector::start);
+  }
+
+  MacOsAclCommandInspector(List<String> commandPrefix) {
+    this(commandPrefix, DEFAULT_TIMEOUT, MacOsAclCommandInspector::start);
+  }
+
+  MacOsAclCommandInspector(List<String> commandPrefix, Duration timeout) {
+    this(commandPrefix, timeout, MacOsAclCommandInspector::start);
+  }
+
+  MacOsAclCommandInspector(
+      List<String> commandPrefix, Duration timeout, CommandStarter commandStarter) {
+    this.commandPrefix = List.copyOf(commandPrefix);
+    this.timeout = timeout;
+    this.commandStarter = commandStarter;
+  }
+
+  boolean hasExtendedAcl(Path path) {
+    return inspect(path).extendedAcl();
+  }
+
+  boolean hasAccessGrant(Path path) {
+    return inspect(path).accessGrant();
+  }
+
+  private AclInspection inspect(Path path) {
+    Process process = null;
+    Path output = null;
+    try {
+      output =
+          Files.createTempFile(
+              ".streamarr-acl-",
+              ".txt",
+              PosixFilePermissions.asFileAttribute(OWNER_ONLY_FILE_PERMISSIONS));
+      var command = new ArrayList<>(commandPrefix);
+      command.add(path.toString());
+      process = commandStarter.start(List.copyOf(command), output);
+      if (!process.waitFor(timeout.toNanos(), TimeUnit.NANOSECONDS)) {
+        terminate(process);
+        throw inspectionFailure(path);
+      }
+      var exitCode = process.exitValue();
+      var lines = Files.readAllLines(output, StandardCharsets.UTF_8);
+      if (exitCode != 0 || lines.isEmpty() || !isMetadataLine(lines.getFirst())) {
+        throw inspectionFailure(path);
+      }
+      return classify(lines, path);
+    } catch (IOException e) {
+      throw inspectionFailure(path, e);
+    } catch (InterruptedException e) {
+      if (process != null) {
+        terminate(process);
+      }
+      Thread.currentThread().interrupt();
+      throw inspectionFailure(path, e);
+    } finally {
+      deleteOutput(output);
+    }
+  }
+
+  private AclInspection classify(List<String> lines, Path path) {
+    if (lines.size() == 1) {
+      var markedAsAcl = lines.getFirst().charAt(10) == '+';
+      return new AclInspection(markedAsAcl, markedAsAcl);
+    }
+    var accessGrant = false;
+    for (var index = 1; index < lines.size(); index++) {
+      accessGrant =
+          switch (aclEffect(lines.get(index))) {
+            case ALLOW -> true;
+            case DENY -> accessGrant;
+            case UNKNOWN -> throw inspectionFailure(path);
+          };
+    }
+    return new AclInspection(true, accessGrant);
+  }
+
+  private AclEffect aclEffect(String line) {
+    var entry = line.stripLeading();
+    var identitySeparator = entry.indexOf(": ");
+    if (identitySeparator <= 0 || !isUnsignedInteger(entry, identitySeparator)) {
+      return AclEffect.UNKNOWN;
+    }
+    var allow = entry.lastIndexOf(" allow ");
+    var deny = entry.lastIndexOf(" deny ");
+    var effect = Math.max(allow, deny);
+    if (effect <= identitySeparator + 2 || effect + " allow ".length() >= entry.length()) {
+      return AclEffect.UNKNOWN;
+    }
+    return allow > deny ? AclEffect.ALLOW : AclEffect.DENY;
+  }
+
+  private boolean isUnsignedInteger(String value, int endIndex) {
+    for (var index = 0; index < endIndex; index++) {
+      if (!Character.isDigit(value.charAt(index))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Process start(List<String> command, Path output) throws IOException {
+    var processBuilder =
+        new ProcessBuilder(command).redirectErrorStream(true).redirectOutput(output.toFile());
+    processBuilder.environment().clear();
+    processBuilder.environment().put("LC_ALL", "C");
+    return processBuilder.start();
+  }
+
+  private void terminate(Process process) {
+    process.destroyForcibly();
+  }
+
+  private void deleteOutput(Path output) {
+    if (output == null) {
+      return;
+    }
+    try {
+      Files.deleteIfExists(output);
+    } catch (IOException _) {
+      // Command metadata is owner-only and contains no trust material.
+    }
+  }
+
+  private boolean isMetadataLine(String line) {
+    if (line.length() < 12 || line.charAt(11) != ' ') {
+      return false;
+    }
+    var type = line.charAt(0);
+    if (type != '-' && type != 'd') {
+      return false;
+    }
+    for (var index = 1; index < 10; index++) {
+      if (MODE_CHARACTERS.get(index - 1).indexOf(line.charAt(index)) < 0) {
+        return false;
+      }
+    }
+    var marker = line.charAt(10);
+    return marker == ' ' || marker == '+' || marker == '@';
+  }
+
+  private CertificateAuthorityStoreException inspectionFailure(Path path) {
+    return new CertificateAuthorityStoreException(
+        "Failed to inspect extended ACLs on certificate authority path: " + path);
+  }
+
+  private CertificateAuthorityStoreException inspectionFailure(Path path, Exception cause) {
+    return new CertificateAuthorityStoreException(
+        "Failed to inspect extended ACLs on certificate authority path: " + path, cause);
+  }
+
+  @FunctionalInterface
+  interface CommandStarter {
+    Process start(List<String> command, Path output) throws IOException;
+  }
+
+  private record AclInspection(boolean extendedAcl, boolean accessGrant) {}
+
+  private enum AclEffect {
+    ALLOW,
+    DENY,
+    UNKNOWN
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/MacOsExtendedAclValidator.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/MacOsExtendedAclValidator.java
@@ -1,0 +1,56 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.nio.file.Path;
+
+final class MacOsExtendedAclValidator {
+
+  private final boolean macOs;
+  private final MacOsAclInspection inspector;
+  private final MacOsAclInspection accessGrantInspector;
+
+  MacOsExtendedAclValidator() {
+    this(System.getProperty("os.name", "").startsWith("Mac"), new MacOsAclCommandInspector());
+  }
+
+  private MacOsExtendedAclValidator(boolean macOs, MacOsAclCommandInspector inspector) {
+    this(macOs, inspector::hasExtendedAcl, inspector::hasAccessGrant);
+  }
+
+  MacOsExtendedAclValidator(boolean macOs, MacOsAclInspection inspector) {
+    this(macOs, inspector, inspector);
+  }
+
+  MacOsExtendedAclValidator(
+      boolean macOs, MacOsAclInspection inspector, MacOsAclInspection accessGrantInspector) {
+    this.macOs = macOs;
+    this.inspector = inspector;
+    this.accessGrantInspector = accessGrantInspector;
+  }
+
+  void requireAbsent(Path path) {
+    if (!macOs) {
+      return;
+    }
+
+    if (!inspector.inspect(path)) {
+      return;
+    }
+    throw new CertificateAuthorityStoreException(
+        "Certificate authority path must not have an extended ACL: " + path);
+  }
+
+  void requireNoAccessGrants(Path path) {
+    if (!macOs) {
+      return;
+    }
+    if (!accessGrantInspector.inspect(path)) {
+      return;
+    }
+    throw new CertificateAuthorityStoreException(
+        "Certificate authority protected ancestor must not grant access through an ACL: " + path);
+  }
+
+  interface MacOsAclInspection {
+    boolean inspect(Path path);
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/PosixOwnerValidator.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/PosixOwnerValidator.java
@@ -1,0 +1,169 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.List;
+
+final class PosixOwnerValidator {
+
+  private static final long ROOT_USER_ID = 0L;
+  private static final int GROUP_OR_OTHER_WRITE = 0022;
+  private static final int STICKY = 01000;
+
+  private final ProcessUserIdSource processUserIdSource;
+  private volatile long resolvedProcessUserId = -1L;
+
+  PosixOwnerValidator() {
+    this(PosixOwnerValidator::currentUserId);
+  }
+
+  PosixOwnerValidator(long processUserId) {
+    this(() -> processUserId);
+  }
+
+  PosixOwnerValidator(ProcessUserIdSource processUserIdSource) {
+    this.processUserIdSource = processUserIdSource;
+  }
+
+  void requireCurrentOwner(Path path) {
+    try {
+      var ownerUserId = userId(path);
+      if (ownerUserId != processUserId()) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority path must be owned by the current process user: " + path);
+      }
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (IOException
+        | UnsupportedOperationException
+        | IllegalArgumentException
+        | ClassCastException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to inspect certificate authority path ownership: " + path, e);
+    }
+  }
+
+  List<Path> requireProtectedAncestors(Path protectedEntry) {
+    var ancestors = new ArrayList<Path>();
+    var entry = protectedEntry;
+    var ancestor = entry.getParent();
+    while (ancestor != null) {
+      var sticky = requireProtectedDirectory(ancestor);
+      if (sticky && Files.exists(entry, LinkOption.NOFOLLOW_LINKS)) {
+        requireTrustedEntry(entry);
+      }
+      ancestors.add(ancestor);
+      entry = ancestor;
+      ancestor = entry.getParent();
+    }
+    return List.copyOf(ancestors);
+  }
+
+  boolean requireProtectedDirectory(Path directory) {
+    try {
+      if (!Files.isDirectory(directory, LinkOption.NOFOLLOW_LINKS)) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority protected ancestor must be a real directory: " + directory);
+      }
+      if (!isTrustedUser(userId(directory), processUserId())) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority protected ancestor must be owned by root or the current"
+                + " process user: "
+                + directory);
+      }
+      var mode = mode(directory);
+      var sticky = (mode & STICKY) != 0;
+      if ((mode & GROUP_OR_OTHER_WRITE) != 0 && !sticky) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority protected ancestor must not be group/other-writable without"
+                + " the sticky bit: "
+                + directory);
+      }
+      return sticky;
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (UnsupportedOperationException | IllegalArgumentException e) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority storage requires POSIX permissions for protected ancestors", e);
+    } catch (IOException | ClassCastException | SecurityException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to secure certificate authority parent directory through protected ancestors", e);
+    }
+  }
+
+  void requireTrustedEntry(Path entry) {
+    try {
+      if (!isTrustedUser(userId(entry), processUserId())) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority protected entry must be owned by root or the current process"
+                + " user: "
+                + entry);
+      }
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (IOException
+        | UnsupportedOperationException
+        | IllegalArgumentException
+        | ClassCastException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to inspect certificate authority protected entry: " + entry, e);
+    }
+  }
+
+  private static long currentUserId() {
+    Path probe = null;
+    try {
+      probe =
+          Files.createTempFile(
+              ".streamarr-owner-",
+              ".tmp",
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+      return userId(probe);
+    } catch (IOException
+        | UnsupportedOperationException
+        | IllegalArgumentException
+        | ClassCastException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to determine the current process user", e);
+    } finally {
+      if (probe != null) {
+        try {
+          Files.deleteIfExists(probe);
+        } catch (IOException _) {
+          // The empty owner probe contains no trust material or other application data.
+        }
+      }
+    }
+  }
+
+  private static long userId(Path path) throws IOException {
+    return ((Number) Files.getAttribute(path, "unix:uid", LinkOption.NOFOLLOW_LINKS)).longValue();
+  }
+
+  private static int mode(Path path) throws IOException {
+    return ((Number) Files.getAttribute(path, "unix:mode", LinkOption.NOFOLLOW_LINKS)).intValue();
+  }
+
+  private static boolean isTrustedUser(long userId, long processUserId) {
+    return userId == ROOT_USER_ID || userId == processUserId;
+  }
+
+  private long processUserId() {
+    var knownUserId = resolvedProcessUserId;
+    if (knownUserId >= 0L) {
+      return knownUserId;
+    }
+    var discoveredUserId = processUserIdSource.get();
+    resolvedProcessUserId = discoveredUserId;
+    return discoveredUserId;
+  }
+
+  @FunctionalInterface
+  interface ProcessUserIdSource {
+    long get();
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityPathResolverTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityPathResolverTest.java
@@ -22,7 +22,9 @@ class CertificateAuthorityPathResolverTest {
   @Test
   @DisplayName("Should reject missing secret path")
   void shouldRejectMissingSecretPath() {
-    assertThatThrownBy(() -> resolver().resolve(null))
+    var resolver = resolver();
+
+    assertThatThrownBy(() -> resolver.resolve(null))
         .isInstanceOf(CertificateAuthorityStoreException.class)
         .hasMessageContaining("path is required");
   }
@@ -31,7 +33,10 @@ class CertificateAuthorityPathResolverTest {
   @DisplayName("Should reject secret path directly below filesystem root")
   void shouldRejectSecretPathDirectlyBelowFilesystemRoot() throws Exception {
     try (var fileSystem = newFileSystem()) {
-      assertThatThrownBy(() -> resolver().resolve(fileSystem.getPath("/authority.p12")))
+      var resolver = resolver();
+      var requested = fileSystem.getPath("/authority.p12");
+
+      assertThatThrownBy(() -> resolver.resolve(requested))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("dedicated parent and final filename");
     }
@@ -43,8 +48,9 @@ class CertificateAuthorityPathResolverTest {
     try (var fileSystem = newFileSystem()) {
       Files.createDirectory(fileSystem.getPath("/actual"));
       var requested = fileSystem.getPath("/actual/../authority/authority.p12");
+      var resolver = resolver();
 
-      assertThatThrownBy(() -> resolver().resolve(requested))
+      assertThatThrownBy(() -> resolver.resolve(requested))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("parent traversal");
     }
@@ -62,8 +68,9 @@ class CertificateAuthorityPathResolverTest {
       Files.createSymbolicLink(base.resolve("alias"), fileSystem.getPath("real/link/.."));
 
       var requested = base.resolve("alias/authority/authority.p12");
+      var resolver = resolver();
 
-      assertThatThrownBy(() -> resolver().resolve(requested))
+      assertThatThrownBy(() -> resolver.resolve(requested))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("parent traversal");
     }
@@ -91,8 +98,10 @@ class CertificateAuthorityPathResolverTest {
     try (var fileSystem = newFileSystem()) {
       var loop = fileSystem.getPath("/loop");
       Files.createSymbolicLink(loop, loop);
+      var requested = loop.resolve("authority/authority.p12");
+      var resolver = resolver();
 
-      assertThatThrownBy(() -> resolver().resolve(loop.resolve("authority/authority.p12")))
+      assertThatThrownBy(() -> resolver.resolve(requested))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("symbolic-link depth or cycle");
     }
@@ -108,9 +117,10 @@ class CertificateAuthorityPathResolverTest {
         var next = index == 40 ? target : fileSystem.getPath("/link-" + (index + 1));
         Files.createSymbolicLink(link, next);
       }
+      var requested = fileSystem.getPath("/link-0/authority/authority.p12");
+      var resolver = resolver();
 
-      assertThatThrownBy(
-              () -> resolver().resolve(fileSystem.getPath("/link-0/authority/authority.p12")))
+      assertThatThrownBy(() -> resolver.resolve(requested))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("symbolic-link depth or cycle");
     }

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityPathResolverTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityPathResolverTest.java
@@ -1,0 +1,154 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+@DisplayName("Certificate Authority Path Resolver Tests")
+class CertificateAuthorityPathResolverTest {
+
+  @TempDir Path directory;
+
+  @Test
+  @DisplayName("Should reject missing secret path")
+  void shouldRejectMissingSecretPath() {
+    assertThatThrownBy(() -> resolver().resolve(null))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("path is required");
+  }
+
+  @Test
+  @DisplayName("Should reject secret path directly below filesystem root")
+  void shouldRejectSecretPathDirectlyBelowFilesystemRoot() throws Exception {
+    try (var fileSystem = newFileSystem()) {
+      assertThatThrownBy(() -> resolver().resolve(fileSystem.getPath("/authority.p12")))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("dedicated parent and final filename");
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject parent traversal in requested secret path")
+  void shouldRejectParentTraversalInRequestedSecretPath() throws Exception {
+    try (var fileSystem = newFileSystem()) {
+      Files.createDirectory(fileSystem.getPath("/actual"));
+      var requested = fileSystem.getPath("/actual/../authority/authority.p12");
+
+      assertThatThrownBy(() -> resolver().resolve(requested))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("parent traversal");
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject parent traversal in protected ancestor symbolic-link target")
+  void shouldRejectParentTraversalInProtectedAncestorSymbolicLinkTarget() throws Exception {
+    try (var fileSystem = newFileSystem()) {
+      var base = Files.createDirectory(fileSystem.getPath("/base"));
+      var real = Files.createDirectory(base.resolve("real"));
+      var target = Files.createDirectory(fileSystem.getPath("/target"));
+      Files.createDirectory(target.resolve("child"));
+      Files.createSymbolicLink(real.resolve("link"), target.resolve("child"));
+      Files.createSymbolicLink(base.resolve("alias"), fileSystem.getPath("real/link/.."));
+
+      var requested = base.resolve("alias/authority/authority.p12");
+
+      assertThatThrownBy(() -> resolver().resolve(requested))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("parent traversal");
+    }
+  }
+
+  @Test
+  @DisplayName("Should resolve absolute protected ancestor symbolic link")
+  void shouldResolveAbsoluteProtectedAncestorSymbolicLink() throws Exception {
+    try (var fileSystem = newFileSystem()) {
+      var actual =
+          Files.createDirectory(
+              fileSystem.getPath("/actual"),
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x")));
+      Files.createSymbolicLink(fileSystem.getPath("/alias"), actual);
+
+      var resolved = resolver().resolve(fileSystem.getPath("/alias/authority/authority.p12"));
+
+      assertThat(resolved).isEqualTo(actual.resolve("authority/authority.p12"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject protected ancestor symbolic-link cycle")
+  void shouldRejectProtectedAncestorSymbolicLinkCycle() throws Exception {
+    try (var fileSystem = newFileSystem()) {
+      var loop = fileSystem.getPath("/loop");
+      Files.createSymbolicLink(loop, loop);
+
+      assertThatThrownBy(() -> resolver().resolve(loop.resolve("authority/authority.p12")))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("symbolic-link depth or cycle");
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject excessive protected ancestor symbolic-link depth")
+  void shouldRejectExcessiveProtectedAncestorSymbolicLinkDepth() throws Exception {
+    try (var fileSystem = newFileSystem()) {
+      var target = Files.createDirectory(fileSystem.getPath("/target"));
+      for (var index = 40; index >= 0; index--) {
+        var link = fileSystem.getPath("/link-" + index);
+        var next = index == 40 ? target : fileSystem.getPath("/link-" + (index + 1));
+        Files.createSymbolicLink(link, next);
+      }
+
+      assertThatThrownBy(
+              () -> resolver().resolve(fileSystem.getPath("/link-0/authority/authority.p12")))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("symbolic-link depth or cycle");
+    }
+  }
+
+  @Test
+  @DisplayName("Should resolve trusted entry through sticky protected ancestor")
+  void shouldResolveTrustedEntryThroughStickyProtectedAncestor() throws Exception {
+    var sticky = Files.createDirectory(directory.resolve("sticky"));
+    var chmod = new ProcessBuilder("/bin/chmod", "1777", sticky.toString()).start();
+    assertThat(chmod.waitFor()).isZero();
+    var trusted =
+        Files.createDirectory(
+            sticky.resolve("trusted"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var resolver =
+        new CertificateAuthorityPathResolver(
+            new PosixOwnerValidator(), new MacOsExtendedAclValidator(false, _ -> false));
+
+    try {
+      var resolved = resolver.resolve(trusted.resolve("authority/authority.p12"));
+
+      assertThat(resolved).isEqualTo(trusted.toRealPath().resolve("authority/authority.p12"));
+    } finally {
+      Files.setPosixFilePermissions(sticky, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  private static CertificateAuthorityPathResolver resolver() {
+    return new CertificateAuthorityPathResolver(
+        new PosixOwnerValidator(1L), new MacOsExtendedAclValidator(false, _ -> false));
+  }
+
+  private static java.nio.file.FileSystem newFileSystem() {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    return Jimfs.newFileSystem(configuration);
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspectorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspectorTest.java
@@ -19,10 +19,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("UnitTest")
 @DisplayName("macOS ACL Command Inspector Tests")
@@ -32,12 +37,11 @@ class MacOsAclCommandInspectorTest {
 
   @TempDir Path directory;
 
-  @Test
-  @DisplayName("Should report no extended ACL when command emits one metadata line")
-  void shouldReportNoExtendedAclWhenCommandEmitsOneMetadataLine() {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("metadataWithoutExtendedAcl")
+  void shouldReportNoExtendedAclForMetadata(String metadata) {
     var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------  1 owner group 0 secret'"));
+        new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "printf '%s\\n' '" + metadata + "'"));
 
     assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
   }
@@ -58,16 +62,6 @@ class MacOsAclCommandInspectorTest {
   }
 
   @Test
-  @DisplayName("Should not confuse extended attributes with an extended ACL")
-  void shouldNotConfuseExtendedAttributesWithExtendedAcl() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------@ 1 owner group 0 secret'"));
-
-    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
-  }
-
-  @Test
   @DisplayName("Should report extended ACL when metadata has the ACL marker")
   void shouldReportExtendedAclWhenMetadataHasAclMarker() {
     var inspector =
@@ -75,16 +69,6 @@ class MacOsAclCommandInspectorTest {
             List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------+ 1 owner group 0 secret'"));
 
     assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isTrue();
-  }
-
-  @Test
-  @DisplayName("Should report no extended ACL for directory metadata")
-  void shouldReportNoExtendedAclForDirectoryMetadata() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' 'drwx------  1 owner group 0 authority'"));
-
-    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
   }
 
   @Test
@@ -190,92 +174,10 @@ class MacOsAclCommandInspectorTest {
     assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isTrue();
   }
 
-  @Test
-  @DisplayName("Should fail closed when ACL command exits unsuccessfully")
-  void shouldFailClosedWhenAclCommandExitsUnsuccessfully() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf 'inspection failed\\n'; exit 7"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when ACL command emits no metadata")
-  void shouldFailClosedWhenAclCommandEmitsNoMetadata() {
-    var inspector = new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "exit 0"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when ACL command emits unrecognized metadata")
-  void shouldFailClosedWhenAclCommandEmitsUnrecognizedMetadata() {
-    var inspector =
-        new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "printf 'unexpected output\\n'"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when ACL metadata is truncated")
-  void shouldFailClosedWhenAclMetadataIsTruncated() {
-    var inspector =
-        new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "printf '%s\\n' 'short'"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when ACL metadata has an unsupported file type")
-  void shouldFailClosedWhenAclMetadataHasUnsupportedFileType() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' 'lrw-------  1 owner group 0 secret'"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when ACL metadata has an invalid permission character")
-  void shouldFailClosedWhenAclMetadataHasInvalidPermissionCharacter() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw----?--  1 owner group 0 secret'"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when permission character is impossible at its mode position")
-  void shouldFailClosedWhenPermissionCharacterIsImpossibleAtItsModePosition() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' '-s--------  1 owner group 0 secret'"));
-
-    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
-        .isInstanceOf(CertificateAuthorityStoreException.class)
-        .hasMessageContaining("Failed to inspect extended ACLs");
-  }
-
-  @Test
-  @DisplayName("Should fail closed when ACL metadata has an invalid marker")
-  void shouldFailClosedWhenAclMetadataHasInvalidMarker() {
-    var inspector =
-        new MacOsAclCommandInspector(
-            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------? 1 owner group 0 secret'"));
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidAclCommandOutput")
+  void shouldFailClosedWhenAclCommandOutputIsInvalid(String script) {
+    var inspector = new MacOsAclCommandInspector(List.of("/bin/sh", "-c", script));
 
     assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
         .isInstanceOf(CertificateAuthorityStoreException.class)
@@ -301,7 +203,7 @@ class MacOsAclCommandInspectorTest {
 
   @Test
   @DisplayName("Should terminate ACL command and fail closed when inspection times out")
-  void shouldTerminateAclCommandAndFailClosedWhenInspectionTimesOut() throws Exception {
+  void shouldTerminateAclCommandAndFailClosedWhenInspectionTimesOut() {
     var starter = new CapturingCommandStarter();
     var inspector =
         new MacOsAclCommandInspector(
@@ -393,8 +295,7 @@ class MacOsAclCommandInspectorTest {
   @Test
   @DisplayName(
       "Should terminate ACL command and preserve interruption when inspection is interrupted")
-  void shouldTerminateAclCommandAndPreserveInterruptionWhenInspectionIsInterrupted()
-      throws Exception {
+  void shouldTerminateAclCommandAndPreserveInterruptionWhenInspectionIsInterrupted() {
     var starter = new CapturingCommandStarter();
     var inspector =
         new MacOsAclCommandInspector(
@@ -435,6 +336,54 @@ class MacOsAclCommandInspectorTest {
   private static long awaitProcessId(Path pidFile) {
     await().atMost(Duration.ofSeconds(2)).until(() -> readPublishedProcessId(pidFile) >= 0L);
     return readPublishedProcessId(pidFile);
+  }
+
+  private static Stream<Arguments> metadataWithoutExtendedAcl() {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "Should report no extended ACL when command emits one metadata line",
+                "-rw-------  1 owner group 0 secret")),
+        Arguments.of(
+            Named.of(
+                "Should not confuse extended attributes with an extended ACL",
+                "-rw-------@ 1 owner group 0 secret")),
+        Arguments.of(
+            Named.of(
+                "Should report no extended ACL for directory metadata",
+                "drwx------  1 owner group 0 authority")));
+  }
+
+  private static Stream<Arguments> invalidAclCommandOutput() {
+    return Stream.of(
+        Arguments.of(
+            Named.of(
+                "Should fail closed when ACL command exits unsuccessfully",
+                "printf 'inspection failed\\n'; exit 7")),
+        Arguments.of(Named.of("Should fail closed when ACL command emits no metadata", "exit 0")),
+        Arguments.of(
+            Named.of(
+                "Should fail closed when ACL command emits unrecognized metadata",
+                "printf 'unexpected output\\n'")),
+        Arguments.of(
+            Named.of(
+                "Should fail closed when ACL metadata is truncated", "printf '%s\\n' 'short'")),
+        Arguments.of(
+            Named.of(
+                "Should fail closed when ACL metadata has an unsupported file type",
+                "printf '%s\\n' 'lrw-------  1 owner group 0 secret'")),
+        Arguments.of(
+            Named.of(
+                "Should fail closed when ACL metadata has an invalid permission character",
+                "printf '%s\\n' '-rw----?--  1 owner group 0 secret'")),
+        Arguments.of(
+            Named.of(
+                "Should fail closed when permission character is impossible at its mode position",
+                "printf '%s\\n' '-s--------  1 owner group 0 secret'")),
+        Arguments.of(
+            Named.of(
+                "Should fail closed when ACL metadata has an invalid marker",
+                "printf '%s\\n' '-rw-------? 1 owner group 0 secret'")));
   }
 
   private static long readPublishedProcessId(Path pidFile) {
@@ -493,7 +442,9 @@ class MacOsAclCommandInspectorTest {
     }
 
     @Override
-    public void destroy() {}
+    public void destroy() {
+      // Intentionally remains alive to simulate a process that cannot be reaped.
+    }
 
     @Override
     public Process destroyForcibly() {

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspectorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/MacOsAclCommandInspectorTest.java
@@ -1,0 +1,547 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+@DisplayName("macOS ACL Command Inspector Tests")
+class MacOsAclCommandInspectorTest {
+
+  private static final Path SECRET_PATH = Path.of("/authority/authority.p12");
+
+  @TempDir Path directory;
+
+  @Test
+  @DisplayName("Should report no extended ACL when command emits one metadata line")
+  void shouldReportNoExtendedAclWhenCommandEmitsOneMetadataLine() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------  1 owner group 0 secret'"));
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should protect and delete redirected ACL command output")
+  void shouldProtectAndDeleteRedirectedAclCommandOutput() {
+    var starter = new CapturingCommandStarter();
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------  1 owner group 0 secret'"),
+            Duration.ofSeconds(1),
+            starter);
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
+    assertThat(starter.outputPermissions()).isEqualTo(PosixFilePermissions.fromString("rw-------"));
+    assertThat(starter.outputPath()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should not confuse extended attributes with an extended ACL")
+  void shouldNotConfuseExtendedAttributesWithExtendedAcl() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------@ 1 owner group 0 secret'"));
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should report extended ACL when metadata has the ACL marker")
+  void shouldReportExtendedAclWhenMetadataHasAclMarker() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------+ 1 owner group 0 secret'"));
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should report no extended ACL for directory metadata")
+  void shouldReportNoExtendedAclForDirectoryMetadata() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' 'drwx------  1 owner group 0 authority'"));
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should report extended ACL when command emits an ACL entry")
+  void shouldReportExtendedAclWhenCommandEmitsAclEntry() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------@ 1 owner group 0 secret'"
+                    + " ' 0: everyone allow read'"));
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should report no access grant when ACL entries only deny access")
+  void shouldReportNoAccessGrantWhenAclEntriesOnlyDenyAccess() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------+ 1 owner group 0 secret'"
+                    + " ' 0: everyone deny delete'"));
+
+    assertThat(inspector.hasAccessGrant(SECRET_PATH)).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should report access grant when an ACL entry allows access")
+  void shouldReportAccessGrantWhenAclEntryAllowsAccess() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------+ 1 owner group 0 secret'"
+                    + " ' 0: everyone allow read'"));
+
+    assertThat(inspector.hasAccessGrant(SECRET_PATH)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should fail closed when an ACL entry has unknown structure")
+  void shouldFailClosedWhenAclEntryHasUnknownStructure() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------+ 1 owner group 0 secret' 'unknown ACL entry'"));
+
+    assertThatThrownBy(() -> inspector.hasAccessGrant(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL entry index is not numeric")
+  void shouldFailClosedWhenAclEntryIndexIsNotNumeric() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------+ 1 owner group 0 secret'"
+                    + " ' x: everyone allow read'"));
+
+    assertThatThrownBy(() -> inspector.hasAccessGrant(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL entry has no permissions")
+  void shouldFailClosedWhenAclEntryHasNoPermissions() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------+ 1 owner group 0 secret' ' 0: everyone allow '"));
+
+    assertThatThrownBy(() -> inspector.hasAccessGrant(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should drain ACL command output while the command is running")
+  void shouldDrainAclCommandOutputWhileCommandIsRunning() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "printf '%s\\n' '-rw-------+ 1 owner group 0 secret'; "
+                    + "/usr/bin/yes ' 0: everyone allow read' | /usr/bin/head -n 5000"),
+            Duration.ofSeconds(2));
+
+    assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL command exits unsuccessfully")
+  void shouldFailClosedWhenAclCommandExitsUnsuccessfully() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf 'inspection failed\\n'; exit 7"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL command emits no metadata")
+  void shouldFailClosedWhenAclCommandEmitsNoMetadata() {
+    var inspector = new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "exit 0"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL command emits unrecognized metadata")
+  void shouldFailClosedWhenAclCommandEmitsUnrecognizedMetadata() {
+    var inspector =
+        new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "printf 'unexpected output\\n'"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL metadata is truncated")
+  void shouldFailClosedWhenAclMetadataIsTruncated() {
+    var inspector =
+        new MacOsAclCommandInspector(List.of("/bin/sh", "-c", "printf '%s\\n' 'short'"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL metadata has an unsupported file type")
+  void shouldFailClosedWhenAclMetadataHasUnsupportedFileType() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' 'lrw-------  1 owner group 0 secret'"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL metadata has an invalid permission character")
+  void shouldFailClosedWhenAclMetadataHasInvalidPermissionCharacter() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw----?--  1 owner group 0 secret'"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when permission character is impossible at its mode position")
+  void shouldFailClosedWhenPermissionCharacterIsImpossibleAtItsModePosition() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-s--------  1 owner group 0 secret'"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL metadata has an invalid marker")
+  void shouldFailClosedWhenAclMetadataHasInvalidMarker() {
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "printf '%s\\n' '-rw-------? 1 owner group 0 secret'"));
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+  }
+
+  @Test
+  @DisplayName("Should fail closed when ACL command cannot start")
+  void shouldFailClosedWhenAclCommandCannotStart() {
+    var starter = new CapturingCommandStarter();
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(directory.resolve("missing-acl-command").toString()),
+            Duration.ofSeconds(1),
+            starter);
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs")
+        .hasCauseInstanceOf(java.io.IOException.class);
+    assertThat(starter.outputPath()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should terminate ACL command and fail closed when inspection times out")
+  void shouldTerminateAclCommandAndFailClosedWhenInspectionTimesOut() throws Exception {
+    var starter = new CapturingCommandStarter();
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "exec /bin/sleep 30"), Duration.ofSeconds(1), starter);
+    var failure = new AtomicReference<Throwable>();
+    var inspection =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  try {
+                    inspector.hasExtendedAcl(SECRET_PATH);
+                  } catch (CertificateAuthorityStoreException thrown) {
+                    failure.set(thrown);
+                  }
+                });
+
+    Process command = null;
+    try {
+      command = starter.awaitProcess();
+      await().atMost(Duration.ofSeconds(2)).until(() -> !inspection.isAlive());
+      var startedCommand = command;
+      await().atMost(Duration.ofSeconds(2)).until(() -> !startedCommand.isAlive());
+
+      assertThat(failure.get())
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("Failed to inspect extended ACLs");
+      assertThat(starter.outputPath()).doesNotExist();
+    } finally {
+      inspection.interrupt();
+      if (command != null) {
+        command.destroyForcibly();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Should read metadata without waiting for descendant to close command output")
+  void shouldReadMetadataWithoutWaitingForDescendantToCloseCommandOutput() {
+    var childPidFile = directory.resolve("acl-command-child.pid");
+    var starter = new CapturingCommandStarter();
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of(
+                "/bin/sh",
+                "-c",
+                "/bin/sleep 10 & printf '%s' \"$!\" > \"$1\"; "
+                    + "printf '%s\\n' '-rw-------  1 owner group 0 secret'",
+                "streamarr-acl-test",
+                childPidFile.toString()),
+            Duration.ofSeconds(1),
+            starter);
+
+    ProcessHandle child = null;
+    try {
+      assertThat(inspector.hasExtendedAcl(SECRET_PATH)).isFalse();
+
+      child = ProcessHandle.of(awaitProcessId(childPidFile)).orElseThrow();
+      assertThat(child.isAlive()).isTrue();
+      assertThat(starter.outputPath()).doesNotExist();
+    } finally {
+      if (child != null) {
+        child.destroyForcibly();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Should fail promptly when timed-out ACL command cannot be reaped")
+  void shouldFailPromptlyWhenTimedOutAclCommandCannotBeReaped() {
+    var process = new DelayedExitProcess(Duration.ofSeconds(2));
+    var output = new AtomicReference<Path>();
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/ls", "--"),
+            Duration.ofMillis(10),
+            (_, outputPath) -> {
+              output.set(outputPath);
+              return process;
+            });
+
+    assertThatThrownBy(() -> inspector.hasExtendedAcl(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("Failed to inspect extended ACLs");
+
+    assertThat(process.hasExited()).isFalse();
+    assertThat(output.get()).doesNotExist();
+  }
+
+  @Test
+  @DisplayName(
+      "Should terminate ACL command and preserve interruption when inspection is interrupted")
+  void shouldTerminateAclCommandAndPreserveInterruptionWhenInspectionIsInterrupted()
+      throws Exception {
+    var starter = new CapturingCommandStarter();
+    var inspector =
+        new MacOsAclCommandInspector(
+            List.of("/bin/sh", "-c", "exec /bin/sleep 30"), Duration.ofSeconds(5), starter);
+    var failure = new AtomicReference<Throwable>();
+    var interrupted = new AtomicBoolean();
+    var inspection =
+        Thread.ofVirtual()
+            .start(
+                () -> {
+                  try {
+                    inspector.hasExtendedAcl(SECRET_PATH);
+                  } catch (CertificateAuthorityStoreException thrown) {
+                    failure.set(thrown);
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                  }
+                });
+
+    Process command = null;
+    try {
+      command = starter.awaitProcess();
+      inspection.interrupt();
+      await().atMost(Duration.ofSeconds(2)).until(() -> !inspection.isAlive());
+      var startedCommand = command;
+      await().atMost(Duration.ofSeconds(2)).until(() -> !startedCommand.isAlive());
+
+      assertThat(failure.get()).isInstanceOf(CertificateAuthorityStoreException.class);
+      assertThat(interrupted.get()).isTrue();
+      assertThat(starter.outputPath()).doesNotExist();
+    } finally {
+      inspection.interrupt();
+      if (command != null) {
+        command.destroyForcibly();
+      }
+    }
+  }
+
+  private static long awaitProcessId(Path pidFile) {
+    await().atMost(Duration.ofSeconds(2)).until(() -> readPublishedProcessId(pidFile) >= 0L);
+    return readPublishedProcessId(pidFile);
+  }
+
+  private static long readPublishedProcessId(Path pidFile) {
+    try {
+      var contents = Files.readString(pidFile).trim();
+      if (!contents.matches("[0-9]+")) {
+        return -1L;
+      }
+      return Long.parseLong(contents);
+    } catch (IOException | NumberFormatException _) {
+      return -1L;
+    }
+  }
+
+  private static final class DelayedExitProcess extends Process {
+
+    private final CompletableFuture<Process> exit = new CompletableFuture<>();
+
+    private DelayedExitProcess(Duration exitDelay) {
+      CompletableFuture.delayedExecutor(exitDelay.toMillis(), TimeUnit.MILLISECONDS)
+          .execute(() -> exit.complete(this));
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+
+    @Override
+    public int waitFor() {
+      exit.join();
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return false;
+    }
+
+    @Override
+    public int exitValue() {
+      if (!exit.isDone()) {
+        throw new IllegalThreadStateException();
+      }
+      return 0;
+    }
+
+    @Override
+    public void destroy() {}
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    @Override
+    public CompletableFuture<Process> onExit() {
+      return exit;
+    }
+
+    private boolean hasExited() {
+      return exit.isDone();
+    }
+  }
+
+  private static final class CapturingCommandStarter
+      implements MacOsAclCommandInspector.CommandStarter {
+
+    private final AtomicReference<Process> process = new AtomicReference<>();
+    private final AtomicReference<Path> output = new AtomicReference<>();
+    private final AtomicReference<Set<PosixFilePermission>> outputPermissions =
+        new AtomicReference<>();
+
+    @Override
+    public Process start(List<String> command, Path outputPath) throws IOException {
+      output.set(outputPath);
+      outputPermissions.set(Files.getPosixFilePermissions(outputPath));
+      var processBuilder =
+          new ProcessBuilder(command).redirectErrorStream(true).redirectOutput(outputPath.toFile());
+      processBuilder.environment().clear();
+      processBuilder.environment().put("LC_ALL", "C");
+      var started = processBuilder.start();
+      process.set(started);
+      return started;
+    }
+
+    private Process awaitProcess() {
+      await().atMost(Duration.ofSeconds(2)).until(() -> process.get() != null);
+      return process.get();
+    }
+
+    private Path outputPath() {
+      return output.get();
+    }
+
+    private Set<PosixFilePermission> outputPermissions() {
+      return outputPermissions.get();
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/MacOsExtendedAclValidatorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/MacOsExtendedAclValidatorTest.java
@@ -1,0 +1,93 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("macOS Extended ACL Validator Tests")
+class MacOsExtendedAclValidatorTest {
+
+  private static final Path SECRET_PATH = Path.of("/authority/authority.p12");
+
+  @Test
+  @DisplayName("Should avoid ACL inspection when operating system is not macOS")
+  void shouldAvoidAclInspectionWhenOperatingSystemIsNotMacOs() {
+    var validator =
+        new MacOsExtendedAclValidator(
+            false,
+            _ -> {
+              throw new AssertionError("macOS ACL inspection must remain lazy");
+            });
+
+    assertThatCode(() -> validator.requireAbsent(SECRET_PATH)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("Should accept authority path when macOS reports no extended ACL")
+  void shouldAcceptAuthorityPathWhenMacOsReportsNoExtendedAcl() {
+    var validator = new MacOsExtendedAclValidator(true, _ -> false);
+
+    assertThatCode(() -> validator.requireAbsent(SECRET_PATH)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("Should reject authority path when macOS reports an extended ACL")
+  void shouldRejectAuthorityPathWhenMacOsReportsExtendedAcl() {
+    var validator = new MacOsExtendedAclValidator(true, _ -> true);
+
+    assertThatThrownBy(() -> validator.requireAbsent(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("must not have an extended ACL");
+  }
+
+  @Test
+  @DisplayName("Should preserve a failed macOS ACL inspection")
+  void shouldPreserveFailedMacOsAclInspection() {
+    var failure = new CertificateAuthorityStoreException("ACL command failed");
+    var validator =
+        new MacOsExtendedAclValidator(
+            true,
+            _ -> {
+              throw failure;
+            });
+
+    assertThatThrownBy(() -> validator.requireAbsent(SECRET_PATH)).isSameAs(failure);
+  }
+
+  @Test
+  @DisplayName("Should accept ancestor when macOS ACL entries only deny access")
+  void shouldAcceptAncestorWhenMacOsAclEntriesOnlyDenyAccess() {
+    var validator = new MacOsExtendedAclValidator(true, _ -> true, _ -> false);
+
+    assertThatCode(() -> validator.requireNoAccessGrants(SECRET_PATH)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("Should reject ancestor when a macOS ACL entry grants access")
+  void shouldRejectAncestorWhenMacOsAclEntryGrantsAccess() {
+    var validator = new MacOsExtendedAclValidator(true, _ -> true, _ -> true);
+
+    assertThatThrownBy(() -> validator.requireNoAccessGrants(SECRET_PATH))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("must not grant access");
+  }
+
+  @Test
+  @DisplayName("Should avoid ancestor ACL inspection when operating system is not macOS")
+  void shouldAvoidAncestorAclInspectionWhenOperatingSystemIsNotMacOs() {
+    var validator =
+        new MacOsExtendedAclValidator(
+            false,
+            _ -> false,
+            _ -> {
+              throw new AssertionError("macOS ACL inspection must remain lazy");
+            });
+
+    assertThatCode(() -> validator.requireNoAccessGrants(SECRET_PATH)).doesNotThrowAnyException();
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/PosixOwnerValidatorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/PosixOwnerValidatorTest.java
@@ -1,0 +1,172 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("POSIX Owner Validator Tests")
+class PosixOwnerValidatorTest {
+
+  @Test
+  @DisplayName("Should reject path owned by another operating-system user")
+  void shouldRejectPathOwnedByAnotherOperatingSystemUser() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var path = Files.createFile(fileSystem.getPath("/secret"));
+      var validator = new PosixOwnerValidator(2L);
+
+      assertThatThrownBy(() -> validator.requireCurrentOwner(path))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("owned by the current process user");
+    }
+  }
+
+  @Test
+  @DisplayName("Should accept path owned by the current operating-system user")
+  void shouldAcceptPathOwnedByCurrentOperatingSystemUser() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var path = Files.createFile(fileSystem.getPath("/secret"));
+      var validator = new PosixOwnerValidator(1L);
+
+      assertThatCode(() -> validator.requireCurrentOwner(path)).doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  @DisplayName("Should fail closed when numeric POSIX ownership cannot be inspected")
+  void shouldFailClosedWhenNumericPosixOwnershipCannotBeInspected() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder().setAttributeViews("basic", "owner", "posix").build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var path = Files.createFile(fileSystem.getPath("/secret"));
+      var validator = new PosixOwnerValidator(1L);
+
+      assertThatThrownBy(() -> validator.requireCurrentOwner(path))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("Failed to inspect certificate authority path ownership");
+    }
+  }
+
+  @Test
+  @DisplayName("Should preserve storage failure when current process user cannot be determined")
+  void shouldPreserveStorageFailureWhenCurrentProcessUserCannotBeDetermined() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var path = Files.createFile(fileSystem.getPath("/secret"));
+      var failure =
+          new CertificateAuthorityStoreException("Failed to determine the current process user");
+      var validator =
+          new PosixOwnerValidator(
+              () -> {
+                throw failure;
+              });
+
+      assertThatThrownBy(() -> validator.requireCurrentOwner(path)).isSameAs(failure);
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject protected ancestor when shared writable mode has no sticky bit")
+  void shouldRejectProtectedAncestorWhenSharedWritableModeHasNoStickyBit() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var ancestor = Files.createDirectory(fileSystem.getPath("/unsafe"));
+      Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("rwxrwxrwx"));
+      var entry = Files.createDirectory(ancestor.resolve("authority"));
+      var validator = new PosixOwnerValidator(1L);
+
+      assertThatThrownBy(() -> validator.requireProtectedAncestors(entry))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("sticky bit");
+    }
+  }
+
+  @Test
+  @DisplayName("Should accept protected ancestors owned by root or current process user")
+  void shouldAcceptProtectedAncestorsOwnedByRootOrCurrentProcessUser() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var ancestor = Files.createDirectory(fileSystem.getPath("/safe"));
+      Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("rwxr-xr-x"));
+      var entry = Files.createDirectory(ancestor.resolve("authority"));
+      var validator = new PosixOwnerValidator(1L);
+
+      assertThatCode(() -> validator.requireProtectedAncestors(entry)).doesNotThrowAnyException();
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject symbolic link used as a protected directory")
+  void shouldRejectSymbolicLinkUsedAsProtectedDirectory() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var actual = Files.createDirectory(fileSystem.getPath("/actual"));
+      var alias = fileSystem.getPath("/alias");
+      Files.createSymbolicLink(alias, actual);
+      var validator = new PosixOwnerValidator(1L);
+
+      assertThatThrownBy(() -> validator.requireProtectedDirectory(alias))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("real directory");
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject protected entry owned by an untrusted operating-system user")
+  void shouldRejectProtectedEntryOwnedByUntrustedOperatingSystemUser() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var entry = Files.createDirectory(fileSystem.getPath("/entry"));
+      var validator = new PosixOwnerValidator(2L);
+
+      assertThatThrownBy(() -> validator.requireTrustedEntry(entry))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("protected entry must be owned");
+    }
+  }
+
+  @Test
+  @DisplayName("Should fail closed when protected entry numeric ownership cannot be inspected")
+  void shouldFailClosedWhenProtectedEntryNumericOwnershipCannotBeInspected() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder().setAttributeViews("basic", "owner", "posix").build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var entry = Files.createDirectory(fileSystem.getPath("/entry"));
+      var validator = new PosixOwnerValidator(1L);
+
+      assertThatThrownBy(() -> validator.requireTrustedEntry(entry))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("Failed to inspect certificate authority protected entry");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Resolve the configured authority path through a protected, symlink-free ancestor namespace.
- Require trusted numeric ownership and reject unsafe POSIX modes, untrusted sticky-directory entries, ambiguous parent traversal, and symbolic-link cycles.
- Inspect macOS ACLs with a fixed, bounded `/bin/ls` command whose output is owner-only and removed after use.
- Keep these primitives inert: no secret is persisted and no startup, enrollment, listener, or distributed playback path is enabled.

## Why

Durable installation trust material needs a filesystem boundary that fails closed across Linux and macOS without granting native access to the server JVM or adding a runtime dependency.

Part of #76. Stacked after #235.

## Validation

Developed test-first with explicit reproductions for unsafe ancestors, ownership changes, sticky-directory substitution, symlink cycles and traversal, malformed ACL output, command failure, timeout, interruption, and cleanup behavior.

- `./mvnw clean verify`
- Focused boundary suite with `--illegal-native-access=deny`
- Sonar findings refactored without removing behavioral scenarios
