### PR TITLE
Persist installation trust material

### DIFF
--- a/docs/adr/0018-direct-fenced-worker-control.adoc
+++ b/docs/adr/0018-direct-fenced-worker-control.adoc
@@ -8,7 +8,7 @@ Accepted
 
 * Streamarr still executes every transcode in the media-server process through `PlaybackTranscodeJobService`, the application-owned `TranscodeWorkerPort`, `LocalTranscodeWorkerAdapter`, and the extracted `LocalTranscodeEngine`.
 * The former rendition-at-a-time, process-shaped `TranscodeExecutor` and its process-handle state have been removed from the server application.
-* The server now contains inert trust-material primitives for the P-256 root, issuer, dedicated revocation signer, and exact certificate-profile validation. No certificate-authority storage or bootstrap, signing lease, enrolled remote worker, worker listener, registration path, or distributed playback route is enabled yet.
+* The server now contains inert trust-material primitives for the P-256 root, issuer, dedicated revocation signer, exact certificate-profile validation, and durable owner-only PKCS#12 storage. No certificate-authority bootstrap, signing lease, enrolled remote worker, worker listener, registration path, or distributed playback route is enabled yet.
 * The completed local extraction introduced the application boundary without introducing a remote transport.
 * The generated-only `streamarr-transcode-contract` module defines the versioned worker transport and compatibility gates. The narrow worker executable depends on it and the engine; the server still depends on neither the contract nor the worker.
 * The worker packages Boot's official gRPC server and shaded Netty, but its unenrolled configuration disables the server, reflection, health service, health scheduler, and all application executors. It exposes no control service until the trust and enrollment slice can enable one with valid credentials.
@@ -212,6 +212,22 @@ Every control-plane replica mounts that same secret, verifies it against the rec
 The private CA key is never stored in PostgreSQL, logged, exported through the API, reused for JWT signing, or copied to a worker.
 Backups of distributed configuration must include this secret; losing it requires explicitly re-enrolling workers under a new trust domain.
 Certificate issuance and issuer/root rotation use a PostgreSQL-backed singleton leadership lease so only one replica performs signing transitions at a time.
+
+The built-in authority is one PKCS#12 file containing fixed root, issuer, and revocation-signer aliases and their chains.
+Its empty PKCS#12 protection value is not presented as encryption: a POSIX owner-only directory and a regular file created as `0600` and thereafter required to retain only owner permission bits, both owned by the process's effective numeric user id, are the at-rest security boundary, avoiding a fixed or adjacent password that would add no independent protection.
+Before probing the final filename, storage resolves the full ancestor namespace component by component and operates on the resulting symlink-free path.
+Every ancestor directory must be owned by root or the effective user; a group/other-writable ancestor is accepted only with the sticky bit, and entries traversed through a sticky directory plus every symbolic-link entry must also have a trusted owner.
+Protected symbolic links are expanded with cycle and depth bounds, ambiguous parent-traversal components are rejected, and the dedicated parent and secret themselves must remain real, non-link entries.
+This deliberately rejects a `0770` fsGroup-writable volume above a secure child: deployers must mount or chown the dedicated trust directory directly, or make the shared ancestor sticky.
+macOS extended ACLs are rejected on the dedicated parent and secret; deny-only ancestor ACLs are accepted, while every allow entry or malformed ACL is rejected.
+Where the Java file provider exposes the POSIX mode but not effective ACL entries, a fixed `/bin/ls -ldeb` metadata command runs with a cleared environment and fails closed on ambiguous output or command failure.
+Its merged output is redirected to an owner-only temporary file and removed after parsing when the filesystem permits, avoiding a bounded-pipe stall without exposing trust material; a cleanup failure can leave only owner-readable path metadata.
+This avoids granting native access to the server's entire unnamed module and adds no permission or process to the local-only runtime; the one-shot command has a five-second bound and runs only while distributed trust storage is being inspected.
+Initial publication writes and forces a same-directory temporary inode, then atomically creates the final name as a no-clobber hard link; an existing final name is loaded and validated, never overwritten.
+A newly created secure container is forced through its ancestor before any secret is written; ordinary loads need only traverse that ancestor.
+Before publication, the prepared container is read back and its root SPIFFE trust domain must match the material's declared installation id.
+Every successful load forces the containing directory, so the creator, a publication-race loser, and a post-crash adopter all establish the final name's durability before returning; storage that cannot provide directory `fsync` fails closed.
+The following bootstrap slice will publish database state only after that file is durable, recover a crash between file and database commits by adopting the exact file, and fail closed when database state has a missing or mismatched file.
 
 The root, online issuing intermediate, and revocation signer use P-256 and `SHA256withECDSA`.
 All three use distinct keys, exact critical and non-critical extension sets, and validated SKI/AKI linkage from each child to its issuer.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -126,11 +126,12 @@ link:adr/0018-direct-fenced-worker-control.adoc[ADR 0018] accepts an optional di
 control plane, but the current implementation remains local-only and opens no worker listener.
 A narrow worker executable now packages the engine, protobuf contract, and shaded gRPC runtime;
 until enrollment lands, its server, reflection, health service, health scheduler, and all executors
