### PR TITLE
Pin the procfile buildpack so /deploy-preview can resolve it

### DIFF
--- a/.github/actions/pack-build/action.yml
+++ b/.github/actions/pack-build/action.yml
@@ -43,12 +43,16 @@ runs:
           publish_flag="--publish"
         fi
 
+        # procfile is pinned because builder-jammy-full carries four copies of it (5.10.1,
+        # 5.13.2, 5.13.5, 5.13.6), pulled in transitively by other buildpacks, and an unversioned
+        # reference cannot resolve against more than one. apt and java need no pin: java appears
+        # exactly once, and apt is not in the builder at all — pack fetches it from the registry.
         pack build index.docker.io/streamarr/streamarr-server \
             ${tag_args} \
             --builder paketobuildpacks/builder-jammy-full \
             --buildpack paketo-buildpacks/apt \
             --buildpack paketo-buildpacks/java \
-            --buildpack paketo-buildpacks/procfile \
+            --buildpack paketo-buildpacks/procfile@5.13.6 \
             --env BP_JVM_VERSION=25 \
             --env BP_INCLUDE_FILES=.profile:Procfile \
             --path . \


### PR DESCRIPTION
`/deploy-preview` fails at the pack build:

```
failed to build: processing buildpacks order: unable to resolve version:
multiple versions of 'paketo-buildpacks/procfile' - must specify an explicit version
```

`paketobuildpacks/builder-jammy-full` is a floating tag, and the copy it now resolves to carries **four** versions of that buildpack — 5.10.1, 5.13.2, 5.13.5, 5.13.6 — pulled in transitively by other buildpacks. An unversioned `--buildpack paketo-buildpacks/procfile` has nothing to resolve to.

Read from the builder image's `io.buildpacks.builder.metadata` label:

| buildpack | copies in builder | pinned? |
|---|---|---|
| `paketo-buildpacks/procfile` | 4 | **yes — 5.13.6** |
| `paketo-buildpacks/java` | 1 | no, unambiguous |
| `paketo-buildpacks/apt` | 0 (fetched from the registry) | no |

Pinned to 5.13.6, the newest copy the builder actually ships — pinning to a version absent from the builder would fail differently.

**This is upstream drift, not a repo regression.** The unpinned reference has been in place since `25e7d7d8` (2026-07-13) and built fine for three weeks. Most pointedly, PR #260 — whose head contains the identical unpinned line — ran this exact action **successfully at 2026-08-03 20:48**, and #261 failed at **21:44** the same day. Same action, same branch lineage, 56 minutes apart. The builder tag was republished underneath us.

That is also the argument for pinning rather than just re-running: an unpinned reference against a floating builder will break again the next time the upstream order changes.

Based on `codex/lean-playback-worker-adr` rather than `main` because `main` has no procfile line at all — the explicit `--buildpack` list arrived with the worker process type on this branch, so there is nothing to pin on main.

Note on reach: `preview.yml` checks out the PR head and then runs the local composite action from the workspace, so a PR's preview uses *its own* copy of `pack-build`. Stacked branches need this merged and picked up before their previews will build.