### PR TITLE
Enforce fenced installation trust persistence

### DIFF
--- a/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepository.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepository.java
@@ -1,0 +1,19 @@
+package com.streamarr.server.repositories.streaming.trust;
+
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityOperation;
+import com.streamarr.server.services.streaming.trust.CertificateSigningLease;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CertificateAuthoritySigningLeaseRepository {
+
+  Optional<CertificateSigningLease> tryAcquire(
+      CertificateAuthorityOperation operation, UUID ownerId, Duration duration);
+
+  Optional<CertificateSigningLease> renew(CertificateSigningLease currentLease, Duration duration);
+
+  boolean isCurrent(CertificateSigningLease lease);
+
+  boolean release(CertificateSigningLease lease);
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryImpl.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryImpl.java
@@ -1,0 +1,178 @@
+package com.streamarr.server.repositories.streaming.trust;
+
+import static com.streamarr.server.jooq.generated.tables.TranscodeCaSigningLease.TRANSCODE_CA_SIGNING_LEASE;
+
+import com.streamarr.server.jooq.generated.tables.records.TranscodeCaSigningLeaseRecord;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityOperation;
+import com.streamarr.server.services.streaming.trust.CertificateSigningLease;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CertificateAuthoritySigningLeaseRepositoryImpl
+    implements CertificateAuthoritySigningLeaseRepository {
+
+  private static final Duration MAXIMUM_LEASE_DURATION = Duration.ofMinutes(5);
+
+  private final DSLContext dsl;
+
+  @Override
+  public Optional<CertificateSigningLease> tryAcquire(
+      CertificateAuthorityOperation operation, UUID ownerId, Duration duration) {
+    requirePositive(duration);
+    return dsl.transactionResult(
+        configuration -> tryAcquire(DSL.using(configuration), operation, ownerId, duration));
+  }
+
+  private Optional<CertificateSigningLease> tryAcquire(
+      DSLContext transaction,
+      CertificateAuthorityOperation operation,
+      UUID ownerId,
+      Duration duration) {
+    var current =
+        transaction
+            .selectFrom(TRANSCODE_CA_SIGNING_LEASE)
+            .where(TRANSCODE_CA_SIGNING_LEASE.SINGLETON.isTrue())
+            .forUpdate()
+            .fetchSingle();
+    var databaseTime = databaseTime(transaction);
+    if (current.getLeaseUntil() != null && current.getLeaseUntil().isAfter(databaseTime)) {
+      return Optional.empty();
+    }
+
+    var leaseUntil = databaseTime.plus(duration);
+    return transaction
+        .update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OPERATION, generated(operation))
+        .set(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID, ownerId)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, leaseUntil)
+        .set(
+            TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH,
+            TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH.plus(1L))
+        .where(TRANSCODE_CA_SIGNING_LEASE.SINGLETON.isTrue())
+        .returning(
+            TRANSCODE_CA_SIGNING_LEASE.OPERATION,
+            TRANSCODE_CA_SIGNING_LEASE.OWNER_ID,
+            TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH,
+            TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL)
+        .fetchOptional(record -> toLease(record, databaseTime.toInstant()));
+  }
+
+  @Override
+  public Optional<CertificateSigningLease> renew(
+      CertificateSigningLease currentLease, Duration duration) {
+    requirePositive(duration);
+    return dsl.transactionResult(
+        configuration -> renew(DSL.using(configuration), currentLease, duration));
+  }
+
+  private Optional<CertificateSigningLease> renew(
+      DSLContext transaction, CertificateSigningLease currentLease, Duration duration) {
+    var current =
+        transaction
+            .selectFrom(TRANSCODE_CA_SIGNING_LEASE)
+            .where(matches(currentLease))
+            .forUpdate()
+            .fetchOptional();
+    if (current.isEmpty()) {
+      return Optional.empty();
+    }
+
+    var databaseTime = databaseTime(transaction);
+    if (!current.orElseThrow().getLeaseUntil().isAfter(databaseTime)) {
+      return Optional.empty();
+    }
+
+    var leaseUntil = databaseTime.plus(duration);
+    return transaction
+        .update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, leaseUntil)
+        .where(matches(currentLease))
+        .returning(
+            TRANSCODE_CA_SIGNING_LEASE.OPERATION,
+            TRANSCODE_CA_SIGNING_LEASE.OWNER_ID,
+            TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH,
+            TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL)
+        .fetchOptional(record -> toLease(record, databaseTime.toInstant()));
+  }
+
+  @Override
+  public boolean isCurrent(CertificateSigningLease lease) {
+    return dsl.fetchExists(
+        dsl.selectOne()
+            .from(TRANSCODE_CA_SIGNING_LEASE)
+            .where(matches(lease))
+            .and(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL.gt(statementTimestamp())));
+  }
+
+  @Override
+  public boolean release(CertificateSigningLease lease) {
+    return dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+            .set(
+                TRANSCODE_CA_SIGNING_LEASE.OPERATION,
+                (com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation) null)
+            .set(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID, (UUID) null)
+            .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, (OffsetDateTime) null)
+            .where(matches(lease))
+            .execute()
+        == 1;
+  }
+
+  private org.jooq.Condition matches(CertificateSigningLease lease) {
+    return TRANSCODE_CA_SIGNING_LEASE
+        .SINGLETON
+        .isTrue()
+        .and(TRANSCODE_CA_SIGNING_LEASE.OPERATION.eq(generated(lease.operation())))
+        .and(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID.eq(lease.ownerId()))
+        .and(TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH.eq(lease.fencingEpoch()));
+  }
+
+  private CertificateSigningLease toLease(
+      TranscodeCaSigningLeaseRecord record, java.time.Instant databaseTime) {
+    var leaseUntil = record.getLeaseUntil().toInstant();
+    return CertificateSigningLease.builder()
+        .operation(CertificateAuthorityOperation.valueOf(record.getOperation().getLiteral()))
+        .ownerId(record.getOwnerId())
+        .fencingEpoch(record.getFencingEpoch())
+        .databaseTime(databaseTime)
+        .leaseUntil(leaseUntil)
+        .build();
+  }
+
+  private OffsetDateTime databaseTime(DSLContext transaction) {
+    return transaction.select(statementTimestamp()).fetchSingle().value1();
+  }
+
+  private com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation generated(
+      CertificateAuthorityOperation operation) {
+    return com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation.valueOf(
+        operation.name());
+  }
+
+  private Field<OffsetDateTime> statementTimestamp() {
+    return DSL.function(DSL.name("statement_timestamp"), SQLDataType.TIMESTAMPWITHTIMEZONE);
+  }
+
+  private void requirePositive(Duration duration) {
+    if (duration.isZero() || duration.isNegative()) {
+      throw new IllegalArgumentException("Certificate authority signing lease must be positive");
+    }
+    if (duration.getNano() % 1_000 != 0) {
+      throw new IllegalArgumentException(
+          "Certificate authority signing lease must use microsecond precision");
+    }
+    if (duration.compareTo(MAXIMUM_LEASE_DURATION) > 0) {
+      throw new IllegalArgumentException(
+          "Certificate authority signing lease must not exceed 5 minutes");
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryImpl.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryImpl.java
@@ -64,7 +64,7 @@ public class CertificateAuthoritySigningLeaseRepositoryImpl
             TRANSCODE_CA_SIGNING_LEASE.OWNER_ID,
             TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH,
             TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL)
-        .fetchOptional(record -> toLease(record, databaseTime.toInstant()));
+        .fetchOptional(leaseRecord -> toLease(leaseRecord, databaseTime.toInstant()));
   }
 
   @Override