-are disabled. The control plane now has inert P-256 installation trust-material generation and
-exact certificate-profile, identity, and key-separation validation. Durable secret storage,
-bootstrap, public persistence, and database-clock-fenced signing leadership land in following
-trust slices. The media-server artifact contains neither the worker nor its protobuf contract, so
-an ordinary local installation still gains no distributed transport runtime resource.
+are disabled. The control plane now has inert P-256 installation trust-material generation,
+exact certificate-profile, identity, and key-separation validation, and durable owner-only PKCS#12
+storage primitives. Application startup does not invoke those primitives yet; bootstrap,
+versioned public persistence, and database-clock-fenced signing leadership land in following trust
+slices. The media-server artifact contains neither the worker nor its protobuf contract, so an
+ordinary local installation still gains no distributed transport runtime resource.
 The extraction preserves the local path as the default:
 
 ----

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStore.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStore.java
@@ -1,0 +1,376 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public final class CertificateAuthorityStore {
+
+  private static final String ROOT_ALIAS = "streamarr-root";
+  private static final String ISSUER_ALIAS = "streamarr-issuer";
+  private static final String REVOCATION_SIGNER_ALIAS = "streamarr-revocation-signer";
+  private static final Set<String> REQUIRED_ALIASES =
+      Set.of(ROOT_ALIAS, ISSUER_ALIAS, REVOCATION_SIGNER_ALIAS);
+  private static final Set<PosixFilePermission> OWNER_FILE_PERMISSIONS =
+      PosixFilePermissions.fromString("rw-------");
+  private static final Set<PosixFilePermission> OWNER_DIRECTORY_PERMISSIONS =
+      PosixFilePermissions.fromString("rwx------");
+  private static final byte[] KEY_MATCH_CHALLENGE =
+      "streamarr-ca-key-pair-validation-v1".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+  private static final String INVALID_SPIFFE_IDENTITY =
+      "Certificate authority root has an invalid SPIFFE trust-domain identity";
+
+  private final Path secretPath;
+  private final MacOsExtendedAclValidator macOsAclValidator;
+  private final PosixOwnerValidator posixOwnerValidator;
+
+  public CertificateAuthorityStore(Path secretPath) {
+    this.macOsAclValidator = new MacOsExtendedAclValidator();
+    this.posixOwnerValidator = new PosixOwnerValidator();
+    this.secretPath =
+        new CertificateAuthorityPathResolver(posixOwnerValidator, macOsAclValidator)
+            .resolve(secretPath);
+  }
+
+  public Optional<CertificateAuthorityMaterial> load() {
+    requireProtectedAncestors();
+    if (!Files.exists(secretPath.getParent(), LinkOption.NOFOLLOW_LINKS)) {
+      return Optional.empty();
+    }
+    requireSecureParent();
+    if (!Files.exists(secretPath, LinkOption.NOFOLLOW_LINKS)) {
+      return Optional.empty();
+    }
+    requireSecureRegularFile();
+
+    try {
+      forceDirectory(secretPath.getParent());
+      try (var channel =
+              FileChannel.open(secretPath, StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+          var input = Channels.newInputStream(channel)) {
+        var keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(input, password());
+        requireExactAliases(keyStore);
+
+        var root = keyMaterial(keyStore, ROOT_ALIAS);
+        var issuer = keyMaterial(keyStore, ISSUER_ALIAS);
+        var revocationSigner = keyMaterial(keyStore, REVOCATION_SIGNER_ALIAS);
+        requireChain(keyStore, ROOT_ALIAS, root.certificate());
+        requireChain(keyStore, ISSUER_ALIAS, issuer.certificate(), root.certificate());
+        requireChain(
+            keyStore,
+            REVOCATION_SIGNER_ALIAS,
+            revocationSigner.certificate(),
+            issuer.certificate(),
+            root.certificate());
+        requireMatchingKey(root);
+        requireMatchingKey(issuer);
+        requireMatchingKey(revocationSigner);
+
+        return Optional.of(
+            new CertificateAuthorityMaterial(
+                installationId(root.certificate()),
+                new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                    root, issuer, revocationSigner)));
+      }
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (IOException
+        | GeneralSecurityException
+        | IllegalArgumentException
+        | ClassCastException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to read certificate authority secret at " + secretPath, e);
+    }
+  }
+
+  public CertificateAuthorityMaterial createIfAbsent(CertificateAuthorityMaterial material) {
+    if (material == null) {
+      throw new CertificateAuthorityStoreException("Certificate authority material is required");
+    }
+    var existing = load();
+    if (existing.isPresent()) {
+      return existing.orElseThrow();
+    }
+    requireSecureParent();
+    requireDurableParentEntry();
+
+    Path temporary = null;
+    try {
+      temporary = createTemporaryFile();
+      writeKeyStore(temporary, material);
+      requirePublicationMatches(temporary, material);
+      try {
+        Files.createLink(secretPath, temporary);
+      } catch (FileAlreadyExistsException _) {
+        Files.deleteIfExists(temporary);
+        return load()
+            .orElseThrow(
+                () ->
+                    new CertificateAuthorityStoreException(
+                        "Certificate authority publication raced without a readable winner"));
+      } catch (UnsupportedOperationException e) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority path must support atomic hard-link publication", e);
+      }
+      Files.delete(temporary);
+      return load()
+          .orElseThrow(
+              () ->
+                  new CertificateAuthorityStoreException(
+                      "Certificate authority publication did not create the secret"));
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (IOException | GeneralSecurityException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to persist certificate authority secret at " + secretPath, e);
+    } finally {
+      if (temporary != null) {
+        try {
+          Files.deleteIfExists(temporary);
+        } catch (IOException _) {
+          // A complete orphaned hard link is harmless and ignored on the next bootstrap.
+        }
+      }
+    }
+  }
+
+  private void writeKeyStore(Path path, CertificateAuthorityMaterial material)
+      throws GeneralSecurityException, IOException {
+    var keyStore = KeyStore.getInstance("PKCS12");
+    keyStore.load(null, password());
+    keyStore.setKeyEntry(
+        ROOT_ALIAS,
+        material.rootPrivateKey(),
+        password(),
+        new Certificate[] {material.rootCertificate()});
+    keyStore.setKeyEntry(
+        ISSUER_ALIAS,
+        material.issuerPrivateKey(),
+        password(),
+        new Certificate[] {material.issuerCertificate(), material.rootCertificate()});
+    keyStore.setKeyEntry(
+        REVOCATION_SIGNER_ALIAS,
+        material.revocationSignerPrivateKey(),
+        password(),
+        new Certificate[] {
+          material.revocationSignerCertificate(),
+          material.issuerCertificate(),
+          material.rootCertificate()
+        });
+
+    try (var channel =
+            FileChannel.open(path, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+        var output = Channels.newOutputStream(channel)) {
+      keyStore.store(output, password());
+      output.flush();
+      channel.force(true);
+    }
+  }
+
+  private void requirePublicationMatches(
+      Path temporary, CertificateAuthorityMaterial expectedMaterial) {
+    var prepared =
+        new CertificateAuthorityStore(temporary)
+            .load()
+            .orElseThrow(
+                () ->
+                    new CertificateAuthorityStoreException(
+                        "Prepared certificate authority secret is unreadable"));
+    if (!prepared.installationId().equals(expectedMaterial.installationId())) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority installation identity does not match its root certificate");
+    }
+  }
+
+  private CertificateAuthorityMaterial.AuthorityKeyMaterial keyMaterial(
+      KeyStore keyStore, String alias) throws GeneralSecurityException {
+    var key = keyStore.getKey(alias, password());
+    var certificate = keyStore.getCertificate(alias);
+    if (!(key instanceof PrivateKey privateKey)
+        || !(certificate instanceof X509Certificate x509Certificate)) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority alias has no private key and X.509 certificate: " + alias);
+    }
+    return new CertificateAuthorityMaterial.AuthorityKeyMaterial(privateKey, x509Certificate);
+  }
+
+  private void requireChain(KeyStore keyStore, String alias, X509Certificate... expected)
+      throws GeneralSecurityException {
+    var actual =
+        Optional.ofNullable(keyStore.getCertificateChain(alias)).orElse(new Certificate[0]);
+    if (actual.length != expected.length) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority alias has an invalid chain: " + alias);
+    }
+    for (int index = 0; index < expected.length; index++) {
+      if (!MessageDigest.isEqual(actual[index].getEncoded(), expected[index].getEncoded())) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority alias has an invalid chain: " + alias);
+      }
+    }
+  }
+
+  private void requireMatchingKey(CertificateAuthorityMaterial.AuthorityKeyMaterial keyMaterial)
+      throws GeneralSecurityException {
+    var signer = Signature.getInstance("SHA256withECDSA");
+    signer.initSign(keyMaterial.privateKey());
+    signer.update(KEY_MATCH_CHALLENGE);
+    var signature = signer.sign();
+
+    var verifier = Signature.getInstance("SHA256withECDSA");
+    verifier.initVerify(keyMaterial.certificate().getPublicKey());
+    verifier.update(KEY_MATCH_CHALLENGE);
+    if (!verifier.verify(signature)) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority contains a mismatched private key");
+    }
+  }
+
+  private UUID installationId(X509Certificate root) throws CertificateParsingException {
+    var names = Optional.ofNullable(root.getSubjectAlternativeNames()).orElse(List.of());
+    requireEqual(
+        names.size(), 1, "Certificate authority root has no exact SPIFFE trust-domain identity");
+    var name = names.iterator().next();
+    requireEqual(
+        name.getFirst(), 6, "Certificate authority root has no exact SPIFFE trust-domain identity");
+    if (!(name.get(1) instanceof String identity)) {
+      throw new CertificateAuthorityStoreException(INVALID_SPIFFE_IDENTITY);
+    }
+    var host = URI.create(identity).getHost();
+    if (host == null) {
+      throw new CertificateAuthorityStoreException(INVALID_SPIFFE_IDENTITY);
+    }
+    var installationId = UUID.fromString(host);
+    requireEqual(identity, "spiffe://" + installationId, INVALID_SPIFFE_IDENTITY);
+    return installationId;
+  }
+
+  private void requireEqual(Object actual, Object expected, String message) {
+    if (!Objects.deepEquals(actual, expected)) {
+      throw new CertificateAuthorityStoreException(message);
+    }
+  }
+
+  private void requireExactAliases(KeyStore keyStore) throws KeyStoreException {
+    var actual = new HashSet<String>();
+    var aliases = keyStore.aliases();
+    while (aliases.hasMoreElements()) {
+      actual.add(aliases.nextElement());
+    }
+    if (!actual.equals(REQUIRED_ALIASES)) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority secret must contain only the required aliases");
+    }
+  }
+
+  private void requireSecureParent() {
+    var parent = secretPath.getParent();
+    try {
+      if (!Files.exists(parent, LinkOption.NOFOLLOW_LINKS)) {
+        try {
+          Files.createDirectory(
+              parent, PosixFilePermissions.asFileAttribute(OWNER_DIRECTORY_PERMISSIONS));
+        } catch (FileAlreadyExistsException _) {
+          // A concurrent replica created it; the checks below still validate the winner.
+        }
+      }
+      if (!Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority parent must be a real directory");
+      }
+      requireOwnerOnly(parent, "Certificate authority parent must be owner-only");
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (IOException | UnsupportedOperationException | SecurityException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to secure certificate authority parent directory", e);
+    }
+  }
+
+  private void requireProtectedAncestors() {
+    var ancestors = posixOwnerValidator.requireProtectedAncestors(secretPath.getParent());
+    for (var ancestor : ancestors) {
+      macOsAclValidator.requireNoAccessGrants(ancestor);
+    }
+  }
+
+  private void requireDurableParentEntry() {
+    var parent = secretPath.getParent();
+    try {
+      forceDirectory(Optional.ofNullable(parent.getParent()).orElse(parent));
+    } catch (IOException e) {
+      throw new CertificateAuthorityStoreException(
+          "Failed to persist certificate authority parent directory", e);
+    }
+  }
+
+  private void requireSecureRegularFile() {
+    if (!Files.isRegularFile(secretPath, LinkOption.NOFOLLOW_LINKS)) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority secret must be a regular file");
+    }
+    requireOwnerOnly(secretPath, "Certificate authority secret must be owner-only");
+  }
+
+  private void requireOwnerOnly(Path path, String message) {
+    try {
+      if (!Files.getFileStore(path).supportsFileAttributeView("posix")) {
+        throw new CertificateAuthorityStoreException(
+            "Certificate authority storage requires POSIX permissions");
+      }
+      posixOwnerValidator.requireCurrentOwner(path);
+      var permissions = Files.getPosixFilePermissions(path, LinkOption.NOFOLLOW_LINKS);
+      if (permissions.stream().anyMatch(permission -> !permission.name().startsWith("OWNER_"))) {
+        throw new CertificateAuthorityStoreException(message);
+      }
+      macOsAclValidator.requireAbsent(path);
+    } catch (CertificateAuthorityStoreException e) {
+      throw e;
+    } catch (IOException | UnsupportedOperationException | SecurityException e) {
+      throw new CertificateAuthorityStoreException("Failed to inspect secret permissions", e);
+    }
+  }
+
+  private Path createTemporaryFile() throws IOException {
+    var parent = secretPath.getParent();
+    return Files.createTempFile(
+        parent,
+        ".streamarr-authority-",
+        ".tmp",
+        PosixFilePermissions.asFileAttribute(OWNER_FILE_PERMISSIONS));
+  }
+
+  private void forceDirectory(Path path) throws IOException {
+    try (var directory = FileChannel.open(path, StandardOpenOption.READ)) {
+      directory.force(true);
+    }
+  }
+
+  private static char[] password() {
+    return new char[0];
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStore.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStore.java
@@ -123,18 +123,12 @@ public final class CertificateAuthorityStore {
       temporary = createTemporaryFile();
       writeKeyStore(temporary, material);
       requirePublicationMatches(temporary, material);
-      try {
-        Files.createLink(secretPath, temporary);
-      } catch (FileAlreadyExistsException _) {
-        Files.deleteIfExists(temporary);
+      if (!publish(temporary)) {
         return load()
             .orElseThrow(
                 () ->
                     new CertificateAuthorityStoreException(
                         "Certificate authority publication raced without a readable winner"));
-      } catch (UnsupportedOperationException e) {
-        throw new CertificateAuthorityStoreException(
-            "Certificate authority path must support atomic hard-link publication", e);
       }
       Files.delete(temporary);
       return load()
@@ -155,6 +149,19 @@ public final class CertificateAuthorityStore {
           // A complete orphaned hard link is harmless and ignored on the next bootstrap.
         }
       }
+    }
+  }
+
+  private boolean publish(Path temporary) throws IOException {
+    try {
+      Files.createLink(secretPath, temporary);
+      return true;
+    } catch (FileAlreadyExistsException _) {
+      Files.deleteIfExists(temporary);
+      return false;
+    } catch (UnsupportedOperationException e) {
+      throw new CertificateAuthorityStoreException(
+          "Certificate authority path must support atomic hard-link publication", e);
     }
   }
 
