### PR TITLE
Non-blocking PR-247 review cleanup (lows, nits, test quality)

### DIFF
--- a/src/main/java/com/streamarr/server/config/health/TranscodeExecutorHealthIndicator.java
+++ b/src/main/java/com/streamarr/server/config/health/TranscodeExecutorHealthIndicator.java
@@ -21,6 +21,10 @@ public class TranscodeExecutorHealthIndicator implements HealthIndicator {
     if (!transcodeExecutor.isHealthy()) {
       return Health.down().withDetail("reason", "No transcode capacity available").build();
     }
-    return Health.up().withDetail("availableSlots", transcodeExecutor.availableSlots()).build();
+    var slots = transcodeExecutor.availableSlots();
+    if (slots == TranscodeExecutor.UNBOUNDED_SLOTS) {
+      return Health.up().withDetail("capacity", "unbounded").build();
+    }
+    return Health.up().withDetail("availableSlots", slots).build();
   }
 }

--- a/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/StreamSession.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 
 @Getter
 @Builder
@@ -19,7 +20,7 @@ public class StreamSession {
 
   private final UUID sessionId;
   private final UUID mediaFileId;
-  private final PlaybackAuthority authority;
+  @NonNull private final PlaybackAuthority authority;
   private final Path sourcePath;
   private final MediaProbe mediaProbe;
   private final TranscodeDecision transcodeDecision;
@@ -38,7 +39,7 @@ public class StreamSession {
       new AtomicReference<>(new PlaybackSnapshot(0, PlaybackState.STOPPED, Instant.now()));
 
   public boolean isOwnedBy(UUID candidateProfileId) {
-    return authority != null && authority.profileId().equals(candidateProfileId);
+    return authority.profileId().equals(candidateProfileId);
   }
 
   public void updatePlaybackState(int positionSeconds, PlaybackState state) {

--- a/src/main/java/com/streamarr/server/domain/streaming/TranscodeHandle.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/TranscodeHandle.java
@@ -1,6 +1,12 @@
 package com.streamarr.server.domain.streaming;
 
+import java.util.Objects;
+
 public record TranscodeHandle(long processId, TranscodeStatus status, int startSequenceNumber) {
+
+  public TranscodeHandle {
+    Objects.requireNonNull(status, "status is required");
+  }
 
   public TranscodeHandle(long processId, TranscodeStatus status) {
     this(processId, status, 0);

--- a/src/main/java/com/streamarr/server/domain/streaming/TranscodeRequest.java
+++ b/src/main/java/com/streamarr/server/domain/streaming/TranscodeRequest.java
@@ -1,6 +1,7 @@
 package com.streamarr.server.domain.streaming;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -19,6 +20,9 @@ public record TranscodeRequest(
     int startSequenceNumber) {
 
   public TranscodeRequest {
+    Objects.requireNonNull(sessionId, "sessionId is required");
+    Objects.requireNonNull(sourcePath, "sourcePath is required");
+    Objects.requireNonNull(transcodeDecision, "transcodeDecision is required");
     variantLabel = variantLabel != null ? variantLabel : StreamSession.defaultVariant();
   }
 }

--- a/src/main/java/com/streamarr/server/services/auth/AuthenticatedIdentity.java
+++ b/src/main/java/com/streamarr/server/services/auth/AuthenticatedIdentity.java
@@ -3,6 +3,8 @@ package com.streamarr.server.services.auth;
 import com.streamarr.server.domain.auth.AccountRole;
 import com.streamarr.server.domain.auth.HouseholdRole;
 import com.streamarr.server.domain.streaming.PlaybackAuthority;
+import com.streamarr.server.exceptions.AuthenticationRequiredException;
+import com.streamarr.server.exceptions.ProfileRequiredException;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
@@ -53,7 +55,7 @@ public record AuthenticatedIdentity(
   public static AuthenticatedIdentity fromJwt(Jwt jwt) {
     return AuthenticatedIdentity.builder()
         .accountId(UUID.fromString(jwt.getSubject()))
-        .role(AccountRole.valueOf(jwt.getClaimAsStringList(TokenClaims.ROLES).getFirst()))
+        .role(roleClaim(jwt))
         .authSessionId(UUID.fromString(jwt.getClaimAsString(TokenClaims.SESSION_ID)))
         .scope(TokenScope.valueOf(jwt.getClaimAsString(TokenClaims.SCOPE).toUpperCase(Locale.ROOT)))
         .householdId(uuidClaim(jwt, TokenClaims.HOUSEHOLD_ID))
@@ -64,12 +66,23 @@ public record AuthenticatedIdentity(
   }
 
   public PlaybackAuthority playbackAuthority() {
+    if (householdId == null || profileId == null) {
+      throw new ProfileRequiredException();
+    }
     return PlaybackAuthority.builder()
         .authSessionId(authSessionId)
         .accountId(accountId)
         .householdId(householdId)
         .profileId(profileId)
         .build();
+  }
+
+  private static AccountRole roleClaim(Jwt jwt) {
+    var roles = jwt.getClaimAsStringList(TokenClaims.ROLES);
+    if (roles == null || roles.isEmpty()) {
+      throw new AuthenticationRequiredException();
+    }
+    return AccountRole.valueOf(roles.getFirst());
   }
 
   private static UUID uuidClaim(Jwt jwt, String claim) {

--- a/src/main/java/com/streamarr/server/services/auth/PasswordChangeCompletionCommand.java
+++ b/src/main/java/com/streamarr/server/services/auth/PasswordChangeCompletionCommand.java
@@ -1,11 +1,19 @@
 package com.streamarr.server.services.auth;
 
+import java.util.Objects;
 import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record PasswordChangeCompletionCommand(
     UUID accountId, UUID sessionId, String expectedPasswordHash, String newPasswordHash) {
+
+  public PasswordChangeCompletionCommand {
+    Objects.requireNonNull(accountId, "accountId is required");
+    Objects.requireNonNull(sessionId, "sessionId is required");
+    Objects.requireNonNull(expectedPasswordHash, "expectedPasswordHash is required");
+    Objects.requireNonNull(newPasswordHash, "newPasswordHash is required");
+  }
 
   public static class PasswordChangeCompletionCommandBuilder {
 

--- a/src/main/java/com/streamarr/server/services/streaming/TranscodeExecutor.java
+++ b/src/main/java/com/streamarr/server/services/streaming/TranscodeExecutor.java
@@ -6,6 +6,9 @@ import java.util.UUID;
 
 public interface TranscodeExecutor {
 
+  /** Sentinel returned by {@link #availableSlots()} when the executor imposes no slot limit. */
+  int UNBOUNDED_SLOTS = Integer.MAX_VALUE;
+
   TranscodeHandle start(TranscodeRequest request);
 
   void stop(UUID sessionId);

--- a/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
+++ b/src/main/java/com/streamarr/server/services/streaming/ffmpeg/LocalTranscodeExecutor.java
@@ -45,7 +45,7 @@ public class LocalTranscodeExecutor implements TranscodeExecutor {
 
   @Override
   public int availableSlots() {
-    return Integer.MAX_VALUE;
+    return UNBOUNDED_SLOTS;
   }
 
   private Path resolveOutputDir(TranscodeRequest request) {

--- a/src/main/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptor.java
+++ b/src/main/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptor.java
@@ -41,6 +41,8 @@ final class WorkerIdentityServerInterceptor implements ServerInterceptor {
           Context.current().withValue(AUTHENTICATED_WORKER_ID, workerId), call, headers, next);
     } catch (SSLPeerUnverifiedException | WorkerIdentityException e) {
       return reject(call, e.getMessage());
+    } catch (RuntimeException e) {
+      return reject(call, e.getMessage());
     }
   }
 

--- a/src/main/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptor.java
+++ b/src/main/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptor.java
@@ -27,6 +27,7 @@ final class WorkerIdentityServerInterceptor implements ServerInterceptor {
   @Override
   public <R, S> ServerCall.Listener<R> interceptCall(
       ServerCall<R, S> call, Metadata headers, ServerCallHandler<R, S> next) {
+    UUID workerId;
     try {
       var sslSession = call.getAttributes().get(Grpc.TRANSPORT_ATTR_SSL_SESSION);
       if (sslSession == null) {
@@ -36,14 +37,14 @@ final class WorkerIdentityServerInterceptor implements ServerInterceptor {
       if (certificates.length == 0 || !(certificates[0] instanceof X509Certificate leaf)) {
         return reject(call, "no X.509 peer certificate");
       }
-      var workerId = identityMapper.workerId(leaf);
-      return Contexts.interceptCall(
-          Context.current().withValue(AUTHENTICATED_WORKER_ID, workerId), call, headers, next);
+      workerId = identityMapper.workerId(leaf);
     } catch (SSLPeerUnverifiedException | WorkerIdentityException e) {
       return reject(call, e.getMessage());
     } catch (RuntimeException e) {
       return reject(call, e.getMessage());
     }
+    return Contexts.interceptCall(
+        Context.current().withValue(AUTHENTICATED_WORKER_ID, workerId), call, headers, next);
   }
 
   private <R, S> ServerCall.Listener<R> reject(ServerCall<R, S> call, String reason) {

--- a/src/main/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptor.java
+++ b/src/main/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptor.java
@@ -38,9 +38,7 @@ final class WorkerIdentityServerInterceptor implements ServerInterceptor {
         return reject(call, "no X.509 peer certificate");
       }
       workerId = identityMapper.workerId(leaf);
-    } catch (SSLPeerUnverifiedException | WorkerIdentityException e) {
-      return reject(call, e.getMessage());
-    } catch (RuntimeException e) {
+    } catch (SSLPeerUnverifiedException | RuntimeException e) {
       return reject(call, e.getMessage());
     }
     return Contexts.interceptCall(

--- a/src/main/java/com/streamarr/transcode/tls/PemTlsIdentity.java
+++ b/src/main/java/com/streamarr/transcode/tls/PemTlsIdentity.java
@@ -8,8 +8,8 @@ import lombok.Builder;
 public record PemTlsIdentity(Path certificate, Path privateKey, Path trustBundle) {
 
   public PemTlsIdentity {
-    Objects.requireNonNull(certificate);
-    Objects.requireNonNull(privateKey);
-    Objects.requireNonNull(trustBundle);
+    Objects.requireNonNull(certificate, "certificate is required");
+    Objects.requireNonNull(privateKey, "privateKey is required");
+    Objects.requireNonNull(trustBundle, "trustBundle is required");
   }
 }

--- a/src/main/java/com/streamarr/transcode/worker/TranscodeWorker.java
+++ b/src/main/java/com/streamarr/transcode/worker/TranscodeWorker.java
@@ -162,7 +162,10 @@ public final class TranscodeWorker implements AutoCloseable {
           fromProto(job.getStreamSessionId()),
           e);
       deleteOutputDirectory(outputDirectory);
-      sendFailure(job, JobAttemptFailure.JOB_ATTEMPT_FAILURE_STARTUP_FAILED);
+      // A failure after engine.start() + activeVariants.put() (e.g. send() throwing) must stop the
+      // engine and drop the entry, otherwise the FFmpeg process leaks. failVariant is a no-op stop
+      // when nothing was registered yet.
+      failVariant(job, JobAttemptFailure.JOB_ATTEMPT_FAILURE_STARTUP_FAILED);
       return;
     }
 

--- a/src/main/java/com/streamarr/transcode/worker/TranscodeWorkerConfiguration.java
+++ b/src/main/java/com/streamarr/transcode/worker/TranscodeWorkerConfiguration.java
@@ -23,14 +23,15 @@ public record TranscodeWorkerConfiguration(
   private static final Duration DEFAULT_KEEPALIVE_TIMEOUT = Duration.ofSeconds(10);
 
   public TranscodeWorkerConfiguration {
-    Objects.requireNonNull(workerId);
-    Objects.requireNonNull(bootId);
+    Objects.requireNonNull(workerId, "workerId is required");
+    Objects.requireNonNull(bootId, "bootId is required");
     if (availableSlots < 1) {
       throw new IllegalArgumentException("Available slots must be positive");
     }
-    Objects.requireNonNull(tlsIdentity);
+    Objects.requireNonNull(tlsIdentity, "tlsIdentity is required");
+    Objects.requireNonNull(sourceNamespaces, "sourceNamespaces is required");
     sourceNamespaces = Map.copyOf(sourceNamespaces);
-    Objects.requireNonNull(segmentBasePath);
+    Objects.requireNonNull(segmentBasePath, "segmentBasePath is required");
     if (keepAliveTime == null) {
       keepAliveTime = DEFAULT_KEEPALIVE_TIME;
     }

--- a/src/test/java/com/streamarr/server/config/health/TranscodeExecutorHealthIndicatorTest.java
+++ b/src/test/java/com/streamarr/server/config/health/TranscodeExecutorHealthIndicatorTest.java
@@ -3,6 +3,7 @@ package com.streamarr.server.config.health;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.streamarr.server.fakes.FakeTranscodeExecutor;
+import com.streamarr.server.services.streaming.TranscodeExecutor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,20 @@ class TranscodeExecutorHealthIndicatorTest {
 
     assertThat(health.getStatus()).isEqualTo(Status.UP);
     assertThat(health.getDetails()).containsEntry("availableSlots", 3);
+  }
+
+  @Test
+  @DisplayName("Should report unbounded capacity when executor imposes no slot limit")
+  void shouldReportUnboundedCapacityWhenExecutorImposesNoSlotLimit() {
+    var executor = new FakeTranscodeExecutor();
+    executor.setAvailableSlots(TranscodeExecutor.UNBOUNDED_SLOTS);
+    var indicator = new TranscodeExecutorHealthIndicator(executor);
+
+    var health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails()).containsEntry("capacity", "unbounded");
+    assertThat(health.getDetails()).doesNotContainKey("availableSlots");
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/config/security/TokenCryptoConfigTest.java
+++ b/src/test/java/com/streamarr/server/config/security/TokenCryptoConfigTest.java
@@ -25,9 +25,12 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
@@ -250,13 +253,22 @@ class TokenCryptoConfigTest {
   }
 
   @Test
-  @DisplayName("Should reject token without the expected audience")
-  void shouldRejectTokenWithoutExpectedAudience() {
+  @DisplayName("Should reject token with an empty audience claim")
+  void shouldRejectTokenWithEmptyAudience() {
     var keys = config.tokenSigningKeys(properties(KEY_A, List.of()));
     var token = mint(config.jwtEncoder(keys), claims -> claims.audience(List.of()));
-    var jwtDecoder = decoder(keys);
 
-    assertThatThrownBy(() -> jwtDecoder.decode(token)).isInstanceOf(JwtValidationException.class);
+    assertRejectedAsInvalidToken(decoder(keys), token);
+  }
+
+  @Test
+  @DisplayName("Should reject token when the audience claim is absent")
+  void shouldRejectTokenWhenAudienceClaimAbsent() {
+    var keys = config.tokenSigningKeys(properties(KEY_A, List.of()));
+    var token =
+        mint(config.jwtEncoder(keys), claims -> claims.claims(c -> c.remove(JwtClaimNames.AUD)));
+
+    assertRejectedAsInvalidToken(decoder(keys), token);
   }
 
   @Test
@@ -264,9 +276,18 @@ class TokenCryptoConfigTest {
   void shouldRejectTokenAddressedToDifferentAudience() {
     var keys = config.tokenSigningKeys(properties(KEY_A, List.of()));
     var token = mint(config.jwtEncoder(keys), claims -> claims.audience(List.of("other-service")));
-    var jwtDecoder = decoder(keys);
 
-    assertThatThrownBy(() -> jwtDecoder.decode(token)).isInstanceOf(JwtValidationException.class);
+    assertRejectedAsInvalidToken(decoder(keys), token);
+  }
+
+  private void assertRejectedAsInvalidToken(JwtDecoder jwtDecoder, String token) {
+    assertThatThrownBy(() -> jwtDecoder.decode(token))
+        .isInstanceOfSatisfying(
+            JwtValidationException.class,
+            ex ->
+                assertThat(ex.getErrors())
+                    .extracting(OAuth2Error::getErrorCode)
+                    .contains(OAuth2ErrorCodes.INVALID_TOKEN));
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/domain/streaming/StreamSessionTest.java
+++ b/src/test/java/com/streamarr/server/domain/streaming/StreamSessionTest.java
@@ -13,6 +13,16 @@ import org.junit.jupiter.api.Test;
 class StreamSessionTest {
 
   @Test
+  @DisplayName("Should reject a null playback authority")
+  void shouldRejectNullPlaybackAuthority() {
+    var builder = StreamSession.builder();
+
+    assertThatThrownBy(() -> builder.authority(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("authority");
+  }
+
+  @Test
   @DisplayName("Should reject direct mutation of the exposed variant handle map")
   void shouldRejectDirectMutationOfExposedVariantHandleMap() {
     var session = buildMpegtsSession();

--- a/src/test/java/com/streamarr/server/fakes/FakePlaybackAuthorityGate.java
+++ b/src/test/java/com/streamarr/server/fakes/FakePlaybackAuthorityGate.java
@@ -6,12 +6,10 @@ import com.streamarr.server.services.streaming.PlaybackAuthorityGate;
 public class FakePlaybackAuthorityGate implements PlaybackAuthorityGate {
 
   private boolean allowed = true;
-  private int checkCount;
   private RuntimeException failure;
 
   @Override
   public boolean allows(PlaybackAuthority authority) {
-    checkCount++;
     if (failure != null) {
       throw failure;
     }
@@ -24,13 +22,5 @@ public class FakePlaybackAuthorityGate implements PlaybackAuthorityGate {
 
   public void failWith(RuntimeException failure) {
     this.failure = failure;
-  }
-
-  public void resetCheckCount() {
-    checkCount = 0;
-  }
-
-  public int checkCount() {
-    return checkCount;
   }
 }

--- a/src/test/java/com/streamarr/server/fakes/FakeTranscodeExecutor.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeTranscodeExecutor.java
@@ -21,7 +21,7 @@ public class FakeTranscodeExecutor implements TranscodeExecutor {
   private final Set<UUID> stopped = new HashSet<>();
   private final Set<UUID> failingOnStop = new HashSet<>();
   private final List<TranscodeRequest> startedRequests = new ArrayList<>();
-  private int availableSlots = Integer.MAX_VALUE;
+  private int availableSlots = TranscodeExecutor.UNBOUNDED_SLOTS;
   private boolean healthy = true;
 
   @Override

--- a/src/test/java/com/streamarr/server/fixtures/StreamSessionFixture.java
+++ b/src/test/java/com/streamarr/server/fixtures/StreamSessionFixture.java
@@ -114,8 +114,7 @@ public final class StreamSessionFixture {
   }
 
   public static StreamSession buildMpegtsSessionOwnedBy(UUID profileId) {
-    var authority = profileId == null ? null : playbackAuthorityFor(profileId);
-    var session = defaultSessionBuilder().authority(authority).build();
+    var session = defaultSessionBuilder().authority(playbackAuthorityFor(profileId)).build();
     session.setHandle(new TranscodeHandle(1L, TranscodeStatus.ACTIVE));
     return session;
   }

--- a/src/test/java/com/streamarr/server/services/auth/AuthenticatedIdentityTest.java
+++ b/src/test/java/com/streamarr/server/services/auth/AuthenticatedIdentityTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.streamarr.server.domain.auth.AccountRole;
 import com.streamarr.server.domain.auth.HouseholdRole;
+import com.streamarr.server.exceptions.AuthenticationRequiredException;
+import com.streamarr.server.exceptions.ProfileRequiredException;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 @Tag("UnitTest")
 @DisplayName("Authenticated Identity Tests")
@@ -89,5 +93,47 @@ class AuthenticatedIdentityTest {
             .streamSessionId(UUID.randomUUID());
 
     assertThatThrownBy(identity::build).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a token missing the roles claim")
+  void shouldRejectTokenMissingRolesClaim() {
+    var jwt =
+        Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .subject(UUID.randomUUID().toString())
+            .claim(TokenClaims.SESSION_ID, UUID.randomUUID().toString())
+            .build();
+
+    assertThatThrownBy(() -> AuthenticatedIdentity.fromJwt(jwt))
+        .isInstanceOf(AuthenticationRequiredException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject a token with an empty roles claim")
+  void shouldRejectTokenWithEmptyRolesClaim() {
+    var jwt =
+        Jwt.withTokenValue("token")
+            .header("alg", "none")
+            .subject(UUID.randomUUID().toString())
+            .claim(TokenClaims.ROLES, List.of())
+            .build();
+
+    assertThatThrownBy(() -> AuthenticatedIdentity.fromJwt(jwt))
+        .isInstanceOf(AuthenticationRequiredException.class);
+  }
+
+  @Test
+  @DisplayName("Should reject building a playback authority for an account-scoped identity")
+  void shouldRejectPlaybackAuthorityForAccountScopedIdentity() {
+    var identity =
+        AuthenticatedIdentity.builder()
+            .accountId(UUID.randomUUID())
+            .role(AccountRole.USER)
+            .authSessionId(UUID.randomUUID())
+            .scope(TokenScope.ACCOUNT)
+            .build();
+
+    assertThatThrownBy(identity::playbackAuthority).isInstanceOf(ProfileRequiredException.class);
   }
 }

--- a/src/test/java/com/streamarr/server/services/auth/PlaybackTokenIssuerTest.java
+++ b/src/test/java/com/streamarr/server/services/auth/PlaybackTokenIssuerTest.java
@@ -100,17 +100,6 @@ class PlaybackTokenIssuerTest {
   }
 
   @Test
-  @DisplayName("Should refuse issuance when session has no owner")
-  void shouldRefuseIssuanceWhenSessionHasNoOwner() {
-    var identity = profileIdentity();
-    var unownedSession = StreamSession.builder().sessionId(UUID.randomUUID()).build();
-    var ttl = Duration.ofHours(1);
-
-    assertThatThrownBy(() -> issuer.issue(identity, unownedSession, ttl))
-        .isInstanceOf(SessionNotFoundException.class);
-  }
-
-  @Test
   @DisplayName("Should refuse issuance when session not owned by identity")
   void shouldRefuseIssuanceWhenSessionNotOwnedByIdentity() {
     var identity = profileIdentity();

--- a/src/test/java/com/streamarr/server/services/auth/RefreshTokenServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/auth/RefreshTokenServiceTest.java
@@ -126,8 +126,8 @@ class RefreshTokenServiceTest {
   }
 
   @Test
-  @DisplayName("Should classify expired successor as superseded replay within grace")
-  void shouldClassifyExpiredSuccessorAsSupersededReplayWithinGrace() {
+  @DisplayName("Should classify expired successor as superseded retry within grace")
+  void shouldClassifyExpiredSuccessorAsSupersededRetryWithinGrace() {
     var shortLivedService =
         serviceWith(
             AuthTokenProperties.builder()

--- a/src/test/java/com/streamarr/server/services/library/StreamingSessionCleanupListenerTest.java
+++ b/src/test/java/com/streamarr/server/services/library/StreamingSessionCleanupListenerTest.java
@@ -3,6 +3,7 @@ package com.streamarr.server.services.library;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.streamarr.server.domain.streaming.StreamSession;
+import com.streamarr.server.fixtures.StreamSessionFixture;
 import com.streamarr.server.services.library.events.LibraryRemovedEvent;
 import com.streamarr.server.services.streaming.CreateStreamSessionCommand;
 import com.streamarr.server.services.streaming.PlaybackRequest;
@@ -68,7 +69,11 @@ class StreamingSessionCleanupListenerTest {
   }
 
   private StreamSession buildSessionForMediaFile(UUID mediaFileId) {
-    return StreamSession.builder().sessionId(UUID.randomUUID()).mediaFileId(mediaFileId).build();
+    return StreamSession.builder()
+        .sessionId(UUID.randomUUID())
+        .mediaFileId(mediaFileId)
+        .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
+        .build();
   }
 
   private static class FakeStreamingService implements StreamingService {

--- a/src/test/java/com/streamarr/server/services/streaming/HlsPlaylistServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsPlaylistServiceTest.java
@@ -15,6 +15,7 @@ import com.streamarr.server.domain.streaming.TranscodeDecision;
 import com.streamarr.server.domain.streaming.TranscodeHandle;
 import com.streamarr.server.domain.streaming.TranscodeMode;
 import com.streamarr.server.domain.streaming.TranscodeStatus;
+import com.streamarr.server.fixtures.StreamSessionFixture;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -53,6 +54,7 @@ class HlsPlaylistServiceTest {
         StreamSession.builder()
             .sessionId(UUID.randomUUID())
             .mediaFileId(UUID.randomUUID())
+            .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
             .sourcePath(Path.of("/media/test.mkv"))
             .mediaProbe(
                 MediaProbe.builder()
@@ -86,6 +88,7 @@ class HlsPlaylistServiceTest {
         StreamSession.builder()
             .sessionId(UUID.randomUUID())
             .mediaFileId(UUID.randomUUID())
+            .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
             .sourcePath(Path.of("/media/test.mkv"))
             .mediaProbe(
                 MediaProbe.builder()
@@ -119,6 +122,7 @@ class HlsPlaylistServiceTest {
         StreamSession.builder()
             .sessionId(UUID.randomUUID())
             .mediaFileId(UUID.randomUUID())
+            .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
             .sourcePath(Path.of("/media/test.mkv"))
             .mediaProbe(
                 MediaProbe.builder()
@@ -175,6 +179,7 @@ class HlsPlaylistServiceTest {
         StreamSession.builder()
             .sessionId(UUID.randomUUID())
             .mediaFileId(UUID.randomUUID())
+            .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
             .sourcePath(Path.of("/media/test.mkv"))
             .mediaProbe(
                 MediaProbe.builder()
@@ -620,6 +625,7 @@ class HlsPlaylistServiceTest {
           StreamSession.builder()
               .sessionId(UUID.randomUUID())
               .mediaFileId(UUID.randomUUID())
+              .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
               .sourcePath(Path.of("/media/test.mkv"))
               .mediaProbe(
                   MediaProbe.builder()

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -242,14 +242,6 @@ class HlsStreamingServiceTest {
   }
 
   @Test
-  @DisplayName("Should return empty when runtime session is missing")
-  void shouldReturnEmptyWhenRuntimeSessionIsMissing() {
-    var result = accessMissingSession(UUID.randomUUID());
-
-    assertThat(result).isEmpty();
-  }
-
-  @Test
   @DisplayName("Should return empty when live playback authority is denied")
   void shouldReturnEmptyWhenLivePlaybackAuthorityIsDenied() {
     var file = seedMediaFile();

--- a/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/HlsStreamingServiceTest.java
@@ -234,22 +234,19 @@ class HlsStreamingServiceTest {
             .streamSessionId(session.getSessionId())
             .authority(defaultPlaybackAuthorityBuilder().build())
             .build();
-    authorityGate.resetCheckCount();
 
     var result = service.accessSession(request);
 
     assertThat(result).isEmpty();
     assertThat(session.getLastAccessedAt()).isEqualTo(lastAccessedAt);
-    assertThat(authorityGate.checkCount()).isZero();
   }
 
   @Test
-  @DisplayName("Should return empty without authority check when runtime session is missing")
-  void shouldReturnEmptyWithoutAuthorityCheckWhenRuntimeSessionIsMissing() {
+  @DisplayName("Should return empty when runtime session is missing")
+  void shouldReturnEmptyWhenRuntimeSessionIsMissing() {
     var result = accessMissingSession(UUID.randomUUID());
 
     assertThat(result).isEmpty();
-    assertThat(authorityGate.checkCount()).isZero();
   }
 
   @Test

--- a/src/test/java/com/streamarr/server/services/streaming/remote/RemotePlaybackIT.java
+++ b/src/test/java/com/streamarr/server/services/streaming/remote/RemotePlaybackIT.java
@@ -22,6 +22,7 @@ import com.streamarr.server.domain.streaming.TranscodeRequest;
 import com.streamarr.server.exceptions.TranscodeException;
 import com.streamarr.server.fakes.FakeFfmpegProcessManager;
 import com.streamarr.server.fakes.FakeSegmentProducingFfmpegProcessManager;
+import com.streamarr.server.fixtures.StreamSessionFixture;
 import com.streamarr.server.services.auth.AuthenticatedIdentity;
 import com.streamarr.server.services.auth.TokenScope;
 import com.streamarr.server.services.authorization.AuthorizationService;
@@ -292,6 +293,7 @@ class RemotePlaybackIT extends AbstractIntegrationTest {
     var session =
         StreamSession.builder()
             .sessionId(streamSessionId)
+            .authority(StreamSessionFixture.playbackAuthorityFor(UUID.randomUUID()))
             .transcodeDecision(transcodeDecision(containerFormat))
             .build();
     when(streamingService.accessSession(any())).thenReturn(Optional.of(session));

--- a/src/test/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptorTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptorTest.java
@@ -79,13 +79,19 @@ class WorkerIdentityServerInterceptorTest {
     }
 
     @Override
-    public void request(int numMessages) {}
+    public void request(int numMessages) {
+      throw new UnsupportedOperationException();
+    }
 
     @Override
-    public void sendHeaders(Metadata headers) {}
+    public void sendHeaders(Metadata headers) {
+      throw new UnsupportedOperationException();
+    }
 
     @Override
-    public void sendMessage(Object message) {}
+    public void sendMessage(Object message) {
+      throw new UnsupportedOperationException();
+    }
 
     @Override
     public void close(Status status, Metadata trailers) {

--- a/src/test/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptorTest.java
+++ b/src/test/java/com/streamarr/server/services/streaming/remote/WorkerIdentityServerInterceptorTest.java
@@ -1,0 +1,114 @@
+package com.streamarr.server.services.streaming.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.grpc.Attributes;
+import io.grpc.Grpc;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import java.lang.reflect.Proxy;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+@DisplayName("Worker Identity Server Interceptor Tests")
+class WorkerIdentityServerInterceptorTest {
+
+  @Test
+  @DisplayName("Should propagate downstream failure without rejecting authenticated call")
+  void shouldPropagateDownstreamFailureWithoutRejectingAuthenticatedCall() throws Exception {
+    var attributes =
+        Attributes.newBuilder()
+            .set(Grpc.TRANSPORT_ATTR_SSL_SESSION, sslSession(workerCertificate()))
+            .build();
+    var call = new RecordingServerCall(attributes);
+    var interceptor =
+        new WorkerIdentityServerInterceptor(new WorkerSpiffeIdentityMapper("streamarr.test"));
+    var downstreamFailure = new IllegalStateException("downstream setup failed");
+    ServerCallHandler<Object, Object> handler =
+        (_, _) -> {
+          throw downstreamFailure;
+        };
+
+    var thrown = catchThrowable(() -> interceptor.interceptCall(call, new Metadata(), handler));
+
+    assertThat(thrown)
+        .as("downstream failure must not be relabeled as %s", call.closedStatus())
+        .isSameAs(downstreamFailure);
+    assertThat(call.closedStatus()).isNull();
+  }
+
+  private X509Certificate workerCertificate() throws Exception {
+    try (var certificate =
+        Objects.requireNonNull(getClass().getResourceAsStream("/tls/worker-cert.pem"))) {
+      return (X509Certificate)
+          CertificateFactory.getInstance("X.509").generateCertificate(certificate);
+    }
+  }
+
+  private static SSLSession sslSession(X509Certificate certificate) {
+    return (SSLSession)
+        Proxy.newProxyInstance(
+            SSLSession.class.getClassLoader(),
+            new Class<?>[] {SSLSession.class},
+            (_, method, _) -> {
+              if (method.getName().equals("getPeerCertificates")) {
+                return new Certificate[] {certificate};
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+
+  private static final class RecordingServerCall extends ServerCall<Object, Object> {
+
+    private final Attributes attributes;
+    private Status closedStatus;
+
+    private RecordingServerCall(Attributes attributes) {
+      this.attributes = attributes;
+    }
+
+    @Override
+    public void request(int numMessages) {}
+
+    @Override
+    public void sendHeaders(Metadata headers) {}
+
+    @Override
+    public void sendMessage(Object message) {}
+
+    @Override
+    public void close(Status status, Metadata trailers) {
+      closedStatus = status;
+    }
+
+    @Override
+    public boolean isCancelled() {
+      return false;
+    }
+
+    @Override
+    public Attributes getAttributes() {
+      return attributes;
+    }
+
+    @Override
+    public MethodDescriptor<Object, Object> getMethodDescriptor() {
+      throw new UnsupportedOperationException();
+    }
+
+    private Status closedStatus() {
+      return closedStatus;
+    }
+  }
+}

--- a/src/test/java/com/streamarr/server/services/watchprogress/SessionProgressServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/watchprogress/SessionProgressServiceTest.java
@@ -311,9 +311,9 @@ class SessionProgressServiceTest {
     }
 
     @Test
-    @DisplayName("Should treat session without owner profile as not found")
-    void shouldTreatSessionWithoutOwnerProfileAsNotFound() {
-      var session = StreamSessionFixture.buildMpegtsSessionOwnedBy(null);
+    @DisplayName("Should treat session owned by another profile as not found")
+    void shouldTreatSessionOwnedByAnotherProfileAsNotFound() {
+      var session = StreamSessionFixture.buildMpegtsSessionOwnedBy(UUID.randomUUID());
       runtimeRegistry.save(session);
       saveMediaFileForSession(session);
 


### PR DESCRIPTION
## Summary

Stacks on #247. The non-blocking Track-C findings from the PR #247 review. Full `./mvnw verify` green (1697 unit + 487 integration tests, 0 Checkstyle violations, Spotless clean).

- **L2** — `TranscodeWorker` startVariant catch routes through `failVariant` (stops the engine + drops the `activeVariants` entry locally) instead of only `sendFailure`. No discriminating test is possible (the throwing-send path always also fires the disconnect handler that reaps the engine — a reproduction is a verified false-green), so this is retained as a Tidy-First local-cleanup improvement.
- **L3** — `WorkerIdentityServerInterceptor` gains a final `catch (RuntimeException)` → `UNAUTHENTICATED` reject.
- **L4** — `StreamSession.authority` is `@NonNull` (builder-enforced); `isOwnedBy`'s redundant null-guard dropped. Rippled to the fixture + 5 tests that built authority-less sessions.
- **N1 / N4** — `AuthenticatedIdentity` guards absent/empty roles (`AuthenticationRequiredException`) and account-scope `playbackAuthority()` (`ProfileRequiredException`) instead of leaking NPEs.
- **N3** — `TranscodeExecutor.UNBOUNDED_SLOTS`; the health indicator reports `capacity: unbounded` for local mode instead of `2147483647`.
- **N5** — `requireNonNull` messages/guards on `PemTlsIdentity`, `TranscodeWorkerConfiguration`, `PasswordChangeCompletionCommand`, and the structural fields of `TranscodeRequest`/`TranscodeHandle`.
- **L6** — `RefreshTokenServiceTest`: `SupersededReplay` → `SupersededRetry` naming.
- **Test-quality** — dropped Fake-based `checkCount` call-counting; `TokenCryptoConfigTest` asserts the `invalid_token` OAuth2 code and adds a truly-absent-`aud` case.

## Deferred

- **N2** (worker-package ArchUnit rule) — the worker package is an adapter where proto is expected; broadening the scope would flag legitimate boundary classes.
- **GAP-T5** (CA-flagged-leaf real-cert fixture) and **GAP-T6** (K8s manifest mTLS wiring assertions) — the meatier coverage items, not reached here.

## Validation

`./mvnw verify` green on the branch rebased onto #247's head (conflict in `FakePlaybackAuthorityGate` resolved to keep #247's `failWith` plus this branch's `checkCount` removal).