### PR TITLE
Bootstrap installation trust for distributed mode

### DIFF
--- a/docs/adr/0018-direct-fenced-worker-control.adoc
+++ b/docs/adr/0018-direct-fenced-worker-control.adoc
@@ -8,7 +8,7 @@ Accepted
 
 * Streamarr still executes every transcode in the media-server process through `PlaybackTranscodeJobService`, the application-owned `TranscodeWorkerPort`, `LocalTranscodeWorkerAdapter`, and the extracted `LocalTranscodeEngine`.
 * The former rendition-at-a-time, process-shaped `TranscodeExecutor` and its process-handle state have been removed from the server application.
-* The server now contains inert trust-material primitives for the P-256 root, issuer, dedicated revocation signer, exact certificate-profile validation, and durable owner-only PKCS#12 storage. No certificate-authority bootstrap, signing lease, enrolled remote worker, worker listener, registration path, or distributed playback route is enabled yet.
+* The server now persists versioned public installation trust and uses a database-clock, epoch-fenced singleton lease for certificate-authority operations. When distributed mode is explicitly enabled, startup eagerly creates or loads the durable owner-only PKCS#12 authority, publishes or verifies its exact public projection, and fails closed on missing or mismatched material. No enrolled remote worker, worker listener, registration path, or distributed playback route is enabled yet.
 * The completed local extraction introduced the application boundary without introducing a remote transport.
 * The generated-only `streamarr-transcode-contract` module defines the versioned worker transport and compatibility gates. The narrow worker executable depends on it and the engine; the server still depends on neither the contract nor the worker.
 * The worker packages Boot's official gRPC server and shaded Netty, but its unenrolled configuration disables the server, reflection, health service, health scheduler, and all application executors. It exposes no control service until the trust and enrollment slice can enable one with valid credentials.
@@ -211,7 +211,7 @@ The first bootstrap node creates one installation-scoped CA secret at a dedicate
 Every control-plane replica mounts that same secret, verifies it against the recorded fingerprint, and refuses distributed startup on a missing or mismatched root; replicas never generate independent authorities.
 The private CA key is never stored in PostgreSQL, logged, exported through the API, reused for JWT signing, or copied to a worker.
 Backups of distributed configuration must include this secret; losing it requires explicitly re-enrolling workers under a new trust domain.
-Certificate issuance and issuer/root rotation use a PostgreSQL-backed singleton leadership lease so only one replica performs signing transitions at a time.
+Certificate issuance and issuer/root rotation use a PostgreSQL-backed singleton leadership lease that assigns one current operation epoch and fences every public-state commit.
 
 The built-in authority is one PKCS#12 file containing fixed root, issuer, and revocation-signer aliases and their chains.
 Its empty PKCS#12 protection value is not presented as encryption: a POSIX owner-only directory and a regular file created as `0600` and thereafter required to retain only owner permission bits, both owned by the process's effective numeric user id, are the at-rest security boundary, avoiding a fixed or adjacent password that would add no independent protection.
@@ -227,7 +227,22 @@ Initial publication writes and forces a same-directory temporary inode, then ato
 A newly created secure container is forced through its ancestor before any secret is written; ordinary loads need only traverse that ancestor.
 Before publication, the prepared container is read back and its root SPIFFE trust domain must match the material's declared installation id.
 Every successful load forces the containing directory, so the creator, a publication-race loser, and a post-crash adopter all establish the final name's durability before returning; storage that cannot provide directory `fsync` fails closed.
-The following bootstrap slice will publish database state only after that file is durable, recover a crash between file and database commits by adopting the exact file, and fail closed when database state has a missing or mismatched file.
+Database publication occurs only after that file is durable.
+A crash between file publication and the database commit is recovered by adopting the exact mounted file; initialized database state with a missing or mismatched file fails distributed startup and is never silently replaced.
+PostgreSQL stores only the installation id, root fingerprint, versioned public certificate DER and digests, active-bundle pointer, and signing-leadership state -- never private key material.
+Initial reads require one canonical trust anchor, issuer, and revocation signer at ordinal zero, verify each stored digest, and require the root fingerprint to match the exact trust-anchor DER.
+
+One singleton lease assigns the current bootstrap, issuance, or rotation epoch across control-plane replicas.
+Work may overlap after a lease expires, but exact epoch checks prevent stale work from committing public state.
+Acquisition and renewal lock the singleton row before reading a fresh PostgreSQL clock value; every lease carries its operation, owner, monotonically increasing fencing epoch, database time, and expiry.
+Initial publication accepts only an exact live `BOOTSTRAP` lease, locks and rechecks it with the database clock before completing, and rolls back every public row when any final singleton transition loses.
+Signing and file I/O remain outside database transactions.
+The default signing lease is thirty seconds and cannot exceed five minutes; the bootstrap leadership retry deadline defaults to two minutes and configuration rejects values above ten minutes.
+
+`streaming.distributed.enabled` currently enables trust preparation only.
+It requires an absolute persistent `ca-secret-path`; absent distributed configuration remains inert and does not inspect storage, poll PostgreSQL, create a secret, or start a transport resource.
+This is a non-user-ready intermediate until P5-B adds rotation: the initial revocation signer expires thirty days after issuance, and any later distributed-enabled startup rejects it as expired.
+Distributed playback remains separately gated until the command lifecycle and topology-A segment plane are complete.
 
 The root, online issuing intermediate, and revocation signer use P-256 and `SHA256withECDSA`.
 All three use distinct keys, exact critical and non-critical extension sets, and validated SKI/AKI linkage from each child to its issuer.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -126,12 +126,15 @@ link:adr/0018-direct-fenced-worker-control.adoc[ADR 0018] accepts an optional di
 control plane, but the current implementation remains local-only and opens no worker listener.
 A narrow worker executable now packages the engine, protobuf contract, and shaded gRPC runtime;
 until enrollment lands, its server, reflection, health service, health scheduler, and all executors
-are disabled. The control plane now has inert P-256 installation trust-material generation,
-exact certificate-profile, identity, and key-separation validation, and durable owner-only PKCS#12
-storage primitives. Application startup does not invoke those primitives yet; bootstrap,
-versioned public persistence, and database-clock-fenced signing leadership land in following trust
-slices. The media-server artifact contains neither the worker nor its protobuf contract, so an
-ordinary local installation still gains no distributed transport runtime resource.
+are disabled. The control plane now has P-256 installation trust-material generation, exact
+certificate-profile validation, durable owner-only PKCS#12 storage, versioned public-trust
+persistence, and database-clock-fenced signing leadership. Explicitly enabling distributed mode
+eagerly creates or verifies that authority before startup completes; this currently prepares trust
+only and does not enable remote playback. Until P5-B adds certificate rotation, this is a
+non-user-ready intermediate whose startup fails closed if its thirty-day revocation signer has
+expired. With distributed configuration absent, the trust runtime is inert. The media-server
+artifact contains neither the worker nor its protobuf contract, so an ordinary local installation
+still gains no distributed transport runtime resource.
 The extraction preserves the local path as the default:
 
 ----