@@ -290,14 +297,7 @@ public final class CertificateAuthorityStore {
   private void requireSecureParent() {
     var parent = secretPath.getParent();
     try {
-      if (!Files.exists(parent, LinkOption.NOFOLLOW_LINKS)) {
-        try {
-          Files.createDirectory(
-              parent, PosixFilePermissions.asFileAttribute(OWNER_DIRECTORY_PERMISSIONS));
-        } catch (FileAlreadyExistsException _) {
-          // A concurrent replica created it; the checks below still validate the winner.
-        }
-      }
+      createParentIfMissing(parent);
       if (!Files.isDirectory(parent, LinkOption.NOFOLLOW_LINKS)) {
         throw new CertificateAuthorityStoreException(
             "Certificate authority parent must be a real directory");
@@ -308,6 +308,18 @@ public final class CertificateAuthorityStore {
     } catch (IOException | UnsupportedOperationException | SecurityException e) {
       throw new CertificateAuthorityStoreException(
           "Failed to secure certificate authority parent directory", e);
+    }
+  }
+
+  private void createParentIfMissing(Path parent) throws IOException {
+    if (Files.exists(parent, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    try {
+      Files.createDirectory(
+          parent, PosixFilePermissions.asFileAttribute(OWNER_DIRECTORY_PERMISSIONS));
+    } catch (FileAlreadyExistsException _) {
+      // A concurrent replica created it; the checks below still validate the winner.
     }
   }
 

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStoreTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStoreTest.java
@@ -1,0 +1,895 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.function.IntFunction;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+@DisplayName("Certificate Authority Store Tests")
+class CertificateAuthorityStoreTest {
+
+  private static final Instant ISSUED_AT = Instant.parse("2026-07-12T12:00:00Z");
+  private static final UUID INSTALLATION_ID =
+      UUID.fromString("72ddb685-348a-4563-adf1-f7806df828cb");
+
+  @TempDir Path directory;
+
+  private Path secretPath;
+
+  @BeforeEach
+  void secureDirectory() throws Exception {
+    secretPath = directory.resolve("authority.p12");
+    if (Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject storage path without a dedicated parent and final filename")
+  void shouldRejectStoragePathWithoutDedicatedParentAndFinalFilename() {
+    assertThatThrownBy(() -> new CertificateAuthorityStore(Path.of("/")))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("dedicated parent and final filename");
+  }
+
+  @Test
+  @DisplayName("Should reject missing authority material before creating storage")
+  void shouldRejectMissingAuthorityMaterialBeforeCreatingStorage() throws Exception {
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(() -> store.createIfAbsent(null))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("material is required");
+    try (var files = Files.list(directory)) {
+      assertThat(files).isEmpty();
+    }
+  }
+
+  @Test
+  @DisplayName("Should atomically round trip owner-only authority when file is created and loaded")
+  void shouldAtomicallyRoundTripOwnerOnlyAuthorityWhenFileIsCreatedAndLoaded() throws Exception {
+    var expected = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+
+    var created = store.createIfAbsent(expected);
+    var retained = store.createIfAbsent(expected);
+    var loaded = store.load().orElseThrow();
+
+    assertMaterialEquals(created, expected);
+    assertMaterialEquals(retained, expected);
+    assertMaterialEquals(loaded, expected);
+    assertThat(created.toString()).doesNotContain("EC Private Key", "privateValue", "S:");
+    assertThat(
+            new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                    new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                        expected.rootPrivateKey(), expected.rootCertificate()),
+                    new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                        expected.issuerPrivateKey(), expected.issuerCertificate()),
+                    new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                        expected.revocationSignerPrivateKey(),
+                        expected.revocationSignerCertificate()))
+                .toString())
+        .isEqualTo("AuthorityChainMaterial[privateKeys=REDACTED]");
+    assertThat(
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    expected.rootPrivateKey(), expected.rootCertificate())
+                .toString())
+        .isEqualTo("AuthorityKeyMaterial[privateKey=REDACTED]");
+    if (Files.getFileStore(secretPath).supportsFileAttributeView("posix")) {
+      assertThat(Files.getPosixFilePermissions(secretPath))
+          .isEqualTo(PosixFilePermissions.fromString("rw-------"));
+    }
+    try (var files = Files.list(directory)) {
+      assertThat(files.map(Path::getFileName).map(Path::toString).toList())
+          .containsExactly("authority.p12");
+    }
+  }
+
+  @Test
+  @DisplayName("Should preserve the first complete authority when creation races")
+  void shouldPreserveFirstCompleteAuthorityWhenCreationRaces() throws Exception {
+    var first = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var second =
+        new BuiltInCertificateAuthority()
+            .create(UUID.fromString("c81e09c3-15fc-4f72-bcd6-883f31f6fc96"), ISSUED_AT);
+    var retained = createConcurrently(secretPath, 8, index -> index % 2 == 0 ? first : second);
+
+    var winner = new CertificateAuthorityStore(secretPath).load().orElseThrow();
+
+    assertThat(retained).hasSize(8);
+    retained.forEach(material -> assertMaterialEquals(material, winner));
+  }
+
+  @Test
+  @DisplayName("Should converge when dedicated parent creation races")
+  void shouldConvergeWhenDedicatedParentCreationRaces() throws Exception {
+    var missingParent = directory.resolve("authority");
+    var sharedSecret = missingParent.resolve("authority.p12");
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var retained = createConcurrently(sharedSecret, 32, _ -> material);
+
+    var winner = new CertificateAuthorityStore(sharedSecret).load().orElseThrow();
+
+    assertThat(retained).hasSize(32);
+    retained.forEach(result -> assertMaterialEquals(result, winner));
+  }
+
+  @Test
+  @DisplayName("Should reject authority file when path is a symbolic link")
+  void shouldRejectAuthorityFileWhenPathIsSymbolicLink() throws Exception {
+    var other = directory.resolve("other.p12");
+    Files.write(other, new byte[] {1, 2, 3});
+    Files.createSymbolicLink(secretPath, other.getFileName());
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("regular file");
+  }
+
+  @Test
+  @DisplayName("Should reject authority file when readable by another user")
+  void shouldRejectAuthorityFileWhenReadableByAnotherUser() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    Files.setPosixFilePermissions(secretPath, PosixFilePermissions.fromString("rw-r--r--"));
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("owner-only");
+  }
+
+  @Test
+  @DisplayName("Should reject authority when parent directory is accessible by another user")
+  void shouldRejectAuthorityWhenParentDirectoryIsAccessibleByAnotherUser() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwxr-xr-x"));
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("parent must be owner-only");
+  }
+
+  @Test
+  @DisplayName("Should reject authority parent entry exposed through writable ancestor")
+  void shouldRejectAuthorityParentEntryExposedThroughWritableAncestor() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwxrwxrwx"));
+    var parent =
+        Files.createDirectory(
+            directory.resolve("authority"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+    try {
+      assertThatThrownBy(
+              () ->
+                  new CertificateAuthorityStore(parent.resolve("authority.p12"))
+                      .createIfAbsent(material))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("protected ancestor");
+    } finally {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should accept authority parent entry protected by sticky writable ancestor")
+  void shouldAcceptAuthorityParentEntryProtectedByStickyWritableAncestor() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwxrwxrwx"));
+    runCommand(List.of("/bin/chmod", "+t", directory.toString()));
+    var parent =
+        Files.createDirectory(
+            directory.resolve("authority"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+    try {
+      var retained =
+          new CertificateAuthorityStore(parent.resolve("authority.p12")).createIfAbsent(material);
+
+      assertMaterialEquals(retained, material);
+    } finally {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject load after protected ancestor becomes non-sticky writable")
+  void shouldRejectLoadAfterProtectedAncestorBecomesNonStickyWritable() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    var parent =
+        Files.createDirectory(
+            directory.resolve("authority"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var store = new CertificateAuthorityStore(parent.resolve("authority.p12"));
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    store.createIfAbsent(material);
+    Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwxrwxrwx"));
+
+    try {
+      assertThatThrownBy(store::load)
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("protected ancestor");
+    } finally {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should resolve protected ancestor symbolic link before storing authority")
+  void shouldResolveProtectedAncestorSymbolicLinkBeforeStoringAuthority() throws Exception {
+    var actual =
+        Files.createDirectory(
+            directory.resolve("actual"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var alias = directory.resolve("alias");
+    Files.createSymbolicLink(alias, actual.getFileName());
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+    new CertificateAuthorityStore(alias.resolve("authority").resolve("authority.p12"))
+        .createIfAbsent(material);
+
+    assertThat(actual.resolve("authority").resolve("authority.p12")).isRegularFile();
+  }
+
+  @Test
+  @EnabledOnOs(OS.MAC)
+  @DisplayName("Should reject authority when secure parent has a macOS extended ACL")
+  void shouldRejectAuthorityWhenSecureParentHasMacOsExtendedAcl() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+
+    assertRejectsMacOsExtendedAcl(directory, "everyone allow search", store);
+  }
+
+  @Test
+  @EnabledOnOs(OS.MAC)
+  @DisplayName("Should reject authority when secret has a macOS extended ACL")
+  void shouldRejectAuthorityWhenSecretHasMacOsExtendedAcl() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+
+    assertRejectsMacOsExtendedAcl(secretPath, "everyone allow read", store);
+  }
+
+  @Test
+  @EnabledOnOs(OS.MAC)
+  @DisplayName("Should accept authority below macOS ancestor with deny-only ACL")
+  void shouldAcceptAuthorityBelowMacOsAncestorWithDenyOnlyAcl() throws Exception {
+    var ancestor =
+        Files.createDirectory(
+            directory.resolve("ancestor"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    runCommand(List.of("/bin/chmod", "+a", "everyone deny delete", ancestor.toString()));
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+    try {
+      var retained =
+          new CertificateAuthorityStore(ancestor.resolve("authority").resolve("authority.p12"))
+              .createIfAbsent(material);
+
+      assertMaterialEquals(retained, material);
+    } finally {
+      runCommand(List.of("/bin/chmod", "-N", ancestor.toString()));
+    }
+  }
+
+  @Test
+  @EnabledOnOs(OS.MAC)
+  @DisplayName("Should reject authority below macOS ancestor with allow ACL")
+  void shouldRejectAuthorityBelowMacOsAncestorWithAllowAcl() throws Exception {
+    var ancestor =
+        Files.createDirectory(
+            directory.resolve("ancestor"),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    runCommand(List.of("/bin/chmod", "+a", "everyone allow read", ancestor.toString()));
+
+    try {
+      assertThatThrownBy(
+              () ->
+                  new CertificateAuthorityStore(
+                      ancestor.resolve("authority").resolve("authority.p12")))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("must not grant access");
+    } finally {
+      runCommand(List.of("/bin/chmod", "-N", ancestor.toString()));
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject storage when POSIX permissions cannot be enforced")
+  void shouldRejectStorageWhenPosixPermissionsCannotBeEnforced() throws Exception {
+    try (var fileSystem = Jimfs.newFileSystem(Configuration.windows())) {
+      var parent = fileSystem.getPath("C:\\authority");
+      Files.createDirectory(parent);
+      var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+      assertThatThrownBy(
+              () ->
+                  new CertificateAuthorityStore(parent.resolve("authority.p12"))
+                      .createIfAbsent(material))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("requires POSIX permissions");
+    }
+  }
+
+  @Test
+  @DisplayName("Should fail with storage exception when missing parent cannot enforce POSIX mode")
+  void shouldFailWithStorageExceptionWhenMissingParentCannotEnforcePosixMode() throws Exception {
+    try (var fileSystem = Jimfs.newFileSystem(Configuration.windows())) {
+      var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+      assertThatThrownBy(
+              () ->
+                  new CertificateAuthorityStore(
+                          fileSystem.getPath("C:\\authority").resolve("authority.p12"))
+                      .createIfAbsent(material))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("requires POSIX permissions");
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject authority hierarchy owned by another operating-system user")
+  void shouldRejectAuthorityHierarchyOwnedByAnotherOperatingSystemUser() throws Exception {
+    var configuration =
+        Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "owner", "posix", "unix")
+            .build();
+    try (var fileSystem = Jimfs.newFileSystem(configuration)) {
+      var parent =
+          Files.createDirectory(
+              fileSystem.getPath("/authority"),
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+      var secret =
+          Files.createFile(
+              parent.resolve("authority.p12"),
+              PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+      var foreignOwner =
+          fileSystem.getUserPrincipalLookupService().lookupPrincipalByName("foreign-owner");
+      Files.setOwner(parent, foreignOwner);
+      Files.setOwner(secret, foreignOwner);
+
+      assertThatThrownBy(() -> new CertificateAuthorityStore(secret).load())
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("owned by root or the current process user");
+    }
+  }
+
+  @Test
+  @DisplayName("Should create dedicated parent with owner-only permissions when missing")
+  void shouldCreateDedicatedParentWithOwnerOnlyPermissionsWhenMissing() throws Exception {
+    var parent = directory.resolve("authority");
+    var nestedSecret = parent.resolve("authority.p12");
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+    new CertificateAuthorityStore(nestedSecret).createIfAbsent(material);
+
+    assertThat(nestedSecret).isRegularFile();
+    if (Files.getFileStore(parent).supportsFileAttributeView("posix")) {
+      assertThat(Files.getPosixFilePermissions(parent))
+          .isEqualTo(PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should report no authority without creating a missing dedicated parent on load")
+  void shouldReportNoAuthorityWithoutCreatingMissingDedicatedParentOnLoad() {
+    var parent = directory.resolve("authority");
+    var store = new CertificateAuthorityStore(parent.resolve("authority.p12"));
+
+    assertThat(store.load()).isEmpty();
+    assertThat(parent).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should load authority when secure container ancestor is traverse-only")
+  void shouldLoadAuthorityWhenSecureContainerAncestorIsTraverseOnly() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    var ancestor = directory.resolve("ancestor");
+    var parent = ancestor.resolve("authority");
+    Files.createDirectory(
+        ancestor,
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    Files.createDirectory(
+        parent, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var path = parent.resolve("authority.p12");
+    var expected = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(path);
+    store.createIfAbsent(expected);
+    Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("--x------"));
+
+    try {
+      assertThat(Files.readAllBytes(path)).isNotEmpty();
+      assertMaterialEquals(store.load().orElseThrow(), expected);
+    } finally {
+      Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should fail closed when secure container entry cannot be made durable")
+  void shouldFailClosedWhenSecureContainerEntryCannotBeMadeDurable() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    var ancestor = directory.resolve("ancestor");
+    var parent = ancestor.resolve("authority");
+    Files.createDirectory(
+        ancestor,
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    Files.createDirectory(
+        parent, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var path = parent.resolve("authority.p12");
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(path);
+    Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("--x------"));
+
+    try {
+      assertThatThrownBy(() -> store.createIfAbsent(material))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("persist certificate authority parent");
+      assertThat(path).doesNotExist();
+    } finally {
+      Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should fail closed when the dedicated parent's ancestor is missing")
+  void shouldFailClosedWhenDedicatedParentAncestorIsMissing() {
+    var nestedSecret = directory.resolve("missing").resolve("authority").resolve("authority.p12");
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+
+    assertThatThrownBy(() -> new CertificateAuthorityStore(nestedSecret).createIfAbsent(material))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("protected ancestor does not exist");
+  }
+
+  @Test
+  @DisplayName("Should reject dedicated parent when it is a symbolic link")
+  void shouldRejectDedicatedParentWhenItIsSymbolicLink() throws Exception {
+    var actualParent = directory.resolve("actual");
+    Files.createDirectory(
+        actualParent,
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var linkedParent = directory.resolve("linked");
+    Files.createSymbolicLink(linkedParent, actualParent.getFileName());
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(linkedParent.resolve("authority.p12"));
+
+    assertThatThrownBy(() -> store.createIfAbsent(material))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("real directory");
+  }
+
+  @Test
+  @DisplayName("Should reject symbolic parent before probing a missing final secret")
+  void shouldRejectSymbolicParentBeforeProbingMissingFinalSecret() throws Exception {
+    var actualParent = directory.resolve("actual");
+    Files.createDirectory(
+        actualParent,
+        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+    var linkedParent = directory.resolve("linked");
+    Files.createSymbolicLink(linkedParent, actualParent.getFileName());
+    var store = new CertificateAuthorityStore(linkedParent.resolve("authority.p12"));
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("real directory");
+  }
+
+  @Test
+  @DisplayName("Should reject authority container when unexpected entry exists")
+  void shouldRejectAuthorityContainerWhenUnexpectedEntryExists() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    var keyStore = loadKeyStore();
+    keyStore.setCertificateEntry("unexpected", material.rootCertificate());
+    writeKeyStore(keyStore);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("required aliases");
+  }
+
+  @Test
+  @DisplayName("Should reject authority alias when private key is missing")
+  void shouldRejectAuthorityAliasWhenPrivateKeyIsMissing() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    var keyStore = loadKeyStore();
+    keyStore.deleteEntry("streamarr-root");
+    keyStore.setCertificateEntry("streamarr-root", material.rootCertificate());
+    writeKeyStore(keyStore);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("private key");
+  }
+
+  @Test
+  @DisplayName("Should reject issuer chain when truncated")
+  void shouldRejectIssuerChainWhenTruncated() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var foreign =
+        new BuiltInCertificateAuthority()
+            .create(UUID.fromString("d4e8de65-9bcc-4f23-81ce-1d9948eec11d"), ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    rewriteAuthorityChains(material, foreign, ChainShape.TRUNCATED);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("invalid chain");
+  }
+
+  @Test
+  @DisplayName("Should reject authority chain when full-length chain ends at another root")
+  void shouldRejectAuthorityChainWhenFullLengthChainEndsAtAnotherRoot() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var foreign =
+        new BuiltInCertificateAuthority()
+            .create(UUID.fromString("76588b47-b8eb-4ba4-b328-b9f1849f657a"), ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    rewriteAuthorityChains(material, foreign, ChainShape.FULL_LENGTH_WRONG_ROOT);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("invalid chain");
+  }
+
+  @Test
+  @DisplayName("Should reject private key when associated with another certificate")
+  void shouldRejectPrivateKeyWhenAssociatedWithAnotherCertificate() throws Exception {
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var other =
+        new BuiltInCertificateAuthority()
+            .create(UUID.fromString("1cf8b73a-3980-4f04-b976-9a938aafbf99"), ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    store.createIfAbsent(material);
+    var keyStore = loadKeyStore();
+    keyStore.setKeyEntry(
+        "streamarr-root",
+        other.rootPrivateKey(),
+        new char[0],
+        new Certificate[] {material.rootCertificate()});
+    writeKeyStore(keyStore);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("mismatched private key");
+  }
+
+  @Test
+  @DisplayName("Should leave no secret when authority persistence fails")
+  void shouldLeaveNoSecretWhenAuthorityPersistenceFails() throws Exception {
+    var valid = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var invalid =
+        new CertificateAuthorityMaterial(
+            INSTALLATION_ID,
+            new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    null, valid.rootCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    valid.issuerPrivateKey(), valid.issuerCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    valid.revocationSignerPrivateKey(), valid.revocationSignerCertificate())));
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(() -> store.createIfAbsent(invalid))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("persist certificate authority secret");
+    assertThat(secretPath).doesNotExist();
+    try (var files = Files.list(directory)) {
+      assertThat(files).isEmpty();
+    }
+  }
+
+  @Test
+  @DisplayName("Should leave no secret when secure parent is not writable")
+  void shouldLeaveNoSecretWhenSecureParentIsNotWritable() throws Exception {
+    if (!Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var store = new CertificateAuthorityStore(secretPath);
+    Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("r-x------"));
+
+    try {
+      assertThatThrownBy(() -> store.createIfAbsent(material))
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("persist certificate authority secret");
+      assertThat(secretPath).doesNotExist();
+    } finally {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when labeled for another installation")
+  void shouldRejectAuthorityMaterialWhenLabeledForAnotherInstallation() throws Exception {
+    var valid = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var mislabeled =
+        new CertificateAuthorityMaterial(
+            UUID.fromString("d4e8de65-9bcc-4f23-81ce-1d9948eec11d"),
+            new CertificateAuthorityMaterial.AuthorityChainMaterial(
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    valid.rootPrivateKey(), valid.rootCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    valid.issuerPrivateKey(), valid.issuerCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    valid.revocationSignerPrivateKey(), valid.revocationSignerCertificate())));
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(() -> store.createIfAbsent(mislabeled))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("installation identity");
+    assertThat(secretPath).doesNotExist();
+    try (var files = Files.list(directory)) {
+      assertThat(files).isEmpty();
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when root trust-domain spelling is not canonical")
+  void shouldRejectAuthorityMaterialWhenRootTrustDomainSpellingIsNotCanonical() throws Exception {
+    var valid = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var malformed = withRootTrustDomain(valid, "SPIFFE://" + INSTALLATION_ID);
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(() -> store.createIfAbsent(malformed))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("invalid SPIFFE trust-domain identity");
+    assertThat(secretPath).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should reject authority material when root trust domain has no host")
+  void shouldRejectAuthorityMaterialWhenRootTrustDomainHasNoHost() throws Exception {
+    var valid = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var malformed = withRootTrustDomain(valid, "spiffe:///" + INSTALLATION_ID);
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(() -> store.createIfAbsent(malformed))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("invalid SPIFFE trust-domain identity");
+    assertThat(secretPath).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should reject authority without regeneration when stored material is corrupted")
+  void shouldRejectAuthorityWithoutRegenerationWhenStoredMaterialIsCorrupted() throws Exception {
+    Files.write(secretPath, new byte[] {1, 2, 3});
+    if (Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      Files.setPosixFilePermissions(secretPath, PosixFilePermissions.fromString("rw-------"));
+    }
+    var store = new CertificateAuthorityStore(secretPath);
+
+    assertThatThrownBy(store::load)
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("read certificate authority");
+    assertThat(Files.readAllBytes(secretPath)).containsExactly(1, 2, 3);
+  }
+
+  private static CopyOnWriteArrayList<CertificateAuthorityMaterial> createConcurrently(
+      Path path, int count, IntFunction<CertificateAuthorityMaterial> candidateForIndex)
+      throws Exception {
+    var start = new CountDownLatch(1);
+    var retained = new CopyOnWriteArrayList<CertificateAuthorityMaterial>();
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (var index = 0; index < count; index++) {
+        var candidate = candidateForIndex.apply(index);
+        executor.submit(
+            () -> {
+              start.await();
+              retained.add(new CertificateAuthorityStore(path).createIfAbsent(candidate));
+              return null;
+            });
+      }
+      start.countDown();
+    }
+    return retained;
+  }
+
+  private static void assertRejectsMacOsExtendedAcl(
+      Path path, String entry, CertificateAuthorityStore store) throws Exception {
+    var modeBeforeAcl = Files.getPosixFilePermissions(path);
+    runCommand(List.of("/bin/chmod", "+a", entry, path.toString()));
+    try {
+      assertThat(Files.getPosixFilePermissions(path)).isEqualTo(modeBeforeAcl);
+      assertThatThrownBy(store::load)
+          .isInstanceOf(CertificateAuthorityStoreException.class)
+          .hasMessageContaining("extended ACL");
+    } finally {
+      runCommand(List.of("/bin/chmod", "-N", path.toString()));
+    }
+  }
+
+  private static void runCommand(List<String> command) throws Exception {
+    var process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    String output;
+    try (var input = process.getInputStream()) {
+      output = new String(input.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+    }
+    assertThat(process.waitFor()).as(output).isZero();
+  }
+
+  private static CertificateAuthorityMaterial withRootTrustDomain(
+      CertificateAuthorityMaterial original, String trustDomain) throws Exception {
+    var root = original.rootCertificate();
+    var subject = new X500Name(root.getSubjectX500Principal().getName());
+    var builder =
+        new JcaX509v3CertificateBuilder(
+            subject,
+            root.getSerialNumber(),
+            root.getNotBefore(),
+            root.getNotAfter(),
+            subject,
+            root.getPublicKey());
+    var extensions = new JcaX509ExtensionUtils();
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(1));
+    builder.addExtension(
+        Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+    builder.addExtension(
+        Extension.subjectKeyIdentifier,
+        false,
+        extensions.createSubjectKeyIdentifier(root.getPublicKey()));
+    builder.addExtension(
+        Extension.authorityKeyIdentifier,
+        false,
+        extensions.createAuthorityKeyIdentifier(root.getPublicKey()));
+    builder.addExtension(
+        Extension.subjectAlternativeName,
+        false,
+        new GeneralNames(new GeneralName(GeneralName.uniformResourceIdentifier, trustDomain)));
+    var signer = new JcaContentSignerBuilder("SHA256withECDSA").build(original.rootPrivateKey());
+    var malformedRoot = new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    return new CertificateAuthorityMaterial(
+        original.installationId(),
+        new CertificateAuthorityMaterial.AuthorityChainMaterial(
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.rootPrivateKey(), malformedRoot),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.issuerPrivateKey(), original.issuerCertificate()),
+            new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                original.revocationSignerPrivateKey(), original.revocationSignerCertificate())));
+  }
+
+  private static void assertMaterialEquals(
+      CertificateAuthorityMaterial actual, CertificateAuthorityMaterial expected) {
+    assertThat(actual.installationId()).isEqualTo(expected.installationId());
+    assertThat(actual.rootPrivateKey().getEncoded())
+        .isEqualTo(expected.rootPrivateKey().getEncoded());
+    assertThat(encoded(actual.rootCertificate())).isEqualTo(encoded(expected.rootCertificate()));
+    assertThat(actual.issuerPrivateKey().getEncoded())
+        .isEqualTo(expected.issuerPrivateKey().getEncoded());
+    assertThat(encoded(actual.issuerCertificate()))
+        .isEqualTo(encoded(expected.issuerCertificate()));
+    assertThat(actual.revocationSignerPrivateKey().getEncoded())
+        .isEqualTo(expected.revocationSignerPrivateKey().getEncoded());
+    assertThat(encoded(actual.revocationSignerCertificate()))
+        .isEqualTo(encoded(expected.revocationSignerCertificate()));
+  }
+
+  private KeyStore loadKeyStore() throws Exception {
+    var keyStore = KeyStore.getInstance("PKCS12");
+    try (var input = Files.newInputStream(secretPath)) {
+      keyStore.load(input, new char[0]);
+    }
+    return keyStore;
+  }
+
+  private void rewriteAuthorityChains(
+      CertificateAuthorityMaterial material,
+      CertificateAuthorityMaterial foreignRoot,
+      ChainShape shape)
+      throws Exception {
+    var keyStore = loadKeyStore();
+    keyStore.deleteEntry("streamarr-root");
+    keyStore.deleteEntry("streamarr-issuer");
+    keyStore.deleteEntry("streamarr-revocation-signer");
+    keyStore.setKeyEntry(
+        "streamarr-root",
+        foreignRoot.rootPrivateKey(),
+        new char[0],
+        new Certificate[] {foreignRoot.rootCertificate()});
+    var issuerChain =
+        switch (shape) {
+          case TRUNCATED -> new Certificate[] {material.issuerCertificate()};
+          case FULL_LENGTH_WRONG_ROOT ->
+              new Certificate[] {material.issuerCertificate(), material.rootCertificate()};
+        };
+    var signerChain =
+        switch (shape) {
+          case TRUNCATED -> new Certificate[] {material.revocationSignerCertificate()};
+          case FULL_LENGTH_WRONG_ROOT ->
+              new Certificate[] {
+                material.revocationSignerCertificate(),
+                material.issuerCertificate(),
+                material.rootCertificate()
+              };
+        };
+    keyStore.setKeyEntry("streamarr-issuer", material.issuerPrivateKey(), new char[0], issuerChain);
+    keyStore.setKeyEntry(
+        "streamarr-revocation-signer",
+        material.revocationSignerPrivateKey(),
+        new char[0],
+        signerChain);
+    writeKeyStore(keyStore);
+  }
+
+  private void writeKeyStore(KeyStore keyStore) throws Exception {
+    try (var output = Files.newOutputStream(secretPath)) {
+      keyStore.store(output, new char[0]);
+    }
+  }
+
+  private static byte[] encoded(java.security.cert.X509Certificate certificate) {
+    try {
+      return certificate.getEncoded();
+    } catch (java.security.cert.CertificateEncodingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private enum ChainShape {
+    TRUNCATED,
+    FULL_LENGTH_WRONG_ROOT
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStoreTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/CertificateAuthorityStoreTest.java
@@ -58,7 +58,9 @@ class CertificateAuthorityStoreTest {
   @Test
   @DisplayName("Should reject storage path without a dedicated parent and final filename")
   void shouldRejectStoragePathWithoutDedicatedParentAndFinalFilename() {
-    assertThatThrownBy(() -> new CertificateAuthorityStore(Path.of("/")))
+    var root = Path.of("/");
+
+    assertThatThrownBy(() -> new CertificateAuthorityStore(root))
         .isInstanceOf(CertificateAuthorityStoreException.class)
         .hasMessageContaining("dedicated parent and final filename");
   }
@@ -92,20 +94,17 @@ class CertificateAuthorityStoreTest {
     assertThat(created.toString()).doesNotContain("EC Private Key", "privateValue", "S:");
     assertThat(
             new CertificateAuthorityMaterial.AuthorityChainMaterial(
-                    new CertificateAuthorityMaterial.AuthorityKeyMaterial(
-                        expected.rootPrivateKey(), expected.rootCertificate()),
-                    new CertificateAuthorityMaterial.AuthorityKeyMaterial(
-                        expected.issuerPrivateKey(), expected.issuerCertificate()),
-                    new CertificateAuthorityMaterial.AuthorityKeyMaterial(
-                        expected.revocationSignerPrivateKey(),
-                        expected.revocationSignerCertificate()))
-                .toString())
-        .isEqualTo("AuthorityChainMaterial[privateKeys=REDACTED]");
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    expected.rootPrivateKey(), expected.rootCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    expected.issuerPrivateKey(), expected.issuerCertificate()),
+                new CertificateAuthorityMaterial.AuthorityKeyMaterial(
+                    expected.revocationSignerPrivateKey(), expected.revocationSignerCertificate())))
+        .hasToString("AuthorityChainMaterial[privateKeys=REDACTED]");
     assertThat(
             new CertificateAuthorityMaterial.AuthorityKeyMaterial(
-                    expected.rootPrivateKey(), expected.rootCertificate())
-                .toString())
-        .isEqualTo("AuthorityKeyMaterial[privateKey=REDACTED]");
+                expected.rootPrivateKey(), expected.rootCertificate()))
+        .hasToString("AuthorityKeyMaterial[privateKey=REDACTED]");
     if (Files.getFileStore(secretPath).supportsFileAttributeView("posix")) {
       assertThat(Files.getPosixFilePermissions(secretPath))
           .isEqualTo(PosixFilePermissions.fromString("rw-------"));
@@ -118,7 +117,7 @@ class CertificateAuthorityStoreTest {
 
   @Test
   @DisplayName("Should preserve the first complete authority when creation races")
-  void shouldPreserveFirstCompleteAuthorityWhenCreationRaces() throws Exception {
+  void shouldPreserveFirstCompleteAuthorityWhenCreationRaces() {
     var first = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
     var second =
         new BuiltInCertificateAuthority()
@@ -133,7 +132,7 @@ class CertificateAuthorityStoreTest {
 
   @Test
   @DisplayName("Should converge when dedicated parent creation races")
-  void shouldConvergeWhenDedicatedParentCreationRaces() throws Exception {
+  void shouldConvergeWhenDedicatedParentCreationRaces() {
     var missingParent = directory.resolve("authority");
     var sharedSecret = missingParent.resolve("authority.p12");
     var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
@@ -201,13 +200,10 @@ class CertificateAuthorityStoreTest {
         Files.createDirectory(
             directory.resolve("authority"),
             PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
-    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+    var storagePath = parent.resolve("authority.p12");
 
     try {
-      assertThatThrownBy(
-              () ->
-                  new CertificateAuthorityStore(parent.resolve("authority.p12"))
-                      .createIfAbsent(material))
+      assertThatThrownBy(() -> new CertificateAuthorityStore(storagePath))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("protected ancestor");
     } finally {
@@ -333,12 +329,10 @@ class CertificateAuthorityStoreTest {
             directory.resolve("ancestor"),
             PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
     runCommand(List.of("/bin/chmod", "+a", "everyone allow read", ancestor.toString()));
+    var storagePath = ancestor.resolve("authority").resolve("authority.p12");
 
     try {
-      assertThatThrownBy(
-              () ->
-                  new CertificateAuthorityStore(
-                      ancestor.resolve("authority").resolve("authority.p12")))
+      assertThatThrownBy(() -> new CertificateAuthorityStore(storagePath))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("must not grant access");
     } finally {
@@ -352,12 +346,9 @@ class CertificateAuthorityStoreTest {
     try (var fileSystem = Jimfs.newFileSystem(Configuration.windows())) {
       var parent = fileSystem.getPath("C:\\authority");
       Files.createDirectory(parent);
-      var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+      var storagePath = parent.resolve("authority.p12");
 
-      assertThatThrownBy(
-              () ->
-                  new CertificateAuthorityStore(parent.resolve("authority.p12"))
-                      .createIfAbsent(material))
+      assertThatThrownBy(() -> new CertificateAuthorityStore(storagePath))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("requires POSIX permissions");
     }
@@ -367,13 +358,9 @@ class CertificateAuthorityStoreTest {
   @DisplayName("Should fail with storage exception when missing parent cannot enforce POSIX mode")
   void shouldFailWithStorageExceptionWhenMissingParentCannotEnforcePosixMode() throws Exception {
     try (var fileSystem = Jimfs.newFileSystem(Configuration.windows())) {
-      var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
+      var storagePath = fileSystem.getPath("C:\\authority").resolve("authority.p12");
 
-      assertThatThrownBy(
-              () ->
-                  new CertificateAuthorityStore(
-                          fileSystem.getPath("C:\\authority").resolve("authority.p12"))
-                      .createIfAbsent(material))
+      assertThatThrownBy(() -> new CertificateAuthorityStore(storagePath))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("requires POSIX permissions");
     }
@@ -400,7 +387,7 @@ class CertificateAuthorityStoreTest {
       Files.setOwner(parent, foreignOwner);
       Files.setOwner(secret, foreignOwner);
 
-      assertThatThrownBy(() -> new CertificateAuthorityStore(secret).load())
+      assertThatThrownBy(() -> new CertificateAuthorityStore(secret))
           .isInstanceOf(CertificateAuthorityStoreException.class)
           .hasMessageContaining("owned by root or the current process user");
     }
@@ -491,9 +478,8 @@ class CertificateAuthorityStoreTest {
   @DisplayName("Should fail closed when the dedicated parent's ancestor is missing")
   void shouldFailClosedWhenDedicatedParentAncestorIsMissing() {
     var nestedSecret = directory.resolve("missing").resolve("authority").resolve("authority.p12");
-    var material = new BuiltInCertificateAuthority().create(INSTALLATION_ID, ISSUED_AT);
 
-    assertThatThrownBy(() -> new CertificateAuthorityStore(nestedSecret).createIfAbsent(material))
+    assertThatThrownBy(() -> new CertificateAuthorityStore(nestedSecret))
         .isInstanceOf(CertificateAuthorityStoreException.class)
         .hasMessageContaining("protected ancestor does not exist");
   }
@@ -728,8 +714,7 @@ class CertificateAuthorityStoreTest {
   }
 
   private static CopyOnWriteArrayList<CertificateAuthorityMaterial> createConcurrently(
-      Path path, int count, IntFunction<CertificateAuthorityMaterial> candidateForIndex)
-      throws Exception {
+      Path path, int count, IntFunction<CertificateAuthorityMaterial> candidateForIndex) {
     var start = new CountDownLatch(1);
     var retained = new CopyOnWriteArrayList<CertificateAuthorityMaterial>();
     try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {


### PR DESCRIPTION
## Summary

- Persist the installation root, issuer, and revocation signer under fixed aliases in one owner-only PKCS#12 file.
- Validate numeric ownership, POSIX modes, protected ancestors, symlink traversal, sticky-directory entries, and macOS ACLs before reading or publishing trust material.
- Publish with a same-directory, no-clobber hard link and force both file and directory metadata for crash durability.
- Keep the slice inert: application startup, public database state, signing leadership, enrollment, and distributed playback remain disabled.

## Why

The certificate-profile slice in #235 defines valid installation trust material, and #236 establishes its filesystem security boundary. This follow-up persists that material durably without enabling distributed transcoding or adding a runtime message broker.

Part of #76. Stacked after #236.

## Validation

Developed test-first with explicit reproductions for publication races, corrupt or mismatched material, unsafe ancestors and symlinks, ownership and ACL failures, command timeout/interruption behavior, and crash-durability boundaries.

- `./mvnw clean verify`
- Focused trust-storage suite with `--illegal-native-access=deny`
- Independent post-fix security and consistency audit