@@ -102,7 +102,7 @@ public class CertificateAuthoritySigningLeaseRepositoryImpl
             TRANSCODE_CA_SIGNING_LEASE.OWNER_ID,
             TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH,
             TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL)
-        .fetchOptional(record -> toLease(record, databaseTime.toInstant()));
+        .fetchOptional(leaseRecord -> toLease(leaseRecord, databaseTime.toInstant()));
   }
 
   @Override
@@ -137,12 +137,12 @@ public class CertificateAuthoritySigningLeaseRepositoryImpl
   }
 
   private CertificateSigningLease toLease(
-      TranscodeCaSigningLeaseRecord record, java.time.Instant databaseTime) {
-    var leaseUntil = record.getLeaseUntil().toInstant();
+      TranscodeCaSigningLeaseRecord leaseRecord, java.time.Instant databaseTime) {
+    var leaseUntil = leaseRecord.getLeaseUntil().toInstant();
     return CertificateSigningLease.builder()
-        .operation(CertificateAuthorityOperation.valueOf(record.getOperation().getLiteral()))
-        .ownerId(record.getOwnerId())
-        .fencingEpoch(record.getFencingEpoch())
+        .operation(CertificateAuthorityOperation.valueOf(leaseRecord.getOperation().getLiteral()))
+        .ownerId(leaseRecord.getOwnerId())
+        .fencingEpoch(leaseRecord.getFencingEpoch())
         .databaseTime(databaseTime)
         .leaseUntil(leaseUntil)
         .build();

--- a/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepository.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepository.java
@@ -1,0 +1,19 @@
+package com.streamarr.server.repositories.streaming.trust;
+
+import com.streamarr.server.services.streaming.trust.CertificateSigningLease;
+import com.streamarr.server.services.streaming.trust.InitialTrustPublication;
+import com.streamarr.server.services.streaming.trust.InstallationTrust;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InstallationTrustRepository {
+
+  UUID installationId();
+
+  Instant databaseTime();
+
+  Optional<InstallationTrust> findInitialized();
+
+  boolean publishInitial(CertificateSigningLease lease, InitialTrustPublication publication);
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryImpl.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -94,27 +95,19 @@ public class InstallationTrustRepositoryImpl implements InstallationTrustReposit
       throw new InstallationTrustException("Installation trust singleton state is missing");
     }
     var state = states.getFirst();
-
     var rootDigest = state.value2();
-    var initializedAt = state.value3();
-    var bundleVersion = state.value4();
-    var activatedAt = state.value5();
-    var createdAt = state.value6();
-    if (rootDigest == null
-        && initializedAt == null
-        && bundleVersion == null
-        && activatedAt == null
-        && createdAt == null) {
+    var persistedState =
+        PersistedTrustState.builder()
+            .installationId(state.value1())
+            .initializedAt(state.value3())
+            .bundleVersion(state.value4())
+            .activatedAt(state.value5())
+            .createdAt(state.value6())
+            .build();
+    if (persistedState.isEmpty(rootDigest)) {
       return Optional.empty();
     }
-    if (rootDigest == null
-        || initializedAt == null
-        || bundleVersion == null
-        || activatedAt == null
-        || createdAt == null) {
-      throw new InstallationTrustException(
-          "Installation trust state is only partially initialized");
-    }
+    persistedState.requireComplete(rootDigest);
 
     var trustAnchors = new ArrayList<X509Certificate>();
     var issuers = new ArrayList<X509Certificate>();
@@ -151,14 +144,14 @@ public class InstallationTrustRepositoryImpl implements InstallationTrustReposit
 
     var bundle =
         PublicTrustBundle.builder()
-            .installationId(state.value1())
-            .version(bundleVersion)
-            .createdAt(createdAt.toInstant())
+            .installationId(persistedState.installationId())
+            .version(persistedState.bundleVersion())
+            .createdAt(persistedState.createdAt().toInstant())
             .trustAnchors(trustAnchors)
             .issuers(issuers)
             .revocationSigners(revocationSigners)
             .build();
-    return Optional.of(new InstallationTrust(state.value1(), rootDigest, bundle));
+    return Optional.of(new InstallationTrust(persistedState.installationId(), rootDigest, bundle));
   }
 
   @Override
@@ -279,8 +272,6 @@ public class InstallationTrustRepositoryImpl implements InstallationTrustReposit
             "Stored public trust certificate is not canonical DER");
       }
       return certificate;
-    } catch (InstallationTrustException e) {
-      throw e;
     } catch (java.security.cert.CertificateException e) {
       throw new InstallationTrustException(
           "Stored public trust certificate is not valid canonical DER", e);
@@ -329,5 +320,33 @@ public class InstallationTrustRepositoryImpl implements InstallationTrustReposit
 
   private Field<OffsetDateTime> statementTimestamp() {
     return DSL.function(DSL.name("statement_timestamp"), SQLDataType.TIMESTAMPWITHTIMEZONE);
+  }
+
+  @Builder
+  private record PersistedTrustState(
+      UUID installationId,
+      OffsetDateTime initializedAt,
+      Long bundleVersion,
+      OffsetDateTime activatedAt,
+      OffsetDateTime createdAt) {
+
+    private boolean isEmpty(byte[] rootDigest) {
+      return rootDigest == null
+          && initializedAt == null
+          && bundleVersion == null
+          && activatedAt == null
+          && createdAt == null;
+    }
+
+    private void requireComplete(byte[] rootDigest) {
+      if (rootDigest == null
+          || initializedAt == null
+          || bundleVersion == null
+          || activatedAt == null
+          || createdAt == null) {
+        throw new InstallationTrustException(
+            "Installation trust state is only partially initialized");
+      }
+    }
   }
 }

