### PR TITLE
Validate exact worker certificate profiles

### DIFF
--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/EncodedWorkerCertificate.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/EncodedWorkerCertificate.java
@@ -1,0 +1,83 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class EncodedWorkerCertificate {
+
+  private static final int MAXIMUM_DER_LENGTH = 65_536;
+
+  private final byte[] der;
+
+  private EncodedWorkerCertificate(byte[] der) {
+    this.der = requireCanonicalDer(der);
+  }
+
+  public static EncodedWorkerCertificate fromDer(byte[] der) {
+    return new EncodedWorkerCertificate(der);
+  }
+
+  public byte[] der() {
+    return der.clone();
+  }
+
+  public Sha256Digest sha256() {
+    try {
+      return new Sha256Digest(MessageDigest.getInstance("SHA-256").digest(der));
+    } catch (java.security.NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is unavailable", e);
+    }
+  }
+
+  public X509Certificate x509Certificate() {
+    try {
+      return (X509Certificate)
+          CertificateFactory.getInstance("X.509")
+              .generateCertificate(new ByteArrayInputStream(der));
+    } catch (CertificateException e) {
+      throw new IllegalStateException("Validated worker certificate cannot be parsed", e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    return other instanceof EncodedWorkerCertificate that && Arrays.equals(der, that.der);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(der);
+  }
+
+  @Override
+  public String toString() {
+    return "EncodedWorkerCertificate[length=" + der.length + "]";
+  }
+
+  private static byte[] requireCanonicalDer(byte[] der) {
+    Objects.requireNonNull(der);
+    if (der.length == 0 || der.length > MAXIMUM_DER_LENGTH) {
+      throw new IllegalArgumentException(
+          "Worker certificate DER must contain between 1 and 65536 bytes");
+    }
+    try {
+      var input = new ByteArrayInputStream(der);
+      var certificate =
+          (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(input);
+      if (input.available() != 0 || !MessageDigest.isEqual(der, certificate.getEncoded())) {
+        throw new IllegalArgumentException("Worker certificate must use canonical X.509 DER");
+      }
+      return der.clone();
+    } catch (CertificateException e) {
+      throw new IllegalArgumentException("Worker certificate must contain valid X.509 DER", e);
+    }
+  }
+}

--- a/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/WorkerCertificateValidator.java
+++ b/streamarr-server/src/main/java/com/streamarr/server/services/streaming/trust/WorkerCertificateValidator.java
@@ -1,0 +1,195 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import javax.security.auth.x500.X500Principal;
+import lombok.Builder;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class WorkerCertificateValidator {
+
+  private static final String SHA256_WITH_ECDSA_OID = "1.2.840.10045.4.3.2";
+  private static final Set<String> CRITICAL_EXTENSIONS =
+      Set.of(
+          Extension.basicConstraints.getId(),
+          Extension.keyUsage.getId(),
+          Extension.extendedKeyUsage.getId());
+  private static final Set<String> NON_CRITICAL_EXTENSIONS =
+      Set.of(
+          Extension.subjectKeyIdentifier.getId(),
+          Extension.authorityKeyIdentifier.getId(),
+          Extension.subjectAlternativeName.getId());
+  private static final Set<String> EXTENDED_KEY_USAGE =
+      Set.of(KeyPurposeId.id_kp_clientAuth.getId(), KeyPurposeId.id_kp_serverAuth.getId());
+
+  public boolean matches(EncodedWorkerCertificate encodedCertificate, ValidationContext context) {
+    Objects.requireNonNull(encodedCertificate);
+    Objects.requireNonNull(context);
+    return switch (context.parameters().profile()) {
+      case V1 -> matchesV1(encodedCertificate.x509Certificate(), context);
+    };
+  }
+
+  private boolean matchesV1(X509Certificate certificate, ValidationContext context) {
+    return certificate.getVersion() == 3
+        && certificate.getIssuerUniqueID() == null
+        && certificate.getSubjectUniqueID() == null
+        && matchesFixedClaim(certificate, context)
+        && matchesNames(certificate, context)
+        && matchesIssuer(certificate, context)
+        && matchesExtensionSet(certificate, context);
+  }
+
+  private boolean matchesFixedClaim(X509Certificate certificate, ValidationContext context) {
+    var parameters = context.parameters();
+    return MessageDigest.isEqual(
+            certificate.getPublicKey().getEncoded(), context.subjectPublicKeyInfo().der())
+        && certificate.getSerialNumber().equals(parameters.serialNumber().value())
+        && certificate.getNotBefore().toInstant().equals(parameters.validity().notBefore())
+        && certificate.getNotAfter().toInstant().equals(parameters.validity().notAfter());
+  }
+
+  private boolean matchesNames(X509Certificate certificate, ValidationContext context) {
+    var expectedSubject = new X500Principal("CN=Streamarr Worker " + context.workerId());
+    if (!certificate.getSubjectX500Principal().equals(expectedSubject)) {
+      return false;
+    }
+    try {
+      var names = certificate.getSubjectAlternativeNames();
+      if (names == null || names.size() != 1) {
+        return false;
+      }
+      var name = names.iterator().next();
+      var expected =
+          URI.create(
+                  "spiffe://"
+                      + context.installationId()
+                      + "/streamarr/worker/"
+                      + context.workerId())
+              .toString();
+      return name.size() >= 2
+          && Integer.valueOf(6).equals(name.getFirst())
+          && expected.equals(name.get(1));
+    } catch (CertificateParsingException _) {
+      return false;
+    }
+  }
+
+  private boolean matchesIssuer(X509Certificate certificate, ValidationContext context) {
+    var issuer = context.issuer();
+    if (!SHA256_WITH_ECDSA_OID.equals(certificate.getSigAlgOID())
+        || !certificate.getIssuerX500Principal().equals(issuer.getSubjectX500Principal())
+        || !matchesIssuerDigest(issuer, context.parameters().issuerCertificateSha256())
+        || certificate.getNotBefore().before(issuer.getNotBefore())
+        || certificate.getNotAfter().after(issuer.getNotAfter())) {
+      return false;
+    }
+    try {
+      certificate.verify(issuer.getPublicKey());
+      return true;
+    } catch (GeneralSecurityException _) {
+      return false;
+    }
+  }
+
+  private boolean matchesIssuerDigest(X509Certificate issuer, Sha256Digest expected) {
+    try {
+      var actual =
+          new Sha256Digest(MessageDigest.getInstance("SHA-256").digest(issuer.getEncoded()));
+      return actual.equals(expected);
+    } catch (CertificateEncodingException | java.security.NoSuchAlgorithmException _) {
+      return false;
+    }
+  }
+
+  private boolean matchesExtensionSet(X509Certificate certificate, ValidationContext context) {
+    return CRITICAL_EXTENSIONS.equals(certificate.getCriticalExtensionOIDs())
+        && NON_CRITICAL_EXTENSIONS.equals(certificate.getNonCriticalExtensionOIDs())
+        && certificate.getBasicConstraints() == -1
+        && matchesKeyUsage(certificate.getKeyUsage())
+        && matchesExtendedKeyUsage(certificate)
+        && matchesSubjectKeyIdentifier(certificate)
+        && matchesAuthorityKeyIdentifier(certificate, context.issuer());
+  }
+
+  private boolean matchesKeyUsage(boolean[] keyUsage) {
+    if (keyUsage == null || keyUsage.length == 0 || !keyUsage[0]) {
+      return false;
+    }
+    for (var index = 1; index < keyUsage.length; index++) {
+      if (keyUsage[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean matchesExtendedKeyUsage(X509Certificate certificate) {
+    try {
+      var usage = certificate.getExtendedKeyUsage();
+      return usage != null
+          && usage.size() == EXTENDED_KEY_USAGE.size()
+          && EXTENDED_KEY_USAGE.equals(Set.copyOf(usage));
+    } catch (CertificateParsingException _) {
+      return false;
+    }
+  }
+
+  private boolean matchesSubjectKeyIdentifier(X509Certificate certificate) {
+    try {
+      var expected =
+          new JcaX509ExtensionUtils()
+              .createSubjectKeyIdentifier(certificate.getPublicKey())
+              .getEncoded();
+      return MessageDigest.isEqual(
+          expected, extensionPayload(certificate, Extension.subjectKeyIdentifier.getId()));
+    } catch (GeneralSecurityException | IOException | IllegalArgumentException _) {
+      return false;
+    }
+  }
+
+  private boolean matchesAuthorityKeyIdentifier(
+      X509Certificate certificate, X509Certificate issuer) {
+    try {
+      var expected = new JcaX509ExtensionUtils().createAuthorityKeyIdentifier(issuer).getEncoded();
+      return MessageDigest.isEqual(
+          expected, extensionPayload(certificate, Extension.authorityKeyIdentifier.getId()));
+    } catch (GeneralSecurityException | IOException | IllegalArgumentException _) {
+      return false;
+    }
+  }
+
+  private byte[] extensionPayload(X509Certificate certificate, String oid) {
+    return ASN1OctetString.getInstance(certificate.getExtensionValue(oid)).getOctets();
+  }
+
+  @Builder
+  public record ValidationContext(
+      UUID installationId,
+      UUID workerId,
+      SubjectPublicKeyInfo subjectPublicKeyInfo,
+      CertificateIssuanceParameters parameters,
+      X509Certificate issuer) {
+
+    public ValidationContext {
+      Objects.requireNonNull(installationId);
+      Objects.requireNonNull(workerId);
+      Objects.requireNonNull(subjectPublicKeyInfo);
+      Objects.requireNonNull(parameters);
+      Objects.requireNonNull(issuer);
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/EncodedWorkerCertificateTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/EncodedWorkerCertificateTest.java
@@ -1,0 +1,84 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Encoded Worker Certificate Tests")
+class EncodedWorkerCertificateTest {
+
+  @Test
+  @DisplayName("Should protect canonical certificate DER from caller mutation")
+  void shouldProtectCanonicalCertificateDerFromCallerMutation() throws Exception {
+    var source = certificateDer();
+    var expected = source.clone();
+    var certificate = EncodedWorkerCertificate.fromDer(source);
+    source[0] ^= 1;
+    var exposed = certificate.der();
+    exposed[0] ^= 1;
+
+    assertThat(certificate.der()).isEqualTo(expected);
+    assertThat(certificate.sha256().bytes())
+        .isEqualTo(MessageDigest.getInstance("SHA-256").digest(expected));
+    assertThat(certificate.x509Certificate().getEncoded()).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("Should compare encoded certificates by content without exposing DER")
+  void shouldCompareEncodedCertificatesByContentWithoutExposingDer() throws Exception {
+    var der = certificateDer();
+    var first = EncodedWorkerCertificate.fromDer(der);
+    var second = EncodedWorkerCertificate.fromDer(der.clone());
+    var different = EncodedWorkerCertificate.fromDer(certificateDer());
+
+    assertThat(first)
+        .isEqualTo(second)
+        .hasSameHashCodeAs(second)
+        .isNotEqualTo(different)
+        .isNotEqualTo("certificate")
+        .hasToString("EncodedWorkerCertificate[length=" + der.length + "]");
+    assertThat(first.equals(first)).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should reject missing or out-of-bounds certificate DER")
+  void shouldRejectMissingOrOutOfBoundsCertificateDer() {
+    assertThatNullPointerException().isThrownBy(() -> EncodedWorkerCertificate.fromDer(null));
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> EncodedWorkerCertificate.fromDer(new byte[0]))
+        .withMessage("Worker certificate DER must contain between 1 and 65536 bytes");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> EncodedWorkerCertificate.fromDer(new byte[65_537]))
+        .withMessage("Worker certificate DER must contain between 1 and 65536 bytes");
+  }
+
+  @Test
+  @DisplayName("Should reject invalid or noncanonical certificate DER")
+  void shouldRejectInvalidOrNoncanonicalCertificateDer() throws Exception {
+    var valid = certificateDer();
+    var trailing = Arrays.copyOf(valid, valid.length + 1);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> EncodedWorkerCertificate.fromDer(new byte[] {1}))
+        .withMessage("Worker certificate must contain valid X.509 DER");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> EncodedWorkerCertificate.fromDer(trailing))
+        .withMessage("Worker certificate must use canonical X.509 DER");
+  }
+
+  private byte[] certificateDer() throws Exception {
+    return new BuiltInCertificateAuthority()
+        .create(UUID.randomUUID(), Instant.parse("2026-01-01T00:00:00Z"))
+        .issuerCertificate()
+        .getEncoded();
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/WorkerCertificateTestFixture.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/WorkerCertificateTestFixture.java
@@ -1,0 +1,189 @@
+package com.streamarr.server.services.streaming.trust;
+
+import java.net.URI;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Builder;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+public final class WorkerCertificateTestFixture {
+
+  private WorkerCertificateTestFixture() {}
+
+  public static CertificateShape.CertificateShapeBuilder validShape(WorkerContext context)
+      throws Exception {
+    Objects.requireNonNull(context);
+    var extensionUtils = new JcaX509ExtensionUtils();
+    return CertificateShape.builder()
+        .context(context)
+        .issuerName(
+            new X500Name(
+                context
+                    .authorityMaterial()
+                    .issuerCertificate()
+                    .getSubjectX500Principal()
+                    .getName()))
+        .subjectName(new X500Name("CN=Streamarr Worker " + context.workerId()))
+        .subjectAlternativeNames(
+            new GeneralNames(
+                new GeneralName(
+                    GeneralName.uniformResourceIdentifier,
+                    URI.create(
+                            "spiffe://"
+                                + context.installationId()
+                                + "/streamarr/worker/"
+                                + context.workerId())
+                        .toString())))
+        .basicConstraints(new BasicConstraints(false))
+        .basicConstraintsCritical(true)
+        .keyUsage(new KeyUsage(KeyUsage.digitalSignature))
+        .keyUsageCritical(true)
+        .extendedKeyUsage(
+            new ExtendedKeyUsage(
+                new KeyPurposeId[] {KeyPurposeId.id_kp_clientAuth, KeyPurposeId.id_kp_serverAuth}))
+        .extendedKeyUsageCritical(true)
+        .subjectKeyIdentifier(extensionUtils.createSubjectKeyIdentifier(context.subjectPublicKey()))
+        .authorityKeyIdentifier(
+            extensionUtils.createAuthorityKeyIdentifier(
+                context.authorityMaterial().issuerCertificate()))
+        .signatureAlgorithm("SHA256withECDSA")
+        .additionalExtensions(List.of());
+  }
+
+  public static X509Certificate certificate(CertificateShape shape) throws Exception {
+    Objects.requireNonNull(shape);
+    var context = shape.context();
+    var parameters = context.parameters();
+    var builder =
+        new JcaX509v3CertificateBuilder(
+            shape.issuerName(),
+            parameters.serialNumber().value(),
+            Date.from(parameters.validity().notBefore()),
+            Date.from(parameters.validity().notAfter()),
+            shape.subjectName(),
+            context.subjectPublicKey());
+    if (shape.issuerUniqueId()) {
+      builder.setIssuerUniqueID(new boolean[] {true});
+    }
+    if (shape.subjectUniqueId()) {
+      builder.setSubjectUniqueID(new boolean[] {true});
+    }
+    addExtensions(builder, shape);
+    var signer =
+        new JcaContentSignerBuilder(shape.signatureAlgorithm())
+            .build(context.authorityMaterial().issuerPrivateKey());
+    return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+  }
+
+  private static void addExtensions(JcaX509v3CertificateBuilder builder, CertificateShape shape)
+      throws Exception {
+    if (shape.basicConstraints() != null) {
+      builder.addExtension(
+          Extension.basicConstraints, shape.basicConstraintsCritical(), shape.basicConstraints());
+    }
+    if (shape.keyUsage() != null) {
+      builder.addExtension(Extension.keyUsage, shape.keyUsageCritical(), shape.keyUsage());
+    }
+    if (shape.extendedKeyUsage() != null) {
+      builder.addExtension(
+          Extension.extendedKeyUsage, shape.extendedKeyUsageCritical(), shape.extendedKeyUsage());
+    }
+    if (shape.subjectKeyIdentifier() != null) {
+      builder.addExtension(
+          Extension.subjectKeyIdentifier,
+          shape.subjectKeyIdentifierCritical(),
+          shape.subjectKeyIdentifier());
+    }
+    if (shape.authorityKeyIdentifier() != null) {
+      builder.addExtension(
+          Extension.authorityKeyIdentifier,
+          shape.authorityKeyIdentifierCritical(),
+          shape.authorityKeyIdentifier());
+    }
+    if (shape.subjectAlternativeNames() != null) {
+      builder.addExtension(
+          Extension.subjectAlternativeName,
+          shape.subjectAlternativeNamesCritical(),
+          shape.subjectAlternativeNames());
+    }
+    for (var extension : shape.additionalExtensions()) {
+      builder.addExtension(extension.oid(), extension.critical(), extension.value());
+    }
+  }
+
+  @Builder
+  public record WorkerContext(
+      UUID installationId,
+      UUID workerId,
+      CertificateAuthorityMaterial authorityMaterial,
+      PublicKey subjectPublicKey,
+      CertificateIssuanceParameters parameters) {
+
+    public WorkerContext {
+      Objects.requireNonNull(installationId);
+      Objects.requireNonNull(workerId);
+      Objects.requireNonNull(authorityMaterial);
+      Objects.requireNonNull(subjectPublicKey);
+      Objects.requireNonNull(parameters);
+    }
+  }
+
+  @Builder(toBuilder = true)
+  public record CertificateShape(
+      WorkerContext context,
+      X500Name issuerName,
+      X500Name subjectName,
+      boolean issuerUniqueId,
+      boolean subjectUniqueId,
+      GeneralNames subjectAlternativeNames,
+      boolean subjectAlternativeNamesCritical,
+      BasicConstraints basicConstraints,
+      boolean basicConstraintsCritical,
+      KeyUsage keyUsage,
+      boolean keyUsageCritical,
+      ExtendedKeyUsage extendedKeyUsage,
+      boolean extendedKeyUsageCritical,
+      SubjectKeyIdentifier subjectKeyIdentifier,
+      boolean subjectKeyIdentifierCritical,
+      AuthorityKeyIdentifier authorityKeyIdentifier,
+      boolean authorityKeyIdentifierCritical,
+      String signatureAlgorithm,
+      List<AdditionalExtension> additionalExtensions) {
+
+    public CertificateShape {
+      Objects.requireNonNull(context);
+      Objects.requireNonNull(issuerName);
+      Objects.requireNonNull(subjectName);
+      Objects.requireNonNull(signatureAlgorithm);
+      additionalExtensions = List.copyOf(additionalExtensions);
+    }
+  }
+
+  public record AdditionalExtension(
+      ASN1ObjectIdentifier oid, boolean critical, ASN1Encodable value) {
+
+    public AdditionalExtension {
+      Objects.requireNonNull(oid);
+      Objects.requireNonNull(value);
+    }
+  }
+}

--- a/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/WorkerCertificateValidatorTest.java
+++ b/streamarr-server/src/test/java/com/streamarr/server/services/streaming/trust/WorkerCertificateValidatorTest.java
@@ -1,0 +1,485 @@
+package com.streamarr.server.services.streaming.trust;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@Tag("UnitTest")
+@DisplayName("Worker Certificate Validator Tests")
+class WorkerCertificateValidatorTest {
+
+  private final WorkerCertificateValidator validator = new WorkerCertificateValidator();
+
+  @Test
+  @DisplayName("Should accept exact worker certificate profile")
+  void shouldAcceptExactWorkerCertificateProfile() throws Exception {
+    var fixture = fixture();
+
+    var matches = validator.matches(encoded(fixture.shape()), fixture.validationContext());
+
+    assertThat(matches).isTrue();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate using unsupported signature algorithm")
+  void shouldRejectWorkerCertificateUsingUnsupportedSignatureAlgorithm() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(fixture.shape().toBuilder().signatureAlgorithm("SHA384withECDSA").build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with another issuer principal")
+  void shouldRejectWorkerCertificateWithAnotherIssuerPrincipal() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(fixture.shape().toBuilder().issuerName(new X500Name("CN=Another Issuer")).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate signed by another issuer key")
+  void shouldRejectWorkerCertificateSignedByAnotherIssuerKey() throws Exception {
+    var fixture = fixture();
+    var currentWorker = fixture.shape().context();
+    var rogueAuthority =
+        new BuiltInCertificateAuthority()
+            .create(
+                currentWorker.installationId(),
+                fixture.validationContext().parameters().validity().notBefore());
+    var rogueSigningContext =
+        WorkerCertificateTestFixture.WorkerContext.builder()
+            .installationId(currentWorker.installationId())
+            .workerId(currentWorker.workerId())
+            .authorityMaterial(rogueAuthority)
+            .subjectPublicKey(currentWorker.subjectPublicKey())
+            .parameters(currentWorker.parameters())
+            .build();
+    var certificate = encoded(fixture.shape().toBuilder().context(rogueSigningContext).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate when pinned issuer digest differs")
+  void shouldRejectWorkerCertificateWhenPinnedIssuerDigestDiffers() throws Exception {
+    var fixture = fixture();
+    var current = fixture.validationContext();
+    var currentParameters = current.parameters();
+    var mismatchedParameters =
+        CertificateIssuanceParameters.builder()
+            .issuerCertificateSha256(
+                new Sha256Digest(MessageDigest.getInstance("SHA-256").digest(new byte[] {1})))
+            .serialNumber(currentParameters.serialNumber())
+            .profile(currentParameters.profile())
+            .validity(currentParameters.validity())
+            .build();
+    var mismatchedContext =
+        WorkerCertificateValidator.ValidationContext.builder()
+            .installationId(current.installationId())
+            .workerId(current.workerId())
+            .subjectPublicKeyInfo(current.subjectPublicKeyInfo())
+            .parameters(mismatchedParameters)
+            .issuer(current.issuer())
+            .build();
+
+    var matches = validator.matches(encoded(fixture.shape()), mismatchedContext);
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate extending beyond issuer validity")
+  void shouldRejectWorkerCertificateExtendingBeyondIssuerValidity() throws Exception {
+    var fixture = fixture();
+    var validity = fixture.validationContext().parameters().validity();
+    var beyondIssuer =
+        new CertificateValidity(
+            validity.notBefore(),
+            fixture.validationContext().issuer().getNotAfter().toInstant().plusSeconds(1));
+    var outsideIssuer = withValidity(fixture, beyondIssuer);
+
+    var matches =
+        validator.matches(encoded(outsideIssuer.shape()), outsideIssuer.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate beginning before issuer validity")
+  void shouldRejectWorkerCertificateBeginningBeforeIssuerValidity() throws Exception {
+    var fixture = fixture();
+    var validity = fixture.validationContext().parameters().validity();
+    var beforeIssuer =
+        new CertificateValidity(
+            fixture.validationContext().issuer().getNotBefore().toInstant().minusSeconds(1),
+            validity.notAfter());
+    var outsideIssuer = withValidity(fixture, beforeIssuer);
+
+    var matches =
+        validator.matches(encoded(outsideIssuer.shape()), outsideIssuer.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate when not after differs from claim")
+  void shouldRejectWorkerCertificateWhenNotAfterDiffersFromClaim() throws Exception {
+    var fixture = fixture();
+    var expectedValidity = fixture.validationContext().parameters().validity();
+    var differentValidity =
+        new CertificateValidity(
+            expectedValidity.notBefore(), expectedValidity.notAfter().minusSeconds(1));
+    var differentCertificate = withValidity(fixture, differentValidity);
+
+    var matches =
+        validator.matches(encoded(differentCertificate.shape()), fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with another subject")
+  void shouldRejectWorkerCertificateWithAnotherSubject() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(fixture.shape().toBuilder().subjectName(new X500Name("CN=Another Worker")).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @ParameterizedTest
+  @EnumSource(SubjectAlternativeNameMismatch.class)
+  @DisplayName("Should reject worker certificate when subject alternative name is not exact")
+  void shouldRejectWorkerCertificateWhenSubjectAlternativeNameIsNotExact(
+      SubjectAlternativeNameMismatch mismatch) throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .subjectAlternativeNames(invalidSubjectAlternativeNames(fixture, mismatch))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with malformed subject alternative name")
+  void shouldRejectWorkerCertificateWithMalformedSubjectAlternativeName() throws Exception {
+    var fixture = fixture();
+    var malformedExtension =
+        new WorkerCertificateTestFixture.AdditionalExtension(
+            Extension.subjectAlternativeName, false, new DERUTF8String("malformed"));
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .subjectAlternativeNames(null)
+                .additionalExtensions(List.of(malformedExtension))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with subject unique identifier")
+  void shouldRejectWorkerCertificateWithSubjectUniqueIdentifier() throws Exception {
+    var fixture = fixture();
+    var certificate = encoded(fixture.shape().toBuilder().subjectUniqueId(true).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with issuer unique identifier")
+  void shouldRejectWorkerCertificateWithIssuerUniqueIdentifier() throws Exception {
+    var fixture = fixture();
+    var certificate = encoded(fixture.shape().toBuilder().issuerUniqueId(true).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with unexpected extension")
+  void shouldRejectWorkerCertificateWithUnexpectedExtension() throws Exception {
+    var fixture = fixture();
+    var extension =
+        new WorkerCertificateTestFixture.AdditionalExtension(
+            new ASN1ObjectIdentifier("1.3.6.1.4.1.55555.1"),
+            false,
+            new DERUTF8String("unexpected"));
+    var certificate =
+        encoded(fixture.shape().toBuilder().additionalExtensions(List.of(extension)).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate when required extension is not critical")
+  void shouldRejectWorkerCertificateWhenRequiredExtensionIsNotCritical() throws Exception {
+    var fixture = fixture();
+    var certificate = encoded(fixture.shape().toBuilder().keyUsageCritical(false).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with CA basic constraints")
+  void shouldRejectWorkerCertificateWithCaBasicConstraints() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(fixture.shape().toBuilder().basicConstraints(new BasicConstraints(true)).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with another key usage")
+  void shouldRejectWorkerCertificateWithAnotherKeyUsage() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .keyUsage(new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate without digital signature usage")
+  void shouldRejectWorkerCertificateWithoutDigitalSignatureUsage() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder().keyUsage(new KeyUsage(KeyUsage.keyEncipherment)).build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate missing client authentication usage")
+  void shouldRejectWorkerCertificateMissingClientAuthenticationUsage() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .extendedKeyUsage(new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with unexpected extended key usage")
+  void shouldRejectWorkerCertificateWithUnexpectedExtendedKeyUsage() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .extendedKeyUsage(
+                    new ExtendedKeyUsage(
+                        new KeyPurposeId[] {
+                          KeyPurposeId.id_kp_serverAuth, KeyPurposeId.id_kp_codeSigning
+                        }))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with wrong subject key identifier")
+  void shouldRejectWorkerCertificateWithWrongSubjectKeyIdentifier() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .subjectKeyIdentifier(new SubjectKeyIdentifier(new byte[20]))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  @Test
+  @DisplayName("Should reject worker certificate with wrong authority key identifier")
+  void shouldRejectWorkerCertificateWithWrongAuthorityKeyIdentifier() throws Exception {
+    var fixture = fixture();
+    var certificate =
+        encoded(
+            fixture.shape().toBuilder()
+                .authorityKeyIdentifier(new AuthorityKeyIdentifier(new byte[20]))
+                .build());
+
+    var matches = validator.matches(certificate, fixture.validationContext());
+
+    assertThat(matches).isFalse();
+  }
+
+  private ValidatorFixture fixture() throws Exception {
+    var installationId = UUID.randomUUID();
+    var workerId = UUID.randomUUID();
+    var issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+    var authority = new BuiltInCertificateAuthority().create(installationId, issuedAt);
+    var keyGenerator = KeyPairGenerator.getInstance("EC");
+    keyGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+    var subjectPublicKey = keyGenerator.generateKeyPair().getPublic();
+    var parameters =
+        CertificateIssuanceParameters.builder()
+            .issuerCertificateSha256(
+                new Sha256Digest(
+                    MessageDigest.getInstance("SHA-256")
+                        .digest(authority.issuerCertificate().getEncoded())))
+            .serialNumber(new CertificateSerialNumber(new BigInteger("12345678901234567890")))
+            .profile(WorkerCertificateProfile.V1)
+            .validity(new CertificateValidity(issuedAt, issuedAt.plus(Duration.ofDays(7))))
+            .build();
+    var workerContext =
+        WorkerCertificateTestFixture.WorkerContext.builder()
+            .installationId(installationId)
+            .workerId(workerId)
+            .authorityMaterial(authority)
+            .subjectPublicKey(subjectPublicKey)
+            .parameters(parameters)
+            .build();
+    var validationContext =
+        WorkerCertificateValidator.ValidationContext.builder()
+            .installationId(installationId)
+            .workerId(workerId)
+            .subjectPublicKeyInfo(SubjectPublicKeyInfo.from(subjectPublicKey))
+            .parameters(parameters)
+            .issuer(authority.issuerCertificate())
+            .build();
+    return ValidatorFixture.builder()
+        .validationContext(validationContext)
+        .shape(WorkerCertificateTestFixture.validShape(workerContext).build())
+        .build();
+  }
+
+  private EncodedWorkerCertificate encoded(WorkerCertificateTestFixture.CertificateShape shape)
+      throws Exception {
+    return EncodedWorkerCertificate.fromDer(
+        WorkerCertificateTestFixture.certificate(shape).getEncoded());
+  }
+
+  private GeneralNames invalidSubjectAlternativeNames(
+      ValidatorFixture fixture, SubjectAlternativeNameMismatch mismatch) {
+    var expected = fixture.shape().subjectAlternativeNames().getNames()[0];
+    return switch (mismatch) {
+      case MISSING -> null;
+      case MULTIPLE ->
+          new GeneralNames(
+              new GeneralName[] {expected, new GeneralName(GeneralName.dNSName, "worker.local")});
+      case NON_URI -> new GeneralNames(new GeneralName(GeneralName.dNSName, "worker.local"));
+      case WRONG_URI ->
+          new GeneralNames(
+              new GeneralName(
+                  GeneralName.uniformResourceIdentifier,
+                  "spiffe://00000000-0000-0000-0000-000000000000/streamarr/worker/unknown"));
+    };
+  }
+
+  private ValidatorFixture withValidity(
+      ValidatorFixture fixture, CertificateValidity certificateValidity) {
+    var current = fixture.validationContext();
+    var currentParameters = current.parameters();
+    var parameters =
+        CertificateIssuanceParameters.builder()
+            .issuerCertificateSha256(currentParameters.issuerCertificateSha256())
+            .serialNumber(currentParameters.serialNumber())
+            .profile(currentParameters.profile())
+            .validity(certificateValidity)
+            .build();
+    var currentWorker = fixture.shape().context();
+    var workerContext =
+        WorkerCertificateTestFixture.WorkerContext.builder()
+            .installationId(currentWorker.installationId())
+            .workerId(currentWorker.workerId())
+            .authorityMaterial(currentWorker.authorityMaterial())
+            .subjectPublicKey(currentWorker.subjectPublicKey())
+            .parameters(parameters)
+            .build();
+    var validationContext =
+        WorkerCertificateValidator.ValidationContext.builder()
+            .installationId(current.installationId())
+            .workerId(current.workerId())
+            .subjectPublicKeyInfo(current.subjectPublicKeyInfo())
+            .parameters(parameters)
+            .issuer(current.issuer())
+            .build();
+    return ValidatorFixture.builder()
+        .validationContext(validationContext)
+        .shape(fixture.shape().toBuilder().context(workerContext).build())
+        .build();
+  }
+
+  @Builder
+  private record ValidatorFixture(
+      WorkerCertificateValidator.ValidationContext validationContext,
+      WorkerCertificateTestFixture.CertificateShape shape) {}
+
+  private enum SubjectAlternativeNameMismatch {
+    MISSING,
+    MULTIPLE,
+    NON_URI,
+    WRONG_URI
+  }
+}


### PR DESCRIPTION
## Summary

- validate worker certificates against the pinned issuing certificate and expected X.509 profile
- require the expected subject, SAN, key usage, extended key usage, and supported extensions
- fail closed for malformed certificates and unexpected certificate attributes

This PR builds on #244 and is part of the work tracked in #76.

## Validation

- exercised valid and adversarial certificate profiles with focused tests
- verified malformed, mismatched, and unsupported certificates are rejected
- ran the full Maven verification build