--- a/streamarr-server/src/main/java/com/streamarr/server/config/DistributedTranscodeProperties.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/config/DistributedTranscodeProperties.java
@@ -1,0 +1,65 @@
+package com.streamarr.server.config;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "streaming.distributed")
+public record DistributedTranscodeProperties(
+    boolean enabled, String caSecretPath, Duration signingLease, Duration bootstrapTimeout) {
+
+  private static final Duration MAXIMUM_SIGNING_LEASE = Duration.ofMinutes(5);
+  private static final Duration MAXIMUM_BOOTSTRAP_TIMEOUT = Duration.ofMinutes(10);
+
+  public DistributedTranscodeProperties {
+    if (caSecretPath == null) {
+      caSecretPath = "";
+    }
+    if (signingLease == null) {
+      signingLease = Duration.ofSeconds(30);
+    }
+    if (bootstrapTimeout == null) {
+      bootstrapTimeout = Duration.ofMinutes(2);
+    }
+
+    if (enabled) {
+      validateOperationalDurations(signingLease, bootstrapTimeout);
+    }
+  }
+
+  private static void validateOperationalDurations(
+      Duration signingLease, Duration bootstrapTimeout) {
+    if (signingLease.isZero() || signingLease.isNegative()) {
+      throw new IllegalArgumentException("Certificate authority signing lease must be positive");
+    }
+    if (signingLease.getNano() % 1_000 != 0) {
+      throw new IllegalArgumentException(
+          "Certificate authority signing lease must use microsecond precision");
+    }
+    if (bootstrapTimeout.isZero() || bootstrapTimeout.isNegative()) {
+      throw new IllegalArgumentException("Installation trust bootstrap timeout must be positive");
+    }
+    if (signingLease.compareTo(MAXIMUM_SIGNING_LEASE) > 0) {
+      throw new IllegalArgumentException(
+          "Certificate authority signing lease must not exceed 5 minutes");
+    }
+    if (bootstrapTimeout.compareTo(MAXIMUM_BOOTSTRAP_TIMEOUT) > 0) {
+      throw new IllegalArgumentException(
+          "Installation trust bootstrap timeout must not exceed 10 minutes");
+    }
+  }
+
+  public Path requiredCaSecretPath() {
+    if (caSecretPath.isBlank()) {
+      throw new IllegalArgumentException("Distributed transcoding requires a CA secret path");
+    }
+    var path = Path.of(caSecretPath);
+    if (!path.isAbsolute()) {
+      throw new IllegalArgumentException(
+          "Distributed transcoding requires an absolute CA secret path");
+    }
+    return path;
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/config/DistributedTrustConfiguration.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/config/DistributedTrustConfiguration.java
@@ -1,0 +1,53 @@
+package com.streamarr.server.config;
+
+import com.streamarr.server.repositories.streaming.trust.CertificateAuthoritySigningLeaseRepository;
+import com.streamarr.server.repositories.streaming.trust.InstallationTrustRepository;
+import com.streamarr.server.services.streaming.trust.BuiltInCertificateAuthority;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityStore;
+import com.streamarr.server.services.streaming.trust.InstallationTrust;
+import com.streamarr.server.services.streaming.trust.InstallationTrustBootstrapService;
+import java.util.UUID;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(DistributedTranscodeProperties.class)
+@ConditionalOnProperty(prefix = "streaming.distributed", name = "enabled", havingValue = "true")
+public class DistributedTrustConfiguration {
+
+  @Bean
+  public CertificateAuthorityStore certificateAuthorityStore(
+      DistributedTranscodeProperties properties) {
+    return new CertificateAuthorityStore(properties.requiredCaSecretPath());
+  }
+
+  @Bean
+  public BuiltInCertificateAuthority builtInCertificateAuthority() {
+    return new BuiltInCertificateAuthority();
+  }
+
+  @Bean
+  public InstallationTrustBootstrapService installationTrustBootstrapService(
+      InstallationTrustRepository trustRepository,
+      CertificateAuthoritySigningLeaseRepository signingLeaseRepository,
+      CertificateAuthorityStore authorityStore,
+      BuiltInCertificateAuthority certificateAuthority,
+      DistributedTranscodeProperties properties) {
+    return InstallationTrustBootstrapService.builder()
+        .trustRepository(trustRepository)
+        .signingLeaseRepository(signingLeaseRepository)
+        .authorityStore(authorityStore)
+        .certificateAuthority(certificateAuthority)
+        .ownerId(UUID.randomUUID())
+        .leaseDuration(properties.signingLease())
+        .bootstrapTimeout(properties.bootstrapTimeout())
+        .build();
+  }
+
+  @Bean
+  public InstallationTrust installationTrust(InstallationTrustBootstrapService bootstrapService) {
+    return bootstrapService.bootstrap();
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthority.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthority.java
@@ -5,7 +5,9 @@ import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
@@ -52,6 +54,36 @@ public final class BuiltInCertificateAuthority {
   public void validate(
       CertificateAuthorityMaterial material, UUID installationId, Instant databaseTime) {
     new CertificateAuthorityValidator().validate(material, installationId, databaseTime);
+  }
+
+  void requireMatches(InstallationTrust trust, CertificateAuthorityMaterial material) {
+    try {
+      var rootDer = material.rootCertificate().getEncoded();
+      if (!trust.installationId().equals(material.installationId())) {
+        throw new InstallationTrustException(
+            "Stored installation trust belongs to another installation");
+      }
+      if (!MessageDigest.isEqual(trust.bootstrapRootSha256(), sha256(rootDer))) {
+        throw new InstallationTrustException(
+            "Stored installation trust root fingerprint does not match the authority secret");
+      }
+
+      var bundle = trust.activeBundle();
+      if (bundle.version() != 1L) {
+        throw new InstallationTrustException(
+            "Stored public trust bundle has an unsupported initial version");
+      }
+      if (!bundle.installationId().equals(material.installationId())
+          || !matches(bundle.trustAnchors(), rootDer)
+          || !matches(bundle.issuers(), material.issuerCertificate().getEncoded())
+          || !matches(
+              bundle.revocationSigners(), material.revocationSignerCertificate().getEncoded())) {
+        throw new InstallationTrustException(
+            "Stored public trust bundle does not match the authority secret");
+      }
+    } catch (CertificateEncodingException e) {
+      throw new InstallationTrustException("Failed to compare installation trust certificates", e);
+    }
   }
 
   public CertificateAuthorityMaterial create(UUID installationId, Instant issuedAt) {
@@ -205,6 +237,20 @@ public final class BuiltInCertificateAuthority {
     var generator = KeyPairGenerator.getInstance("EC");
     generator.initialize(new ECGenParameterSpec("secp256r1"), secureRandom);
     return generator.generateKeyPair();
+  }
+
+  private static boolean matches(java.util.List<X509Certificate> certificates, byte[] expected)
+      throws CertificateEncodingException {
+    return certificates.size() == 1
+        && MessageDigest.isEqual(certificates.getFirst().getEncoded(), expected);
+  }
+
+  private static byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is unavailable", e);
+    }
   }
 
   private BigInteger positiveSerial() {

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapService.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapService.java
@@ -1,0 +1,175 @@
+package com.streamarr.server.services.streaming.trust;
+
+import com.streamarr.server.repositories.streaming.trust.CertificateAuthoritySigningLeaseRepository;
+import com.streamarr.server.repositories.streaming.trust.InstallationTrustRepository;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public final class InstallationTrustBootstrapService {
+
+  private static final Duration DEFAULT_BOOTSTRAP_TIMEOUT = Duration.ofMinutes(2);
+  private static final Duration INITIAL_RETRY_INTERVAL = Duration.ofMillis(100);
+  private static final Duration MAXIMUM_RETRY_INTERVAL = Duration.ofSeconds(1);
+
+  interface BootstrapTiming {
+
+    long nanoTime();
+
+    void parkNanos(long nanoseconds);
+  }
+
+  private static final BootstrapTiming SYSTEM_TIMING =
+      new BootstrapTiming() {
+        @Override
+        public long nanoTime() {
+          return System.nanoTime();
+        }
+
+        @Override
+        public void parkNanos(long nanoseconds) {
+          LockSupport.parkNanos(nanoseconds);
+        }
+      };
+
+  private final InstallationTrustRepository trustRepository;
+  private final CertificateAuthoritySigningLeaseRepository signingLeaseRepository;
+  private final CertificateAuthorityStore authorityStore;
+  private final BuiltInCertificateAuthority certificateAuthority;
+  private final UUID ownerId;
+  private final Duration leaseDuration;
+  private final Duration bootstrapTimeout;
+  private final BootstrapTiming timing;
+
+  public InstallationTrust bootstrap() {
+    requireNotInterrupted();
+    requirePositiveLeaseDuration();
+    var runtimeTiming = timing == null ? SYSTEM_TIMING : timing;
+    var timeoutNanos = bootstrapTimeoutNanos();
+    var startedAt = runtimeTiming.nanoTime();
+    var retryIntervalNanos = INITIAL_RETRY_INTERVAL.toNanos();
+
+    while (runtimeTiming.nanoTime() - startedAt < timeoutNanos) {
+      var initialized = loadInitialized();
+      requireNotInterrupted();
+      if (initialized.isPresent()) {
+        return initialized.orElseThrow();
+      }
+
+      var lease =
+          signingLeaseRepository.tryAcquire(
+              CertificateAuthorityOperation.BOOTSTRAP, ownerId, leaseDuration);
+      if (lease.isPresent()) {
+        var bootstrapped =
+            bootstrapWithLease(
+                lease.orElseThrow(), () -> runtimeTiming.nanoTime() - startedAt >= timeoutNanos);
+        if (bootstrapped.isPresent()) {
+          return bootstrapped.orElseThrow();
+        }
+      }
+
+      requireNotInterrupted();
+      var elapsed = runtimeTiming.nanoTime() - startedAt;
+      var remaining = timeoutNanos - elapsed;
+      if (remaining <= 0) {
+        break;
+      }
+      runtimeTiming.parkNanos(Math.min(retryIntervalNanos, remaining));
+      requireNotInterrupted();
+      retryIntervalNanos = Math.min(retryIntervalNanos * 2, MAXIMUM_RETRY_INTERVAL.toNanos());
+    }
+
+    throw new InstallationTrustException(
+        "Installation trust bootstrap did not obtain signing leadership");
+  }
+
+  private Optional<InstallationTrust> bootstrapWithLease(
+      CertificateSigningLease lease, BooleanSupplier deadlineExceeded) {
+    try {
+      requireNotInterrupted();
+      if (deadlineExceeded.getAsBoolean()) {
+        return Optional.empty();
+      }
+      var initialized = loadInitialized();
+      if (initialized.isPresent()) {
+        return initialized;
+      }
+      if (deadlineExceeded.getAsBoolean()) {
+        return Optional.empty();
+      }
+
+      var installationId = trustRepository.installationId();
+      var material =
+          authorityStore
+              .load()
+              .orElseGet(
+                  () ->
+                      authorityStore.createIfAbsent(
+                          certificateAuthority.create(installationId, lease.databaseTime())));
+      certificateAuthority.validate(material, installationId, trustRepository.databaseTime());
+      requireNotInterrupted();
+
+      if (!trustRepository.publishInitial(lease, InitialTrustPublication.from(material))) {
+        return loadInitialized();
+      }
+      return Optional.of(
+          loadInitialized()
+              .orElseThrow(
+                  () ->
+                      new InstallationTrustException(
+                          "Installation trust publication committed no active bundle")));
+    } finally {
+      signingLeaseRepository.release(lease);
+    }
+  }
+
+  private Optional<InstallationTrust> loadInitialized() {
+    return trustRepository
+        .findInitialized()
+        .map(
+            trust -> {
+              var material =
+                  authorityStore
+                      .load()
+                      .orElseThrow(
+                          () ->
+                              new InstallationTrustException(
+                                  "Initialized installation certificate authority secret is missing"));
+              certificateAuthority.validate(
+                  material, trust.installationId(), trustRepository.databaseTime());
+              certificateAuthority.requireMatches(trust, material);
+              return trust;
+            });
+  }
+
+  private void requirePositiveLeaseDuration() {
+    if (leaseDuration.isZero() || leaseDuration.isNegative()) {
+      throw new IllegalArgumentException("Certificate authority signing lease must be positive");
+    }
+  }
+
+  private long bootstrapTimeoutNanos() {
+    var timeout = bootstrapTimeout == null ? DEFAULT_BOOTSTRAP_TIMEOUT : bootstrapTimeout;
+    if (timeout.isZero() || timeout.isNegative()) {
+      throw new IllegalArgumentException("Installation trust bootstrap timeout must be positive");
+    }
+    try {
+      return timeout.toNanos();
+    } catch (ArithmeticException e) {
+      throw new IllegalArgumentException("Installation trust bootstrap timeout is too large", e);
+    }
+  }
+
+  private void requireNotInterrupted() {
+    if (Thread.currentThread().isInterrupted()) {
+      throw new InstallationTrustException("Installation trust bootstrap was interrupted");
+    }
+  }
+}

--- a/streamarr-server/src/main/resources/application.yml
+++ b/streamarr-server/src/main/resources/application.yml
@@ -50,6 +50,11 @@ streaming:
   transcode-startup-timeout: ${STREAMING_TRANSCODE_STARTUP_TIMEOUT:30s}
   session-retention: ${STREAMING_SESSION_RETENTION:24h}
   segment-base-path: ${STREAMING_SEGMENT_BASE_PATH:}
+  distributed:
+    enabled: ${STREAMING_DISTRIBUTED_ENABLED:false}
+    ca-secret-path: ${STREAMING_DISTRIBUTED_CA_SECRET_PATH:}
+    signing-lease: ${STREAMING_DISTRIBUTED_SIGNING_LEASE:30s}
+    bootstrap-timeout: ${STREAMING_DISTRIBUTED_BOOTSTRAP_TIMEOUT:2m}
   watch-progress:
     min-played-percent: ${STREAMING_WATCH_PROGRESS_MIN_RESUME_PERCENT:5.0}
     max-played-percent: ${STREAMING_WATCH_PROGRESS_MAX_RESUME_PERCENT:90.0}

--- a/streamarr-server/src/test/java/com/streamarr/server/config/DistributedTrustConfigurationTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/config/DistributedTrustConfigurationTest.java
@@ -1,0 +1,262 @@
+package com.streamarr.server.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.server.repositories.streaming.trust.CertificateAuthoritySigningLeaseRepository;
+import com.streamarr.server.repositories.streaming.trust.InstallationTrustRepository;
+import com.streamarr.server.services.streaming.trust.BuiltInCertificateAuthority;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityMaterial;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityOperation;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityStore;
+import com.streamarr.server.services.streaming.trust.CertificateAuthorityStoreException;
+import com.streamarr.server.services.streaming.trust.CertificateSigningLease;
+import com.streamarr.server.services.streaming.trust.InitialTrustPublication;
+import com.streamarr.server.services.streaming.trust.InstallationTrust;
+import com.streamarr.server.services.streaming.trust.InstallationTrustBootstrapService;
+import com.streamarr.server.services.streaming.trust.InstallationTrustException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@Tag("UnitTest")
+@DisplayName("Distributed Trust Configuration Tests")
+class DistributedTrustConfigurationTest {
+
+  @TempDir Path directory;
+
+  @Test
+  @DisplayName("Should create no trust runtime or secret when distributed mode is disabled")
+  void shouldCreateNoTrustRuntimeOrSecretWhenDistributedModeDisabled() {
+    var secret = directory.resolve("authority.p12");
+    var runner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(
+                DistributedTrustConfiguration.class, ApplicationPropertyBinding.class)
+            .withPropertyValues(
+                "streaming.distributed.ca-secret-path=" + secret,
+                "streaming.distributed.signing-lease=0s",
+                "streaming.distributed.bootstrap-timeout=0s");
+
+    runner.run(
+        context -> {
+          assertThat(context)
+              .doesNotHaveBean(InstallationTrust.class)
+              .doesNotHaveBean(InstallationTrustBootstrapService.class)
+              .doesNotHaveBean(CertificateAuthorityStore.class)
+              .doesNotHaveBean(BuiltInCertificateAuthority.class)
+              .doesNotHaveBean(CertificateAuthorityMaterial.class);
+          assertThat(secret).doesNotExist();
+        });
+  }
+
+  @EnableConfigurationProperties(DistributedTranscodeProperties.class)
+  static class ApplicationPropertyBinding {}
+
+  @Test
+  @DisplayName("Should reject distributed mode without a certificate authority path")
+  void shouldRejectDistributedModeWithoutCertificateAuthorityPath() {
+    var properties =
+        new DistributedTranscodeProperties(true, "", Duration.ofSeconds(30), Duration.ofMinutes(2));
+
+    assertThat(org.assertj.core.api.Assertions.catchThrowable(properties::requiredCaSecretPath))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("CA secret path");
+  }
+
+  @Test
+  @DisplayName("Should reject a relative certificate authority path")
+  void shouldRejectRelativeCertificateAuthorityPath() {
+    var properties =
+        new DistributedTranscodeProperties(
+            true, "authority.p12", Duration.ofSeconds(30), Duration.ofMinutes(2));
+
+    assertThatThrownBy(properties::requiredCaSecretPath)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("absolute");
+  }
+
+  @Test
+  @DisplayName("Should reject parent traversal in the configured certificate authority path")
+  void shouldRejectParentTraversalInConfiguredCertificateAuthorityPath() {
+    var properties =
+        new DistributedTranscodeProperties(
+            true,
+            directory.resolve("safe/../trust/authority.p12").toString(),
+            Duration.ofSeconds(30),
+            Duration.ofMinutes(2));
+    var secretPath = properties.requiredCaSecretPath();
+
+    assertThatThrownBy(() -> new CertificateAuthorityStore(secretPath))
+        .isInstanceOf(CertificateAuthorityStoreException.class)
+        .hasMessageContaining("parent traversal");
+  }
+
+  @Test
+  @DisplayName("Should use independent defaults for signing lease and bootstrap timeout")
+  void shouldUseIndependentDefaultsForSigningLeaseAndBootstrapTimeout() {
+    var properties = new DistributedTranscodeProperties(false, null, null, null);
+
+    assertThat(properties.signingLease()).isEqualTo(Duration.ofSeconds(30));
+    assertThat(properties.bootstrapTimeout()).isEqualTo(Duration.ofMinutes(2));
+  }
+
+  @Test
+  @DisplayName("Should reject a non-positive bootstrap timeout")
+  void shouldRejectNonPositiveBootstrapTimeout() {
+    var secretPath = directory.resolve("authority.p12").toString();
+    var signingLease = Duration.ofSeconds(30);
+
+    assertThatThrownBy(
+            () -> new DistributedTranscodeProperties(true, secretPath, signingLease, Duration.ZERO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bootstrap timeout");
+  }
+
+  @Test
+  @DisplayName("Should reject a signing lease below database time precision")
+  void shouldRejectSigningLeaseBelowDatabaseTimePrecision() {
+    var secretPath = directory.resolve("authority.p12").toString();
+    var subMicrosecondLease = Duration.ofSeconds(30).plusNanos(1);
+    var bootstrapTimeout = Duration.ofMinutes(2);
+
+    assertThatThrownBy(
+            () ->
+                new DistributedTranscodeProperties(
+                    true, secretPath, subMicrosecondLease, bootstrapTimeout))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("microsecond");
+  }
+
+  @Test
+  @DisplayName("Should reject distributed trust durations beyond operational bounds")
+  void shouldRejectDistributedTrustDurationsBeyondOperationalBounds() {
+    var secretPath = directory.resolve("authority.p12").toString();
+    var excessiveSigningLease = Duration.ofMinutes(5).plusSeconds(1);
+    var excessiveBootstrapTimeout = Duration.ofMinutes(10).plusSeconds(1);
+    var signingLease = Duration.ofSeconds(30);
+    var bootstrapTimeout = Duration.ofMinutes(2);
+
+    assertThatThrownBy(
+            () ->
+                new DistributedTranscodeProperties(
+                    true, secretPath, excessiveSigningLease, bootstrapTimeout))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("signing lease")
+        .hasMessageContaining("5 minutes");
+    assertThatThrownBy(
+            () ->
+                new DistributedTranscodeProperties(
+                    true, secretPath, signingLease, excessiveBootstrapTimeout))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bootstrap timeout")
+        .hasMessageContaining("10 minutes");
+  }
+
+  @Test
+  @DisplayName("Should fail startup eagerly when enabled bootstrap cannot obtain leadership")
+  void shouldFailStartupEagerlyWhenEnabledBootstrapCannotObtainLeadership() {
+    var secret = directory.resolve("trust/authority.p12");
+    var runner =
+        runnerWithUnavailableTrustBoundaries()
+            .withPropertyValues(
+                "streaming.distributed.enabled=true",
+                "streaming.distributed.ca-secret-path=" + secret,
+                "streaming.distributed.bootstrap-timeout=50ms");
+
+    runner.run(
+        context -> {
+          assertThat(context).hasFailed();
+          assertThat(context.getStartupFailure())
+              .rootCause()
+              .isInstanceOf(InstallationTrustException.class)
+              .hasMessageContaining("did not obtain signing leadership");
+          assertThat(secret).doesNotExist();
+        });
+  }
+
+  @Test
+  @DisplayName("Should fail enabled startup without a certificate authority path")
+  void shouldFailEnabledStartupWithoutCertificateAuthorityPath() {
+    var runner =
+        runnerWithUnavailableTrustBoundaries()
+            .withPropertyValues("streaming.distributed.enabled=true");
+
+    runner.run(
+        context -> {
+          assertThat(context).hasFailed();
+          assertThat(context.getStartupFailure())
+              .rootCause()
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessageContaining("CA secret path");
+        });
+  }
+
+  private ApplicationContextRunner runnerWithUnavailableTrustBoundaries() {
+    return new ApplicationContextRunner()
+        .withUserConfiguration(DistributedTrustConfiguration.class)
+        .withBean(InstallationTrustRepository.class, EmptyInstallationTrustRepository::new)
+        .withBean(
+            CertificateAuthoritySigningLeaseRepository.class,
+            UnavailableSigningLeaseRepository::new);
+  }
+
+  private static final class EmptyInstallationTrustRepository
+      implements InstallationTrustRepository {
+
+    @Override
+    public UUID installationId() {
+      return UUID.fromString("6c758b20-bf6c-4970-a5db-c9b012b24cbf");
+    }
+
+    @Override
+    public Instant databaseTime() {
+      return Instant.parse("2026-07-12T12:00:00Z");
+    }
+
+    @Override
+    public Optional<InstallationTrust> findInitialized() {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean publishInitial(
+        CertificateSigningLease lease, InitialTrustPublication publication) {
+      return false;
+    }
+  }
+
+  private static final class UnavailableSigningLeaseRepository
+      implements CertificateAuthoritySigningLeaseRepository {
+
+    @Override
+    public Optional<CertificateSigningLease> tryAcquire(
+        CertificateAuthorityOperation operation, UUID ownerId, Duration duration) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<CertificateSigningLease> renew(
+        CertificateSigningLease currentLease, Duration duration) {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean isCurrent(CertificateSigningLease lease) {
+      return false;
+    }
+
+    @Override
+    public boolean release(CertificateSigningLease lease) {
+      return false;
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthorityMatchTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/BuiltInCertificateAuthorityMatchTest.java
@@ -1,0 +1,104 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.MessageDigest;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Built-in Certificate Authority Trust Matching Tests")
+class BuiltInCertificateAuthorityMatchTest {
+
+  private static final UUID INSTALLATION_ID =
+      UUID.fromString("f097da43-35bf-4a7f-9916-3a9241ef3e38");
+  private static final Instant ISSUED_AT = Instant.parse("2026-07-12T12:00:00Z");
+
+  private BuiltInCertificateAuthority authority;
+  private CertificateAuthorityMaterial material;
+
+  @BeforeEach
+  void createAuthorityMaterial() {
+    authority = new BuiltInCertificateAuthority();
+    material = authority.create(INSTALLATION_ID, ISSUED_AT);
+  }
+
+  @Test
+  @DisplayName("Should accept the exact initial public trust projection")
+  void shouldAcceptExactInitialPublicTrustProjection() {
+    var trust = trust(trustBundleBuilder());
+
+    assertThatCode(() -> authority.requireMatches(trust, material)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("Should reject a non-initial bundle before rotation is supported")
+  void shouldRejectNonInitialBundleBeforeRotationIsSupported() {
+    var trust = trust(trustBundleBuilder().version(2L));
+
+    assertThatThrownBy(() -> authority.requireMatches(trust, material))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("version");
+  }
+
+  @Test
+  @DisplayName("Should reject a substituted certificate in the public trust projection")
+  void shouldRejectSubstitutedCertificateInPublicTrustProjection() {
+    var foreign = authority.create(INSTALLATION_ID, ISSUED_AT);
+    var trust = trust(trustBundleBuilder().issuers(List.of(foreign.issuerCertificate())));
+
+    assertThatThrownBy(() -> authority.requireMatches(trust, material))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("public trust bundle");
+  }
+
+  @Test
+  @DisplayName("Should reject a missing certificate role in the public trust projection")
+  void shouldRejectMissingCertificateRoleInPublicTrustProjection() {
+    var trust = trust(trustBundleBuilder().issuers(List.of()));
+
+    assertThatThrownBy(() -> authority.requireMatches(trust, material))
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("public trust bundle");
+  }
+
+  private InstallationTrust trust(PublicTrustBundle.PublicTrustBundleBuilder bundleBuilder) {
+    var bundle = bundleBuilder.build();
+    var root = bundle.trustAnchors().getFirst();
+    return new InstallationTrust(INSTALLATION_ID, sha256(encoded(root)), bundle);
+  }
+
+  private PublicTrustBundle.PublicTrustBundleBuilder trustBundleBuilder() {
+    return PublicTrustBundle.builder()
+        .installationId(INSTALLATION_ID)
+        .version(1L)
+        .createdAt(ISSUED_AT)
+        .trustAnchors(List.of(material.rootCertificate()))
+        .issuers(List.of(material.issuerCertificate()))
+        .revocationSigners(List.of(material.revocationSignerCertificate()));
+  }
+
+  private static byte[] encoded(X509Certificate certificate) {
+    try {
+      return certificate.getEncoded();
+    } catch (CertificateEncodingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapIT.java
@@ -1,0 +1,277 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static com.streamarr.server.jooq.generated.tables.TranscodeActiveTrustBundle.TRANSCODE_ACTIVE_TRUST_BUNDLE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeCaSigningLease.TRANSCODE_CA_SIGNING_LEASE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeInstallation.TRANSCODE_INSTALLATION;
+import static com.streamarr.server.jooq.generated.tables.TranscodePublicTrustBundle.TRANSCODE_PUBLIC_TRUST_BUNDLE;
+import static com.streamarr.server.jooq.generated.tables.TranscodeTrustCertificate.TRANSCODE_TRUST_CERTIFICATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.server.AbstractIntegrationTest;
+import com.streamarr.server.jooq.generated.enums.TranscodeCaSigningOperation;
+import com.streamarr.server.jooq.generated.enums.TranscodeTrustCertificateKind;
+import com.streamarr.server.repositories.streaming.trust.CertificateAuthoritySigningLeaseRepository;
+import com.streamarr.server.repositories.streaming.trust.InstallationTrustRepository;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.MessageDigest;
+import java.security.cert.CertificateExpiredException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Tag("IntegrationTest")
+@DisplayName("Installation Trust Bootstrap Integration Tests")
+class InstallationTrustBootstrapIT extends AbstractIntegrationTest {
+
+  private static final Duration LEASE_DURATION = Duration.ofSeconds(5);
+
+  @Autowired private InstallationTrustRepository trustRepository;
+  @Autowired private CertificateAuthoritySigningLeaseRepository signingLeaseRepository;
+  @Autowired private DSLContext dsl;
+
+  @TempDir Path directory;
+
+  private Path secretPath;
+
+  @BeforeEach
+  void resetTrustAuthority() throws Exception {
+    secretPath = directory.resolve("authority.p12");
+    if (Files.getFileStore(directory).supportsFileAttributeView("posix")) {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"));
+    }
+    dsl.update(TRANSCODE_ACTIVE_TRUST_BUNDLE)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.BUNDLE_VERSION, (Long) null)
+        .set(TRANSCODE_ACTIVE_TRUST_BUNDLE.ACTIVATED_AT, (OffsetDateTime) null)
+        .execute();
+    dsl.update(TRANSCODE_INSTALLATION)
+        .set(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256, (byte[]) null)
+        .set(TRANSCODE_INSTALLATION.INITIALIZED_AT, (OffsetDateTime) null)
+        .execute();
+    dsl.deleteFrom(TRANSCODE_TRUST_CERTIFICATE).execute();
+    dsl.deleteFrom(TRANSCODE_PUBLIC_TRUST_BUNDLE).execute();
+    dsl.update(TRANSCODE_CA_SIGNING_LEASE)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OPERATION, (TranscodeCaSigningOperation) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.OWNER_ID, (UUID) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.LEASE_UNTIL, (OffsetDateTime) null)
+        .set(TRANSCODE_CA_SIGNING_LEASE.FENCING_EPOCH, 0L)
+        .execute();
+  }
+
+  @Test
+  @DisplayName("Should durably create one installation authority and public bundle")
+  void shouldDurablyCreateOneInstallationAuthorityAndPublicBundle() {
+    var trust = service(UUID.randomUUID()).bootstrap();
+
+    assertThat(Files.isRegularFile(secretPath)).isTrue();
+    assertThat(trust.installationId()).isEqualTo(trustRepository.installationId());
+    assertThat(trust.activeBundle().version()).isEqualTo(1L);
+    assertThat(trust.activeBundle().trustAnchors()).hasSize(1);
+    assertThat(trust.activeBundle().issuers()).hasSize(1);
+    assertThat(trust.activeBundle().revocationSigners()).hasSize(1);
+    assertThat(trust.bootstrapRootSha256()).hasSize(32);
+    assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isEqualTo(1);
+    assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isEqualTo(3);
+    assertThat(trustRepository.findInitialized()).contains(trust);
+    var deleteBundle = dsl.deleteFrom(TRANSCODE_PUBLIC_TRUST_BUNDLE);
+    assertThatThrownBy(deleteBundle::execute)
+        .isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
+    assertThat(
+            List.of(
+                    TRANSCODE_INSTALLATION,
+                    TRANSCODE_ACTIVE_TRUST_BUNDLE,
+                    TRANSCODE_PUBLIC_TRUST_BUNDLE,
+                    TRANSCODE_TRUST_CERTIFICATE,
+                    TRANSCODE_CA_SIGNING_LEASE)
+                .stream()
+                .flatMap(table -> table.fieldStream())
+                .map(field -> field.getName().toLowerCase(java.util.Locale.ROOT)))
+        .noneMatch(
+            name -> name.contains("private") || name.contains("token") || name.contains("secret"));
+  }
+
+  @Test
+  @DisplayName("Should converge on the same authority when replicas bootstrap concurrently")
+  void shouldConvergeOnSameAuthorityWhenReplicasBootstrapConcurrently() throws Exception {
+    var start = new CountDownLatch(1);
+    var trusts = new CopyOnWriteArrayList<InstallationTrust>();
+    var failures = new CopyOnWriteArrayList<Throwable>();
+    try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (var service : List.of(service(UUID.randomUUID()), service(UUID.randomUUID()))) {
+        executor.submit(
+            () -> {
+              start.await();
+              try {
+                trusts.add(service.bootstrap());
+              } catch (Throwable failure) {
+                failures.add(failure);
+              }
+              return null;
+            });
+      }
+      start.countDown();
+    }
+
+    assertThat(failures).isEmpty();
+    assertThat(trusts).hasSize(2).allMatch(trusts.getFirst()::equals);
+    assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isEqualTo(1);
+    assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("Should adopt a complete authority file after a lost database publication")
+  void shouldAdoptCompleteAuthorityFileAfterLostDatabasePublication() {
+    var material =
+        new BuiltInCertificateAuthority()
+            .create(trustRepository.installationId(), Instant.parse("2026-07-12T12:00:00Z"));
+    new CertificateAuthorityStore(secretPath).createIfAbsent(material);
+
+    var trust = service(UUID.randomUUID()).bootstrap();
+
+    assertThat(encoded(trust.activeBundle().trustAnchors().getFirst()))
+        .isEqualTo(encoded(material.rootCertificate()));
+    assertThat(trustRepository.findInitialized()).contains(trust);
+  }
+
+  @Test
+  @DisplayName("Should refuse an expired bootstrap authority before publication")
+  void shouldRefuseExpiredBootstrapAuthorityBeforePublication() {
+    var expired =
+        new BuiltInCertificateAuthority()
+            .create(
+                trustRepository.installationId(),
+                trustRepository.databaseTime().minus(Duration.ofDays(31)));
+    new CertificateAuthorityStore(secretPath).createIfAbsent(expired);
+    var bootstrapService = service(UUID.randomUUID());
+
+    assertThatThrownBy(bootstrapService::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasCauseInstanceOf(CertificateExpiredException.class);
+    assertThat(trustRepository.findInitialized()).isEmpty();
+    assertThat(dsl.fetchCount(TRANSCODE_PUBLIC_TRUST_BUNDLE)).isZero();
+    assertThat(dsl.fetchCount(TRANSCODE_TRUST_CERTIFICATE)).isZero();
+  }
+
+  @Test
+  @DisplayName("Should fail closed when initialized authority secret is missing")
+  void shouldFailClosedWhenInitializedAuthoritySecretMissing() throws Exception {
+    service(UUID.randomUUID()).bootstrap();
+    Files.delete(secretPath);
+    var bootstrapService = service(UUID.randomUUID());
+
+    assertThatThrownBy(bootstrapService::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("missing");
+    assertThat(secretPath).doesNotExist();
+  }
+
+  @Test
+  @DisplayName("Should reject an authority restored from another installation")
+  void shouldRejectAuthorityRestoredFromAnotherInstallation() throws Exception {
+    service(UUID.randomUUID()).bootstrap();
+    Files.delete(secretPath);
+    var foreign =
+        new BuiltInCertificateAuthority()
+            .create(UUID.fromString("872667d4-32d8-4624-b216-92788a966bd7"), Instant.now());
+    new CertificateAuthorityStore(secretPath).createIfAbsent(foreign);
+    var bootstrapService = service(UUID.randomUUID());
+
+    assertThatThrownBy(bootstrapService::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("installation");
+  }
+
+  @Test
+  @DisplayName("Should reject a substituted authority for the same installation")
+  void shouldRejectSubstitutedAuthorityForSameInstallation() throws Exception {
+    var original = service(UUID.randomUUID()).bootstrap();
+    Files.delete(secretPath);
+    var substitute =
+        new BuiltInCertificateAuthority()
+            .create(trustRepository.installationId(), trustRepository.databaseTime());
+    new CertificateAuthorityStore(secretPath).createIfAbsent(substitute);
+    var bootstrapService = service(UUID.randomUUID());
+
+    assertThatThrownBy(bootstrapService::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("fingerprint");
+    assertThat(trustRepository.findInitialized()).contains(original);
+  }
+
+  @Test
+  @DisplayName("Should reject a database fingerprint that no longer matches the mounted secret")
+  void shouldRejectDatabaseFingerprintThatNoLongerMatchesMountedSecret() {
+    service(UUID.randomUUID()).bootstrap();
+    dsl.update(TRANSCODE_INSTALLATION)
+        .set(TRANSCODE_INSTALLATION.BOOTSTRAP_ROOT_SHA256, new byte[32])
+        .execute();
+    var bootstrapService = service(UUID.randomUUID());
+
+    assertThatThrownBy(bootstrapService::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("fingerprint");
+  }
+
+  @Test
+  @DisplayName("Should reject a substituted public certificate on startup")
+  void shouldRejectSubstitutedPublicCertificateOnStartup() {
+    var original = service(UUID.randomUUID()).bootstrap();
+    var substitute =
+        new BuiltInCertificateAuthority()
+            .create(trustRepository.installationId(), trustRepository.databaseTime());
+    var substituteIssuer = encoded(substitute.issuerCertificate());
+    dsl.update(TRANSCODE_TRUST_CERTIFICATE)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_DER, substituteIssuer)
+        .set(TRANSCODE_TRUST_CERTIFICATE.CERTIFICATE_SHA256, sha256(substituteIssuer))
+        .where(TRANSCODE_TRUST_CERTIFICATE.KIND.eq(TranscodeTrustCertificateKind.ISSUER))
+        .execute();
+    var bootstrapService = service(UUID.randomUUID());
+
+    assertThat(trustRepository.findInitialized()).isPresent();
+    assertThatThrownBy(bootstrapService::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("public trust bundle");
+    assertThat(trustRepository.findInitialized()).isNotEqualTo(java.util.Optional.of(original));
+  }
+
+  private InstallationTrustBootstrapService service(UUID ownerId) {
+    return InstallationTrustBootstrapService.builder()
+        .trustRepository(trustRepository)
+        .signingLeaseRepository(signingLeaseRepository)
+        .authorityStore(new CertificateAuthorityStore(secretPath))
+        .certificateAuthority(new BuiltInCertificateAuthority())
+        .ownerId(ownerId)
+        .leaseDuration(LEASE_DURATION)
+        .build();
+  }
+
+  private static byte[] encoded(java.security.cert.X509Certificate certificate) {
+    try {
+      return certificate.getEncoded();
+    } catch (java.security.cert.CertificateEncodingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static byte[] sha256(byte[] value) {
+    try {
+      return MessageDigest.getInstance("SHA-256").digest(value);
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapIT.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapIT.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import org.jooq.DSLContext;
+import org.jooq.Fields;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -98,7 +99,7 @@ class InstallationTrustBootstrapIT extends AbstractIntegrationTest {
                     TRANSCODE_TRUST_CERTIFICATE,
                     TRANSCODE_CA_SIGNING_LEASE)
                 .stream()
-                .flatMap(table -> table.fieldStream())
+                .flatMap(Fields::fieldStream)
                 .map(field -> field.getName().toLowerCase(java.util.Locale.ROOT)))
         .noneMatch(
             name -> name.contains("private") || name.contains("token") || name.contains("secret"));

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapServiceTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/InstallationTrustBootstrapServiceTest.java
@@ -1,0 +1,525 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.streamarr.server.repositories.streaming.trust.CertificateAuthoritySigningLeaseRepository;
+import com.streamarr.server.repositories.streaming.trust.InstallationTrustRepository;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@Tag("UnitTest")
+@DisplayName("Installation Trust Bootstrap Service Tests")
+class InstallationTrustBootstrapServiceTest {
+
+  @TempDir Path directory;
+
+  @Test
+  @DisplayName("Should stop waiting at the bootstrap timeout independently of the signing lease")
+  void shouldStopWaitingAtBootstrapTimeoutIndependentlyOfSigningLease() {
+    var timing = new FakeBootstrapTiming();
+    var bootstrapTimeout = Duration.ofMillis(250);
+    var service = waitingServiceBuilder(timing).bootstrapTimeout(bootstrapTimeout).build();
+
+    assertThatThrownBy(service::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("did not obtain signing leadership");
+    assertThat(timing.elapsed()).isEqualTo(bootstrapTimeout);
+  }
+
+  @Test
+  @DisplayName("Should bound bootstrap waiting when no timeout is provided")
+  void shouldBoundBootstrapWaitingWhenNoTimeoutIsProvided() {
+    var timing = new FakeBootstrapTiming();
+    var service = waitingServiceBuilder(timing).build();
+
+    assertThatThrownBy(service::bootstrap).isInstanceOf(InstallationTrustException.class);
+
+    assertThat(timing.elapsed()).isEqualTo(Duration.ofMinutes(2));
+  }
+
+  @Test
+  @DisplayName("Should back off signing leadership retries while bootstrap waits")
+  void shouldBackOffSigningLeadershipRetriesWhileBootstrapWaits() {
+    var timing = new FakeBootstrapTiming();
+    var service = waitingServiceBuilder(timing).bootstrapTimeout(Duration.ofMillis(350)).build();
+
+    assertThatThrownBy(service::bootstrap).isInstanceOf(InstallationTrustException.class);
+
+    assertThat(timing.waits())
+        .containsExactly(Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(50));
+  }
+
+  @Test
+  @DisplayName("Should fail before reading trust state when bootstrap begins interrupted")
+  void shouldFailBeforeReadingTrustStateWhenBootstrapBeginsInterrupted() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository = new EmptyInstallationTrustRepository();
+    var service =
+        waitingServiceBuilder(timing, trustRepository)
+            .bootstrapTimeout(Duration.ofSeconds(1))
+            .build();
+
+    Thread.currentThread().interrupt();
+    try {
+      assertThatThrownBy(service::bootstrap)
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("interrupted");
+      assertThat(trustRepository.reads()).isZero();
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("Should report interruption that occurs during the final bootstrap wait")
+  void shouldReportInterruptionThatOccursDuringFinalBootstrapWait() {
+    var timing = new FakeBootstrapTiming();
+    timing.interruptOnNextWait();
+    var service = waitingServiceBuilder(timing).bootstrapTimeout(Duration.ofMillis(100)).build();
+
+    try {
+      assertThatThrownBy(service::bootstrap)
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("interrupted");
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("Should reject a non-positive bootstrap timeout before reading trust state")
+  void shouldRejectNonPositiveBootstrapTimeoutBeforeReadingTrustState() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository = new EmptyInstallationTrustRepository();
+    var service =
+        waitingServiceBuilder(timing, trustRepository).bootstrapTimeout(Duration.ZERO).build();
+
+    assertThatThrownBy(service::bootstrap)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bootstrap timeout");
+    assertThat(trustRepository.reads()).isZero();
+  }
+
+  @Test
+  @DisplayName("Should not wait again when a trust read exhausts the bootstrap timeout")
+  void shouldNotWaitAgainWhenTrustReadExhaustsBootstrapTimeout() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository =
+        new EmptyInstallationTrustRepository(() -> timing.advance(Duration.ofMillis(200)));
+    var service =
+        waitingServiceBuilder(timing, trustRepository)
+            .bootstrapTimeout(Duration.ofMillis(100))
+            .build();
+
+    assertThatThrownBy(service::bootstrap).isInstanceOf(InstallationTrustException.class);
+
+    assertThat(timing.waits()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Should not acquire leadership after a trust read is interrupted")
+  void shouldNotAcquireLeadershipAfterTrustReadIsInterrupted() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository =
+        new EmptyInstallationTrustRepository(() -> Thread.currentThread().interrupt());
+    var signingLeaseRepository = new UnavailableSigningLeaseRepository();
+    var service =
+        waitingServiceBuilder(timing, trustRepository, signingLeaseRepository)
+            .bootstrapTimeout(Duration.ofSeconds(1))
+            .build();
+
+    try {
+      assertThatThrownBy(service::bootstrap)
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("interrupted");
+      assertThat(signingLeaseRepository.acquisitionAttempts()).isZero();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("Should release leadership without side effects when acquisition is interrupted")
+  void shouldReleaseLeadershipWithoutSideEffectsWhenAcquisitionIsInterrupted() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository = new EmptyInstallationTrustRepository();
+    var signingLeaseRepository = new InterruptingSigningLeaseRepository();
+    var service =
+        waitingServiceBuilder(timing, trustRepository, signingLeaseRepository)
+            .bootstrapTimeout(Duration.ofSeconds(1))
+            .build();
+
+    try {
+      assertThatThrownBy(service::bootstrap)
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("interrupted");
+      assertThat(trustRepository.reads()).isEqualTo(1);
+      assertThat(signingLeaseRepository.releases()).isEqualTo(1);
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("Should not publish trust when authority validation is interrupted")
+  void shouldNotPublishTrustWhenAuthorityValidationIsInterrupted() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository = new InterruptingValidationTrustRepository();
+    var signingLeaseRepository = new AvailableSigningLeaseRepository();
+    var service =
+        waitingServiceBuilder(timing, trustRepository, signingLeaseRepository)
+            .bootstrapTimeout(Duration.ofSeconds(1))
+            .build();
+
+    try {
+      assertThatThrownBy(service::bootstrap)
+          .isInstanceOf(InstallationTrustException.class)
+          .hasMessageContaining("interrupted");
+      assertThat(trustRepository.publicationAttempted()).isFalse();
+      assertThat(signingLeaseRepository.releases()).isEqualTo(1);
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  @DisplayName("Should release leadership without side effects when acquisition exceeds timeout")
+  void shouldReleaseLeadershipWithoutSideEffectsWhenAcquisitionExceedsTimeout() {
+    var timing = new FakeBootstrapTiming();
+    var trustRepository = new EmptyInstallationTrustRepository();
+    var signingLeaseRepository = new SlowSigningLeaseRepository(timing);
+    var service =
+        waitingServiceBuilder(timing, trustRepository, signingLeaseRepository)
+            .bootstrapTimeout(Duration.ofSeconds(1))
+            .build();
+
+    assertThatThrownBy(service::bootstrap)
+        .isInstanceOf(InstallationTrustException.class)
+        .hasMessageContaining("did not obtain signing leadership");
+    assertThat(trustRepository.reads()).isEqualTo(1);
+    assertThat(signingLeaseRepository.releases()).isEqualTo(1);
+  }
+
+  private InstallationTrustBootstrapService.InstallationTrustBootstrapServiceBuilder
+      waitingServiceBuilder(InstallationTrustBootstrapService.BootstrapTiming timing) {
+    return waitingServiceBuilder(timing, new EmptyInstallationTrustRepository());
+  }
+
+  private InstallationTrustBootstrapService.InstallationTrustBootstrapServiceBuilder
+      waitingServiceBuilder(
+          InstallationTrustBootstrapService.BootstrapTiming timing,
+          InstallationTrustRepository trustRepository) {
+    return waitingServiceBuilder(timing, trustRepository, new UnavailableSigningLeaseRepository());
+  }
+
+  private InstallationTrustBootstrapService.InstallationTrustBootstrapServiceBuilder
+      waitingServiceBuilder(
+          InstallationTrustBootstrapService.BootstrapTiming timing,
+          InstallationTrustRepository trustRepository,
+          CertificateAuthoritySigningLeaseRepository signingLeaseRepository) {
+    return InstallationTrustBootstrapService.builder()
+        .trustRepository(trustRepository)
+        .signingLeaseRepository(signingLeaseRepository)
+        .authorityStore(new CertificateAuthorityStore(directory.resolve("trust/authority.p12")))
+        .certificateAuthority(new BuiltInCertificateAuthority())
+        .ownerId(UUID.randomUUID())
+        .leaseDuration(Duration.ofSeconds(30))
+        .timing(timing);
+  }
+
+  private static final class EmptyInstallationTrustRepository
+      implements InstallationTrustRepository {
+
+    private final Runnable onRead;
+    private int reads;
+
+    EmptyInstallationTrustRepository() {
+      this(() -> {});
+    }
+
+    EmptyInstallationTrustRepository(Runnable onRead) {
+      this.onRead = onRead;
+    }
+
+    @Override
+    public UUID installationId() {
+      throw new AssertionError("No lease holder may create installation trust");
+    }
+
+    @Override
+    public Instant databaseTime() {
+      throw new AssertionError("No lease holder may read signing time");
+    }
+
+    @Override
+    public Optional<InstallationTrust> findInitialized() {
+      reads++;
+      onRead.run();
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean publishInitial(
+        CertificateSigningLease lease, InitialTrustPublication publication) {
+      throw new AssertionError("No lease holder may publish installation trust");
+    }
+
+    int reads() {
+      return reads;
+    }
+  }
+
+  private static final class UnavailableSigningLeaseRepository
+      implements CertificateAuthoritySigningLeaseRepository {
+
+    private int acquisitionAttempts;
+
+    @Override
+    public Optional<CertificateSigningLease> tryAcquire(
+        CertificateAuthorityOperation operation, UUID ownerId, Duration duration) {
+      acquisitionAttempts++;
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<CertificateSigningLease> renew(
+        CertificateSigningLease currentLease, Duration duration) {
+      throw new AssertionError("An unavailable lease cannot be renewed");
+    }
+
+    @Override
+    public boolean isCurrent(CertificateSigningLease lease) {
+      return false;
+    }
+
+    @Override
+    public boolean release(CertificateSigningLease lease) {
+      throw new AssertionError("An unavailable lease cannot be released");
+    }
+
+    int acquisitionAttempts() {
+      return acquisitionAttempts;
+    }
+  }
+
+  private static final class InterruptingSigningLeaseRepository
+      implements CertificateAuthoritySigningLeaseRepository {
+
+    private int releases;
+
+    @Override
+    public Optional<CertificateSigningLease> tryAcquire(
+        CertificateAuthorityOperation operation, UUID ownerId, Duration duration) {
+      Thread.currentThread().interrupt();
+      var databaseTime = Instant.parse("2026-07-12T12:00:00Z");
+      return Optional.of(
+          CertificateSigningLease.builder()
+              .operation(operation)
+              .ownerId(ownerId)
+              .fencingEpoch(1L)
+              .databaseTime(databaseTime)
+              .leaseUntil(databaseTime.plus(duration))
+              .build());
+    }
+
+    @Override
+    public Optional<CertificateSigningLease> renew(
+        CertificateSigningLease currentLease, Duration duration) {
+      throw new AssertionError("Interrupted bootstrap cannot renew leadership");
+    }
+
+    @Override
+    public boolean isCurrent(CertificateSigningLease lease) {
+      return false;
+    }
+
+    @Override
+    public boolean release(CertificateSigningLease lease) {
+      releases++;
+      return true;
+    }
+
+    int releases() {
+      return releases;
+    }
+  }
+
+  private static final class InterruptingValidationTrustRepository
+      implements InstallationTrustRepository {
+
+    private static final UUID INSTALLATION_ID =
+        UUID.fromString("7ec27eaa-7a7c-418e-8bf2-f940ca21b7df");
+    private static final Instant DATABASE_TIME = Instant.parse("2026-07-12T12:00:00Z");
+
+    private boolean publicationAttempted;
+
+    @Override
+    public UUID installationId() {
+      return INSTALLATION_ID;
+    }
+
+    @Override
+    public Instant databaseTime() {
+      Thread.currentThread().interrupt();
+      return DATABASE_TIME;
+    }
+
+    @Override
+    public Optional<InstallationTrust> findInitialized() {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean publishInitial(
+        CertificateSigningLease lease, InitialTrustPublication publication) {
+      publicationAttempted = true;
+      return false;
+    }
+
+    boolean publicationAttempted() {
+      return publicationAttempted;
+    }
+  }
+
+  private static final class AvailableSigningLeaseRepository
+      implements CertificateAuthoritySigningLeaseRepository {
+
+    private static final Instant DATABASE_TIME = Instant.parse("2026-07-12T12:00:00Z");
+
+    private int releases;
+
+    @Override
+    public Optional<CertificateSigningLease> tryAcquire(
+        CertificateAuthorityOperation operation, UUID ownerId, Duration duration) {
+      return Optional.of(
+          CertificateSigningLease.builder()
+              .operation(operation)
+              .ownerId(ownerId)
+              .fencingEpoch(1L)
+              .databaseTime(DATABASE_TIME)
+              .leaseUntil(DATABASE_TIME.plus(duration))
+              .build());
+    }
+
+    @Override
+    public Optional<CertificateSigningLease> renew(
+        CertificateSigningLease currentLease, Duration duration) {
+      throw new AssertionError("Bootstrap does not renew its signing lease");
+    }
+
+    @Override
+    public boolean isCurrent(CertificateSigningLease lease) {
+      return true;
+    }
+
+    @Override
+    public boolean release(CertificateSigningLease lease) {
+      releases++;
+      return true;
+    }
+
+    int releases() {
+      return releases;
+    }
+  }
+
+  private static final class SlowSigningLeaseRepository
+      implements CertificateAuthoritySigningLeaseRepository {
+
+    private final FakeBootstrapTiming timing;
+    private int releases;
+
+    SlowSigningLeaseRepository(FakeBootstrapTiming timing) {
+      this.timing = timing;
+    }
+
+    @Override
+    public Optional<CertificateSigningLease> tryAcquire(
+        CertificateAuthorityOperation operation, UUID ownerId, Duration duration) {
+      timing.advance(Duration.ofSeconds(2));
+      var databaseTime = Instant.parse("2026-07-12T12:00:00Z");
+      return Optional.of(
+          CertificateSigningLease.builder()
+              .operation(operation)
+              .ownerId(ownerId)
+              .fencingEpoch(1L)
+              .databaseTime(databaseTime)
+              .leaseUntil(databaseTime.plus(duration))
+              .build());
+    }
+
+    @Override
+    public Optional<CertificateSigningLease> renew(
+        CertificateSigningLease currentLease, Duration duration) {
+      throw new AssertionError("Timed-out bootstrap cannot renew leadership");
+    }
+
+    @Override
+    public boolean isCurrent(CertificateSigningLease lease) {
+      return false;
+    }
+
+    @Override
+    public boolean release(CertificateSigningLease lease) {
+      releases++;
+      return true;
+    }
+
+    int releases() {
+      return releases;
+    }
+  }
+
+  private static final class FakeBootstrapTiming
+      implements InstallationTrustBootstrapService.BootstrapTiming {
+
+    private final List<Duration> waits = new ArrayList<>();
+    private boolean interruptOnNextWait;
+    private long now;
+
+    @Override
+    public long nanoTime() {
+      return now;
+    }
+
+    @Override
+    public void parkNanos(long nanoseconds) {
+      waits.add(Duration.ofNanos(nanoseconds));
+      now += nanoseconds;
+      if (interruptOnNextWait) {
+        interruptOnNextWait = false;
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    Duration elapsed() {
+      return Duration.ofNanos(now);
+    }
+
+    List<Duration> waits() {
+      return List.copyOf(waits);
+    }
+
+    void interruptOnNextWait() {
+      interruptOnNextWait = true;
+    }
+
+    void advance(Duration duration) {
+      now += duration.toNanos();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add opt-in distributed-transcoding configuration with bounded, database-compatible lease settings.
- Eagerly create or load durable PKCS#12 authority material, validate it against the public projection, and publish initial trust under a fenced lease.
- Keep the default local-only runtime inert and fail distributed startup closed when authority files or public trust disagree.
- Document the bootstrap, lease, timeout, and signer-expiry guarantees.

## Why

Distributed enrollment needs one durable installation identity before any worker can be trusted. Bootstrap must survive competing server replicas and restarts without exposing private key material or allowing stale leaders to publish.

## Validation

- Exercised first startup, restart, replica races, timeout and interruption paths, malformed configuration, and file/database mismatches.
- Verified disabled mode creates no trust runtime or secret and ignores unused distributed-only duration values.
- Verified substituted certificate hierarchies, expired revocation signers, unsafe paths, and post-validation interruption fail before public trust is committed.