--- a/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryImpl.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryImpl.java
@@ -1,0 +1,333 @@
+package com.streamarr.server.repositories.streaming.trust;
+
+import static com.streamarr.server.jooq.generated.tables.TranscodeActiveTrustBundle.TRANSCODE_ACTIVE_TRUST_BUNDLE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeCaSigningLease.TRANSCODE_CA_SIGNING_LEASE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeInstallation.TRANSCODE_INSTALLATION;
+import static com.streamarr.server.jooq.generated.tables.TranscodePublicTrustBundle.TRANSCODE_PUBLIC_TRUST_BUNDLE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeTrustCertificate.TRANSCODE_TRUST_CERTIFICATE;
+
+import com.streamarr.server.jooq.generated.enums.TranscodeTrustCertificateKind;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityOperation;
+import com.streamarr.server.services.streaming.trust.CertificateSigningLease;
+import com.streamarr.server.services.streaming.trust.InitialTrustPublication;
+import com.streamarr.server.services.streaming.trust.InstallationTrust;
+import com.streamarr.server.services.streaming.trust.InstallationTrustException;
+import com.streamarr.server.services.streaming.trust.PublicTrustBundle;
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class InstallationTrustRepositoryImpl implements InstallationTrustRepository {
+
+  private static final long INITIAL_BUNDLE_VERSION = 1L;
+
+  private final DSLContext dsl;
+
+  @Override
+  public UUID installationId() {
+    return dsl.select(TRANSCODE_INSTALLATION.INSTALLATION_ID)
+        .from(TRANSCODE_INSTALLATION)
+        .where(TRANSCODE_INSTALLATION.SINGLETON.isTrue())
+        .fetchSingle(TRANSCODE_INSTALLATION.INSTALLATION_ID);
+  }
+
+  @Override
+  public Instant databaseTime() {
+    return dsl.select(statementTimestamp()).fetchSingle().value1().toInstant();
+  }
+
+  @Override
+  public Optional<InstallationTrust> findInitialized() {
+    var states =
+        dsl.select(
+                TRANSCODE_INSTALLATION.INSTALLATION_ID,
+                TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256,
+                TRANSCODE_INSTALLATION.INITIALIZED_AT,
+                TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION,
+                TRANSCODE_ACTIVE_TRUST_BUNDLE.ACTIVATED_AT,
+                TRANSCODE_PUBLIC_TRUST_BUNDLE.CREATED_AT,
+                TRANSCODE_TRUST_CERTIFICATE.KIND,
+                TRANSCODE_TRUST_CERTIFICATE.ORDINAL,
+                TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER,
+                TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_SHA256)
+            .from(TRANSCODE_INSTALLATION)
+            .join(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+            .on(
+                TRANSCODE_ACTIVE_TRUST_BUNDLE.INSTALLATION_ID.eq(
+                    TRANSCODE_INSTALLATION.INSTALLATION_ID))
+            .leftJoin(TRANSCODE_PUBLIC_TRUST_BUNDLE)
+            .on(
+                TRANSCODE_PUBLIC_TRUST_BUNDLE
+                    .INSTALLATION_ID
+                    .eq(TRANSCODE_ACTIVE_TRUST_BUNDLE.INSTALLATION_ID)
+                    .and(
+                        TRANSCODE_PUBLIC_TRUST_BUNDLE.VERSION.eq(
+                            TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION)))
+            .leftJoin(TRANSCODE_TRUST_CERTIFICATE)
+            .on(
+                TRANSCODE_TRUST_CERTIFICATE
+                    .INSTALLATION_ID
+                    .eq(TRANSCODE_ACTIVE_TRUST_BUNDLE.INSTALLATION_ID)
+                    .and(
+                        TRANSCODE_TRUST_CERTIFICATE.BUNDLE_VERSION.eq(
+                            TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION)))
+            .where(TRANSCODE_INSTALLATION.SINGLETON.isTrue())
+            .and(TRANSCODE_ACTIVE_TRUST_BUNDLE.SINGLETON.isTrue())
+            .orderBy(TRANSCODE_TRUST_CERTIFICATE.KIND, TRANSCODE_TRUST_CERTIFICATE.ORDINAL)
+            .fetch();
+    if (states.isEmpty()) {
+      throw new InstallationTrustException("Installation trust singleton state is missing");
+    }
+    var state = states.getFirst();
+
+    var rootDigest = state.value2();
+    var initializedAt = state.value3();
+    var bundleVersion = state.value4();
+    var activatedAt = state.value5();
+    var createdAt = state.value6();
+    if (rootDigest == null
+        && initializedAt == null
+        && bundleVersion == null
+        && activatedAt == null
+        && createdAt == null) {
+      return Optional.empty();
+    }
+    if (rootDigest == null
+        || initializedAt == null
+        || bundleVersion == null
+        || activatedAt == null
+        || createdAt == null) {
+      throw new InstallationTrustException(
+          "Installation trust state is only partially initialized");
+    }
+
+    var trustAnchors = new ArrayList<X509Certificate>();
+    var issuers = new ArrayList<X509Certificate>();
+    var revocationSigners = new ArrayList<X509Certificate>();
+    for (var certificate : states) {
+      var kind = certificate.value7();
+      if (kind == null) {
+        continue;
+      }
+      if (certificate.value8() != 0) {
+        throw new InstallationTrustException(
+            "Initial public trust certificate has an invalid role and ordinal");
+      }
+      var certificateDer = certificate.value9();
+      if (!MessageDigest.isEqual(sha256(certificateDer), certificate.value10())) {
+        throw new InstallationTrustException(
+            "Stored public trust certificate digest does not match exact DER");
+      }
+      var parsed = parse(certificateDer);
+      switch (kind) {
+        case TRUST_ANCHOR -> trustAnchors.add(parsed);
+        case ISSUER -> issuers.add(parsed);
+        case REVOCATION_SIGNER -> revocationSigners.add(parsed);
+      }
+    }
+    if (trustAnchors.size() != 1 || issuers.size() != 1 || revocationSigners.size() != 1) {
+      throw new InstallationTrustException(
+          "Initial public trust bundle must contain the exact certificate roles");
+    }
+    if (!MessageDigest.isEqual(rootDigest, sha256(trustAnchors.getFirst()))) {
+      throw new InstallationTrustException(
+          "Installation root fingerprint does not match the active trust anchor");
+    }
+
+    var bundle =
+        PublicTrustBundle.builder()
+            .installationId(state.value1())
+            .version(bundleVersion)
+            .createdAt(createdAt.toInstant())
+            .trustAnchors(trustAnchors)
+            .issuers(issuers)
+            .revocationSigners(revocationSigners)
+            .build();
+    return Optional.of(new InstallationTrust(state.value1(), rootDigest, bundle));
+  }
+
+  @Override
+  public boolean publishInitial(
+      CertificateSigningLease lease, InitialTrustPublication publication) {
+    if (lease.operation() != CertificateAuthorityOperation.BOOTSTRAP) {
+      return false;
+    }
+    return dsl.transactionResult(
+        configuration -> publishInitial(DSL.using(configuration), lease, publication));
+  }
+
+  private boolean publishInitial(
+      DSLContext transaction, CertificateSigningLease lease, InitialTrustPublication publication) {
+    var currentLease =
+        transaction
+            .select(TRANSCODE_CA_SIGNING_LEASE.SINGLETON)
+            .from(TRANSCODE_CA_SIGNING_LEASE)
+            .where(leaseIdentity(lease))
+            .forUpdate()
+            .fetchOptional();
+    if (currentLease.isEmpty()) {
+      return false;
+    }
+
+    var installation =
+        transaction
+            .select(
+                TRANSCODE_INSTALLATION.INSTALLATION_ID,
+                TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256)
+            .from(TRANSCODE_INSTALLATION)
+            .where(TRANSCODE_INSTALLATION.SINGLETON.isTrue())
+            .forUpdate()
+            .fetchSingle();
+    if (!installation.value1().equals(publication.installationId())
+        || installation.value2() != null) {
+      return false;
+    }
+
+    var activeBundle =
+        transaction
+            .select(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION)
+            .from(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+            .where(TRANSCODE_ACTIVE_TRUST_BUNDLE.SINGLETON.isTrue())
+            .forUpdate()
+            .fetchSingle(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION);
+    if (activeBundle != null) {
+      return false;
+    }
+    if (!isCurrent(transaction, lease)) {
+      return false;
+    }
+
+    transaction
+        .insertInto(TRANSCODE_PUBLIC_TRUST_BUNDLE)
+        .set(TRANSCODE_PUBLIC_TRUST_BUNDLE.INSTALLATION_ID, publication.installationId())
+        .set(TRANSCODE_PUBLIC_TRUST_BUNDLE.VERSION, INITIAL_BUNDLE_VERSION)
+        .execute();
+    insertCertificate(transaction, publication, TranscodeTrustCertificateKind.TRUST_ANCHOR);
+    insertCertificate(transaction, publication, TranscodeTrustCertificateKind.ISSUER);
+    insertCertificate(transaction, publication, TranscodeTrustCertificateKind.REVOCATION_SIGNER);
+
+    var initialized =
+        transaction
+            .update(TRANSCODE_INSTALLATION)
+            .set(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256, publication.bootstrapRootSha256())
+            .set(TRANSCODE_INSTALLATION.INITIALIZED_AT, statementTimestamp())
+            .where(TRANSCODE_INSTALLATION.SINGLETON.isTrue())
+            .and(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256.isNull())
+            .execute();
+    var activated =
+        transaction
+            .update(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+            .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION, INITIAL_BUNDLE_VERSION)
+            .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.ACTIVATED_AT, statementTimestamp())
+            .where(TRANSCODE_ACTIVE_TRUST_BUNDLE.SINGLETON.isTrue())
+            .and(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION.isNull())
+            .execute();
+    if (initialized != 1 || activated != 1) {
+      throw new InstallationTrustException(
+          "Installation trust publication did not commit its final state");
+    }
+    if (!isCurrent(transaction, lease)) {
+      throw new InstallationTrustException(
+          "Installation trust publication lease expired before final commit");
+    }
+    return true;
+  }
+
+  private void insertCertificate(
+      DSLContext transaction,
+      InitialTrustPublication publication,
+      TranscodeTrustCertificateKind kind) {
+    var certificateDer =
+        switch (kind) {
+          case TRUST_ANCHOR -> publication.rootCertificateDer();
+          case ISSUER -> publication.issuerCertificateDer();
+          case REVOCATION_SIGNER -> publication.revocationSignerCertificateDer();
+        };
+    transaction
+        .insertInto(TRANSCODE_TRUST_CERTIFICATE)
+        .set(TRANSCODE_TRUST_CERTIFICATE.INSTALLATION_ID, publication.installationId())
+        .set(TRANSCODE_TRUST_CERTIFICATE.BUNDLE_VERSION, INITIAL_BUNDLE_VERSION)
+        .set(TRANSCODE_TRUST_CERTIFICATE.KIND, kind)
+        .set(TRANSCODE_TRUST_CERTIFICATE.ORDINAL, (short) 0)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER, certificateDer)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_SHA256, sha256(certificateDer))
+        .execute();
+  }
+
+  private X509Certificate parse(byte[] der) {
+    try {
+      var input = new ByteArrayInputStream(der);
+      var certificate =
+          (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(input);
+      if (input.available() != 0 || !MessageDigest.isEqual(certificate.getEncoded(), der)) {
+        throw new InstallationTrustException(
+            "Stored public trust certificate is not canonical DER");
+      }
+      return certificate;
+    } catch (InstallationTrustException e) {
+      throw e;
+    } catch (java.security.cert.CertificateException e) {
+      throw new InstallationTrustException(
+          "Stored public trust certificate is not valid canonical DER", e);
+    }
+  }
+
+  private byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is unavailable", e);
+    }
+  }
+
+  private byte[] sha256(X509Certificate certificate) {
+    try {
+      return sha256(certificate.getEncoded());
+    } catch (java.security.cert.CertificateEncodingException e) {
+      throw new InstallationTrustException("Stored public trust certificate cannot be encoded", e);
+    }
+  }
+
+  private com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation generated(
+      CertificateAuthorityOperation operation) {
+    return com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation.valueOf(
+        operation.name());
+  }
+
+  private Condition leaseIdentity(CertificateSigningLease lease) {
+    return TRANSCODE_CA_SIGNING_LEASE
+        .SINGLETON
+        .isTrue()
+        .and(TRANSCODE_CA_SIGNING_LEASE.OPERATION.eq(generated(lease.operation())))
+        .and(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID.eq(lease.ownerId()))
+        .and(TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH.eq(lease.fencingEpoch()));
+  }
+
+  private boolean isCurrent(DSLContext transaction, CertificateSigningLease lease) {
+    return transaction.fetchExists(
+        transaction
+            .selectOne()
+            .from(TRANSCODE_CA_SIGNING_LEASE)
+            .where(leaseIdentity(lease))
+            .and(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL.gt(statementTimestamp())));
+  }
+
+  private Field<OffsetDateTime> statementTimestamp() {
+    return DSL.function(DSL.name("statement_timestamp"), SQLDataType.TIMESTAMPWITHTIMEZONE);
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryIT.java
@@ -47,7 +47,7 @@ class CertificateAuthoritySigningLeaseRepositoryIT extends AbstractIntegrationTe
 
   @Test
   @DisplayName("Should grant exactly one signing lease when owners acquire concurrently")
-  void shouldGrantExactlyOneSigningLeaseWhenOwnersAcquireConcurrently() throws Exception {
+  void shouldGrantExactlyOneSigningLeaseWhenOwnersAcquireConcurrently() {
     var start = new CountDownLatch(1);
     var results = new CopyOnWriteArrayList<Boolean>();
     try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {

--- a/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryIT.java
@@ -1,0 +1,304 @@
+package com.streamarr.server.repositories.streaming.trust;
+
+import static com.streamarr.server.jooq.generated.tables.TranscodeCaSigningLease.TRANSCODE_CA_SIGNING_LEASE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityOperation;
+import com.streamarr.server.services.streaming.trust.CertificateSigningLease;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Certificate Authority Signing Lease Repository Integration Tests")
+class CertificateAuthoritySigningLeaseRepositoryIT extends AbstractIntegrationTest {
+
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(30);
+
+  @Autowired private CertificateAuthoritySigningLeaseRepository repository;
+  @Autowired private DSLContext dsl;
+
+  @BeforeEach
+  void resetLease() {
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OPERATION, (TranscodeCaSigningOperation) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID, (UUID) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, (OffsetDateTime) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH, 0L)
+        .execute();
+  }
+
+  @Test
+  @DisplayName("Should grant exactly one signing lease when owners acquire concurrently")
+  void shouldGrantExactlyOneSigningLeaseWhenOwnersAcquireConcurrently() throws Exception {
+    var start = new CountDownLatch(1);
+    var results = new CopyOnWriteArrayList<Boolean>();
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (var ownerId : List.of(UUID.randomUUID(), UUID.randomUUID())) {
+        executor.submit(
+            () -> {
+              start.await();
+              results.add(
+                  repository
+                      .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, ownerId, LEASE_DURATION)
+                      .isPresent());
+              return null;
+            });
+      }
+      start.countDown();
+    }
+
+    assertThat(results).containsExactlyInAnyOrder(true, false);
+  }
+
+  @Test
+  @DisplayName("Should report the exact database acquisition time")
+  void shouldReportExactDatabaseAcquisitionTime() {
+    var duration = Duration.ofSeconds(30).plusNanos(123_000);
+    var before = databaseTime().toInstant();
+
+    var lease =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), duration)
+            .orElseThrow();
+
+    var after = databaseTime().toInstant();
+    assertThat(lease.databaseTime()).isBetween(before, after);
+    assertThat(lease.databaseTime().getNano() % 1_000).isZero();
+  }
+
+  @Test
+  @DisplayName("Should reject a signing lease duration below database precision")
+  void shouldRejectSigningLeaseDurationBelowDatabasePrecision() {
+    assertThatThrownBy(
+            () ->
+                repository.tryAcquire(
+                    CertificateAuthorityOperation.BOOTSTRAP,
+                    UUID.randomUUID(),
+                    Duration.ofNanos(1)))
+        .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("microsecond");
+  }
+
+  @Test
+  @DisplayName("Should reject non-positive signing lease durations")
+  void shouldRejectNonPositiveSigningLeaseDurations() {
+    var current =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    for (var duration : List.of(Duration.ZERO, Duration.ofSeconds(-1))) {
+      assertThatThrownBy(
+              () ->
+                  repository.tryAcquire(
+                      CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), duration))
+          .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
+          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("positive");
+      assertThatThrownBy(() -> repository.renew(current, duration))
+          .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
+          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("positive");
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject signing leases longer than five minutes")
+  void shouldRejectSigningLeasesLongerThanFiveMinutes() {
+    var excessiveDuration = Duration.ofMinutes(5).plusNanos(1_000);
+
+    assertThatThrownBy(
+            () ->
+                repository.tryAcquire(
+                    CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), excessiveDuration))
+        .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("5 minutes");
+
+    var current =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThatThrownBy(() -> repository.renew(current, excessiveDuration))
+        .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("5 minutes");
+    assertThat(repository.isCurrent(current)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should retain the fence when the current owner renews before expiry")
+  void shouldRetainFenceWhenCurrentOwnerRenewsBeforeExpiry() {
+    var lease =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.ISSUANCE, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+
+    var renewed = repository.renew(lease, LEASE_DURATION).orElseThrow();
+
+    assertThat(renewed.fencingEpoch()).isEqualTo(lease.fencingEpoch());
+    assertThat(renewed.leaseUntil()).isAfter(lease.leaseUntil());
+    assertThat(repository.isCurrent(renewed)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should reject a signing lease with the wrong identity")
+  void shouldRejectSigningLeaseWithWrongIdentity() {
+    var current =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    var wrongOperation =
+        CertificateSigningLease.builder()
+            .operation(CertificateAuthorityOperation.ROTATION)
+            .ownerId(current.ownerId())
+            .fencingEpoch(current.fencingEpoch())
+            .databaseTime(current.databaseTime())
+            .leaseUntil(current.leaseUntil())
+            .build();
+    var wrongOwner =
+        CertificateSigningLease.builder()
+            .operation(current.operation())
+            .ownerId(UUID.randomUUID())
+            .fencingEpoch(current.fencingEpoch())
+            .databaseTime(current.databaseTime())
+            .leaseUntil(current.leaseUntil())
+            .build();
+    var wrongFence =
+        CertificateSigningLease.builder()
+            .operation(current.operation())
+            .ownerId(current.ownerId())
+            .fencingEpoch(current.fencingEpoch() + 1)
+            .databaseTime(current.databaseTime())
+            .leaseUntil(current.leaseUntil())
+            .build();
+
+    for (var stale : List.of(wrongOperation, wrongOwner, wrongFence)) {
+      assertThat(repository.isCurrent(stale)).isFalse();
+      assertThat(repository.renew(stale, LEASE_DURATION)).isEmpty();
+      assertThat(repository.release(stale)).isFalse();
+    }
+    assertThat(repository.isCurrent(current)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should refuse renewal when the lease expires while waiting for its row lock")
+  void shouldRefuseRenewalWhenLeaseExpiresWhileWaitingForItsRowLock() throws Exception {
+    var lease =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.ISSUANCE, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    var expiresAt = databaseTime().plusSeconds(2);
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, expiresAt)
+        .execute();
+
+    var rowLocked = new CountDownLatch(1);
+    var releaseRow = new CountDownLatch(1);
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var blocker =
+          executor.submit(
+              () ->
+                  dsl.transaction(
+                      configuration -> {
+                        DSL.using(configuration)
+                            .selectOne()
+                            .from(TRANSCODE_CA_SIGNING_LEASE)
+                            .where(TRANSCODE_CA_SIGNING_LEASE.SINGLETON.isTrue())
+                            .forUpdate()
+                            .fetchSingle();
+                        rowLocked.countDown();
+                        releaseRow.await();
+                      }));
+      assertThat(rowLocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+      var renewal = executor.submit(() -> repository.renew(lease, LEASE_DURATION));
+      try {
+        awaitBlockedLeaseStatement();
+        awaitDatabaseTime(expiresAt);
+      } finally {
+        releaseRow.countDown();
+      }
+
+      assertThat(renewal.get(5, TimeUnit.SECONDS)).isEmpty();
+      blocker.get(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  @DisplayName("Should advance the fence and reject the stale owner after expiry")
+  void shouldAdvanceFenceAndRejectStaleOwnerAfterExpiry() {
+    var stale =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.ROTATION, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, databaseTime().minusSeconds(1))
+        .execute();
+
+    var current =
+        repository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+
+    assertThat(current.fencingEpoch()).isGreaterThan(stale.fencingEpoch());
+    assertThat(repository.isCurrent(stale)).isFalse();
+    assertThat(repository.renew(stale, LEASE_DURATION)).isEmpty();
+    assertThat(repository.release(stale)).isFalse();
+    assertThat(repository.isCurrent(current)).isTrue();
+    assertThat(repository.release(current)).isTrue();
+    assertThat(repository.isCurrent(current)).isFalse();
+  }
+
+  private OffsetDateTime databaseTime() {
+    return dsl.select(statementTimestamp()).fetchSingle().value1();
+  }
+
+  private void awaitDatabaseTime(OffsetDateTime expected) {
+    while (databaseTime().isBefore(expected)) {
+      LockSupport.parkNanos(Duration.ofMillis(1).toNanos());
+    }
+  }
+
+  private void awaitBlockedLeaseStatement() {
+    var waitEventType = DSL.field(DSL.name("wait_event_type"), String.class);
+    var query = DSL.field(DSL.name("query"), String.class);
+    var activity = DSL.table(DSL.name("pg_stat_activity"));
+    var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      var blocked =
+          dsl.selectCount()
+              .from(activity)
+              .where(waitEventType.eq("Lock"))
+              .and(query.contains("transcode_ca_signing_lease"))
+              .fetchSingle(0, int.class);
+      if (blocked > 0) {
+        return;
+      }
+      LockSupport.parkNanos(Duration.ofMillis(1).toNanos());
+    }
+    throw new AssertionError("Signing lease statement did not wait for the row lock");
+  }
+
+  private org.jooq.Field<OffsetDateTime> statementTimestamp() {
+    return DSL.function(DSL.name("statement_timestamp"), SQLDataType.TIMESTAMPWITHTIMEZONE);
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/CertificateAuthoritySigningLeaseRepositoryIT.java
@@ -87,12 +87,11 @@ class CertificateAuthoritySigningLeaseRepositoryIT extends AbstractIntegrationTe
   @Test
   @DisplayName("Should reject a signing lease duration below database precision")
   void shouldRejectSigningLeaseDurationBelowDatabasePrecision() {
+    var ownerId = UUID.randomUUID();
+    var duration = Duration.ofNanos(1);
+
     assertThatThrownBy(
-            () ->
-                repository.tryAcquire(
-                    CertificateAuthorityOperation.BOOTSTRAP,
-                    UUID.randomUUID(),
-                    Duration.ofNanos(1)))
+            () -> repository.tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, ownerId, duration))
         .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("microsecond");
@@ -106,10 +105,11 @@ class CertificateAuthoritySigningLeaseRepositoryIT extends AbstractIntegrationTe
             .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
             .orElseThrow();
     for (var duration : List.of(Duration.ZERO, Duration.ofSeconds(-1))) {
+      var ownerId = UUID.randomUUID();
+
       assertThatThrownBy(
               () ->
-                  repository.tryAcquire(
-                      CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), duration))
+                  repository.tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, ownerId, duration))
           .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
           .hasCauseInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("positive");
@@ -123,12 +123,13 @@ class CertificateAuthoritySigningLeaseRepositoryIT extends AbstractIntegrationTe
   @Test
   @DisplayName("Should reject signing leases longer than five minutes")
   void shouldRejectSigningLeasesLongerThanFiveMinutes() {
+    var ownerId = UUID.randomUUID();
     var excessiveDuration = Duration.ofMinutes(5).plusNanos(1_000);
 
     assertThatThrownBy(
             () ->
                 repository.tryAcquire(
-                    CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), excessiveDuration))
+                    CertificateAuthorityOperation.BOOTSTRAP, ownerId, excessiveDuration))
         .isInstanceOf(org.springframework.dao.InvalidDataAccessApiUsageException.class)
         .hasCauseInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("5 minutes");

--- a/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryIT.java
@@ -204,9 +204,10 @@ class InstallationTrustRepositoryIT extends AbstractIntegrationTest {
             .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
             .orElseThrow();
     installSuppressedActivationTrigger();
+    var publication = publication();
 
     try {
-      assertThatThrownBy(() -> repository.publishInitial(lease, publication()))
+      assertThatThrownBy(() -> repository.publishInitial(lease, publication))
           .isInstanceOf(InstallationTrustException.class)
           .hasMessageContaining("publication");
       assertThat(repository.findInitialized()).isEmpty();

--- a/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/repositories/streaming/trust/InstallationTrustRepositoryIT.java
@@ -1,0 +1,489 @@
+package com.streamarr.server.repositories.streaming.trust;
+
+import static com.streamarr.server.jooq.generated.tables.TranscodeActiveTrustBundle.TRANSCODE_ACTIVE_TRUST_BUNDLE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeCaSigningLease.TRANSCODE_CA_SIGNING_LEASE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeInstallation.TRANSCODE_INSTALLATION;
+import static com.streamarr.server.jooq.generated.tables.TranscodePublicTrustBundle.TRANSCODE_PUBLIC_TRUST_BUNDLE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeTrustCertificate.TRANSCODE_TRUST_CERTIFICATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation;
+import com.streamarr.server.jooq.generated.enums.TranscodeTrustCertificateKind;
+import com.streamarr.server.services.streaming.trust.BuiltInCertificateAuthority;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityOperation;
+import com.streamarr.server.services.streaming.trust.InitialTrustPublication;
+import com.streamarr.server.services.streaming.trust.InstallationTrustException;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Installation Trust Repository Integration Tests")
+class InstallationTrustRepositoryIT extends AbstractIntegrationTest {
+
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(30);
+
+  @Autowired private InstallationTrustRepository repository;
+  @Autowired private CertificateAuthoritySigningLeaseRepository signingLeaseRepository;
+  @Autowired private DSLContext dsl;
+
+  @BeforeEach
+  void resetTrustState() {
+    dsl.update(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION, (Long) null)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.ACTIVATED_AT, (OffsetDateTime) null)
+        .execute();
+    dsl.update(TRANSCODE_INSTALLATION)
+        .set(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256, (byte[]) null)
+        .set(TRANSCODE_INSTALLATION.INITIALIZED_AT, (OffsetDateTime) null)
+        .execute();
+    dsl.deleteFrom(TRANSCODE_TRUST_CERTIFICATE).execute();
+    dsl.deleteFrom(TRANSCODE_PUBLIC_TRUST_BUNDLE).execute();
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OPERATION, (TranscodeCaSigningOperation) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID, (UUID) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, (OffsetDateTime) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH, 0L)
+        .execute();
+  }
+
+  @Test
+  @DisplayName("Should refuse initial publication under a non-bootstrap signing lease")
+  void shouldRefuseInitialPublicationUnderNonBootstrapSigningLease() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.ISSUANCE, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    var publication = publication();
+
+    var published = repository.publishInitial(lease, publication);
+
+    assertThat(published).isFalse();
+    assertThat(repository.findInitialized()).isEmpty();
+    assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isZero();
+    assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isZero();
+  }
+
+  @Test
+  @DisplayName("Should reject stored certificate when digest does not match exact DER")
+  void shouldRejectStoredCertificateWhenDigestDoesNotMatchExactDer() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThat(repository.publishInitial(lease, publication())).isTrue();
+    dsl.update(TRANSCODE_TRUST_CERTIFICATE)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_SHA256, new byte[32])
+        .where(TRANSCODE_TRUST_CERTIFICATE.KIND.eq(TranscodeTrustCertificateKind.TRUST_ANCHOR))
+        .execute();
+
+    assertThatThrownBy(repository::findInitialized)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("digest");
+  }
+
+  @Test
+  @DisplayName("Should reject stored certificate when bytes are not canonical DER")
+  void shouldRejectStoredCertificateWhenBytesAreNotCanonicalDer() throws Exception {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThat(repository.publishInitial(lease, publication())).isTrue();
+    var certificateDer =
+        dsl.select(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER)
+            .from(TRANSCODE_TRUST_CERTIFICATE)
+            .where(TRANSCODE_TRUST_CERTIFICATE.KIND.eq(TranscodeTrustCertificateKind.ISSUER))
+            .fetchSingle(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER);
+    var nonCanonicalDer = Arrays.copyOf(certificateDer, certificateDer.length + 1);
+    dsl.update(TRANSCODE_TRUST_CERTIFICATE)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER, nonCanonicalDer)
+        .set(
+            TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_SHA256,
+            MessageDigest.getInstance("SHA-256").digest(nonCanonicalDer))
+        .where(TRANSCODE_TRUST_CERTIFICATE.KIND.eq(TranscodeTrustCertificateKind.ISSUER))
+        .execute();
+
+    assertThatThrownBy(repository::findInitialized)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("canonical DER");
+  }
+
+  @Test
+  @DisplayName("Should reject initial bundle when a certificate has a nonzero ordinal")
+  void shouldRejectInitialBundleWhenCertificateHasNonzeroOrdinal() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThat(repository.publishInitial(lease, publication())).isTrue();
+    dsl.update(TRANSCODE_TRUST_CERTIFICATE)
+        .set(TRANSCODE_TRUST_CERTIFICATE.ORDINAL, (short) 1)
+        .where(TRANSCODE_TRUST_CERTIFICATE.KIND.eq(TranscodeTrustCertificateKind.ISSUER))
+        .execute();
+
+    assertThatThrownBy(repository::findInitialized)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("role and ordinal");
+  }
+
+  @Test
+  @DisplayName("Should reject initial bundle when a required certificate role is missing")
+  void shouldRejectInitialBundleWhenRequiredCertificateRoleIsMissing() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThat(repository.publishInitial(lease, publication())).isTrue();
+    dsl.deleteFrom(TRANSCODE_TRUST_CERTIFICATE)
+        .where(TRANSCODE_TRUST_CERTIFICATE.KIND.eq(TranscodeTrustCertificateKind.REVOCATION_SIGNER))
+        .execute();
+
+    assertThatThrownBy(repository::findInitialized)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("exact certificate roles");
+  }
+
+  @Test
+  @DisplayName("Should reject partially initialized trust state through typed boundary")
+  void shouldRejectPartiallyInitializedTrustStateThroughTypedBoundary() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThat(repository.publishInitial(lease, publication())).isTrue();
+    dsl.update(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION, (Long) null)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.ACTIVATED_AT, (OffsetDateTime) null)
+        .execute();
+
+    assertThatThrownBy(repository::findInitialized)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("partially initialized");
+  }
+
+  @Test
+  @DisplayName("Should reject initialized state when root fingerprint does not match trust anchor")
+  void shouldRejectInitializedStateWhenRootFingerprintDoesNotMatchTrustAnchor() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    assertThat(repository.publishInitial(lease, publication())).isTrue();
+    dsl.update(TRANSCODE_INSTALLATION)
+        .set(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256, new byte[32])
+        .execute();
+
+    assertThatThrownBy(repository::findInitialized)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("root fingerprint");
+  }
+
+  @Test
+  @DisplayName("Should roll back every trust row when final publication write loses")
+  void shouldRollBackEveryTrustRowWhenFinalPublicationWriteLoses() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    installSuppressedActivationTrigger();
+
+    try {
+      assertThatThrownBy(() -> repository.publishInitial(lease, publication()))
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("publication");
+      assertThat(repository.findInitialized()).isEmpty();
+      assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isZero();
+      assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isZero();
+      assertThat(
+              dsl.select(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256)
+                  .from(TRANSCODE_INSTALLATION)
+                  .fetchSingle(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256))
+          .isNull();
+      assertThat(
+              dsl.select(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION)
+                  .from(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+                  .fetchSingle(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION))
+          .isNull();
+    } finally {
+      removeSuppressedActivationTrigger();
+    }
+  }
+
+  @Test
+  @DisplayName("Should refuse publication when lease expires while waiting for its row lock")
+  void shouldRefusePublicationWhenLeaseExpiresWhileWaitingForItsRowLock() throws Exception {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    var publication = publication();
+    var expiresAt = repository.databaseTime().plusSeconds(2);
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, expiresAt.atOffset(ZoneOffset.UTC))
+        .execute();
+
+    var rowLocked = new CountDownLatch(1);
+    var releaseRow = new CountDownLatch(1);
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var blocker =
+          executor.submit(
+              () ->
+                  dsl.transaction(
+                      configuration -> {
+                        DSL.using(configuration)
+                            .selectOne()
+                            .from(TRANSCODE_CA_SIGNING_LEASE)
+                            .where(TRANSCODE_CA_SIGNING_LEASE.SINGLETON.isTrue())
+                            .forUpdate()
+                            .fetchSingle();
+                        rowLocked.countDown();
+                        releaseRow.await();
+                      }));
+      assertThat(rowLocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+      var publisher = executor.submit(() -> repository.publishInitial(lease, publication));
+      try {
+        awaitTableReadBlocked("transcode_ca_signing_lease", "Signing lease");
+        awaitDatabaseTime(expiresAt);
+      } finally {
+        releaseRow.countDown();
+      }
+
+      assertThat(publisher.get(5, TimeUnit.SECONDS)).isFalse();
+      blocker.get(5, TimeUnit.SECONDS);
+    }
+    assertThat(repository.findInitialized()).isEmpty();
+    assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isZero();
+    assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isZero();
+  }
+
+  @Test
+  @DisplayName("Should roll back publication when lease expires during final write")
+  void shouldRollBackPublicationWhenLeaseExpiresDuringFinalWrite() {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    var publication = publication();
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(
+            TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL,
+            repository.databaseTime().plusSeconds(2).atOffset(ZoneOffset.UTC))
+        .execute();
+    installDelayedActivationTrigger();
+
+    try {
+      assertThatThrownBy(() -> repository.publishInitial(lease, publication))
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("lease expired");
+      assertThat(repository.findInitialized()).isEmpty();
+      assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isZero();
+      assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isZero();
+    } finally {
+      removeDelayedActivationTrigger();
+    }
+  }
+
+  @Test
+  @DisplayName("Should read one coherent trust snapshot while active bundle is replaced")
+  void shouldReadOneCoherentTrustSnapshotWhileActiveBundleIsReplaced() throws Exception {
+    var lease =
+        signingLeaseRepository
+            .tryAcquire(CertificateAuthorityOperation.BOOTSTRAP, UUID.randomUUID(), LEASE_DURATION)
+            .orElseThrow();
+    var publication = publication();
+    assertThat(repository.publishInitial(lease, publication)).isTrue();
+
+    var tableLocked = new CountDownLatch(1);
+    var replaceBundle = new CountDownLatch(1);
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      var replacement =
+          executor.submit(
+              () ->
+                  dsl.transaction(
+                      configuration -> {
+                        var transaction = DSL.using(configuration);
+                        transaction.execute(
+                            "LOCK TABLE transcode_trust_certificate IN ACCESS EXCLUSIVE MODE");
+                        tableLocked.countDown();
+                        replaceBundle.await();
+                        replaceActiveBundle(transaction, publication);
+                      }));
+      assertThat(tableLocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+      var reader = executor.submit(repository::findInitialized);
+      try {
+        awaitCertificateReadBlocked();
+      } finally {
+        replaceBundle.countDown();
+      }
+
+      var observed = reader.get(5, TimeUnit.SECONDS).orElseThrow();
+      replacement.get(5, TimeUnit.SECONDS);
+      assertThat(observed.activeBundle().version()).isIn(1L, 2L);
+      assertThat(observed.activeBundle().trustAnchors()).hasSize(1);
+      assertThat(observed.activeBundle().issuers()).hasSize(1);
+      assertThat(observed.activeBundle().revocationSigners()).hasSize(1);
+    }
+  }
+
+  private InitialTrustPublication publication() {
+    var material =
+        new BuiltInCertificateAuthority()
+            .create(repository.installationId(), repository.databaseTime());
+    return InitialTrustPublication.from(material);
+  }
+
+  private void awaitDatabaseTime(Instant expected) {
+    while (repository.databaseTime().isBefore(expected)) {
+      LockSupport.parkNanos(Duration.ofMillis(1).toNanos());
+    }
+  }
+
+  private void awaitCertificateReadBlocked() {
+    awaitTableReadBlocked("transcode_trust_certificate", "Trust certificate");
+  }
+
+  private void awaitTableReadBlocked(String tableName, String description) {
+    var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (System.nanoTime() < deadline) {
+      var blocked =
+          dsl.fetchExists(
+              DSL.selectOne()
+                  .from(DSL.table(DSL.name("pg_catalog", "pg_stat_activity")))
+                  .where(DSL.field(DSL.name("wait_event_type"), String.class).eq("Lock"))
+                  .and(DSL.field(DSL.name("query"), String.class).contains(tableName)));
+      if (blocked) {
+        return;
+      }
+      LockSupport.parkNanos(Duration.ofMillis(1).toNanos());
+    }
+    throw new AssertionError(description + " read did not block on the database lock");
+  }
+
+  private void replaceActiveBundle(DSLContext transaction, InitialTrustPublication publication) {
+    transaction
+        .insertInto(TRANSCODE_PUBLIC_TRUST_BUNDLE)
+        .set(TRANSCODE_PUBLIC_TRUST_BUNDLE.INSTALLATION_ID, publication.installationId())
+        .set(TRANSCODE_PUBLIC_TRUST_BUNDLE.VERSION, 2L)
+        .execute();
+    insertCertificate(transaction, publication, TranscodeTrustCertificateKind.TRUST_ANCHOR);
+    insertCertificate(transaction, publication, TranscodeTrustCertificateKind.ISSUER);
+    insertCertificate(transaction, publication, TranscodeTrustCertificateKind.REVOCATION_SIGNER);
+    transaction
+        .update(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION, 2L)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.ACTIVATED_AT, DSL.currentOffsetDateTime())
+        .execute();
+    transaction
+        .deleteFrom(TRANSCODE_TRUST_CERTIFICATE)
+        .where(TRANSCODE_TRUST_CERTIFICATE.BUNDLE_VERSION.eq(1L))
+        .execute();
+    transaction
+        .deleteFrom(TRANSCODE_PUBLIC_TRUST_BUNDLE)
+        .where(TRANSCODE_PUBLIC_TRUST_BUNDLE.VERSION.eq(1L))
+        .execute();
+  }
+
+  private void insertCertificate(
+      DSLContext transaction,
+      InitialTrustPublication publication,
+      TranscodeTrustCertificateKind kind) {
+    var certificateDer =
+        switch (kind) {
+          case TRUST_ANCHOR -> publication.rootCertificateDer();
+          case ISSUER -> publication.issuerCertificateDer();
+          case REVOCATION_SIGNER -> publication.revocationSignerCertificateDer();
+        };
+    transaction
+        .insertInto(TRANSCODE_TRUST_CERTIFICATE)
+        .set(TRANSCODE_TRUST_CERTIFICATE.INSTALLATION_ID, publication.installationId())
+        .set(TRANSCODE_TRUST_CERTIFICATE.BUNDLE_VERSION, 2L)
+        .set(TRANSCODE_TRUST_CERTIFICATE.KIND, kind)
+        .set(TRANSCODE_TRUST_CERTIFICATE.ORDINAL, (short) 0)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER, certificateDer)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_SHA256, sha256(certificateDer))
+        .execute();
+  }
+
+  private byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void installSuppressedActivationTrigger() {
+    dsl.execute(
+        """
+        CREATE FUNCTION suppress_initial_trust_activation() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        BEGIN
+          RETURN NULL;
+        END
+        $$
+        """);
+    dsl.execute(
+        """
+        CREATE TRIGGER suppress_initial_trust_activation
+        BEFORE UPDATE ON transcode_active_trust_bundle
+        FOR EACH ROW
+        WHEN (NEW.bundle_version IS NOT NULL)
+        EXECUTE FUNCTION suppress_initial_trust_activation()
+        """);
+  }
+
+  private void removeSuppressedActivationTrigger() {
+    dsl.execute(
+        "DROP TRIGGER IF EXISTS suppress_initial_trust_activation "
+            + "ON transcode_active_trust_bundle");
+    dsl.execute("DROP FUNCTION IF EXISTS suppress_initial_trust_activation()");
+  }
+
+  private void installDelayedActivationTrigger() {
+    dsl.execute(
+        """
+        CREATE FUNCTION delay_initial_trust_activation() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        BEGIN
+          PERFORM pg_sleep(3);
+          RETURN NEW;
+        END
+        $$
+        """);
+    dsl.execute(
+        """
+        CREATE TRIGGER delay_initial_trust_activation
+        BEFORE UPDATE ON transcode_active_trust_bundle
+        FOR EACH ROW
+        WHEN (NEW.bundle_version IS NOT NULL)
+        EXECUTE FUNCTION delay_initial_trust_activation()
+        """);
+  }
+
+  private void removeDelayedActivationTrigger() {
+    dsl.execute(
+        "DROP TRIGGER IF EXISTS delay_initial_trust_activation "
+            + "ON transcode_active_trust_bundle");
+    dsl.execute("DROP FUNCTION IF EXISTS delay_initial_trust_activation()");
+  }
+}


### PR DESCRIPTION
## Summary

- Load public installation trust only when certificate roles, canonical DER, digests, ordinals, and the root fingerprint form one coherent state.
- Publish the initial public bundle atomically under the exact live bootstrap lease.
- Coordinate bootstrap, issuance, and rotation with database-clock leases and monotonically increasing fencing epochs.

## Why

Public trust must fail closed when durable state is partial or malformed, and a stale signing leader must never publish after losing its lease. This slice establishes those persistence guarantees without activating trust bootstrap at startup.

## Validation

- Exercised concurrent acquisition, renewal, release, lease expiry while waiting on locks, and stale or mismatched lease identities.
- Verified malformed and partial trust state is rejected rather than projected.
- Verified initial publication is atomic and rolls back when the final singleton or fencing check fails.
