### PR TITLE
Clear a stale profile during auto-selection

### DIFF
--- a/src/main/java/com/streamarr/server/services/auth/SessionScopeService.java
+++ b/src/main/java/com/streamarr/server/services/auth/SessionScopeService.java
@@ -11,6 +11,7 @@ import com.streamarr.server.repositories.auth.AuthSessionRepository;
 import com.streamarr.server.repositories.auth.HouseholdMembershipRepository;
 import com.streamarr.server.repositories.auth.UserAccountRepository;
 import java.time.Clock;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -43,12 +44,7 @@ public class SessionScopeService {
 
     var householdId = memberships.getFirst().getHouseholdId();
     session.setActiveHouseholdId(householdId);
-
-    var links =
-        accountProfileRepository.findByAccountIdAndHouseholdId(account.getId(), householdId);
-    if (links.size() == 1) {
-      session.setActiveProfileId(links.getFirst().getProfileId());
-    }
+    soleSelectableProfileId(account.getId(), householdId).ifPresent(session::setActiveProfileId);
 
     persistSelection(session);
 
@@ -119,12 +115,7 @@ public class SessionScopeService {
         .orElseThrow(HouseholdAccessDeniedException::new);
 
     session.setActiveHouseholdId(householdId);
-    session.setActiveProfileId(null);
-
-    var links = accountProfileRepository.findByAccountIdAndHouseholdId(accountId, householdId);
-    if (links.size() == 1) {
-      session.setActiveProfileId(links.getFirst().getProfileId());
-    }
+    session.setActiveProfileId(soleSelectableProfileId(accountId, householdId).orElse(null));
 
     sessionRepository.save(session);
 
@@ -181,6 +172,14 @@ public class SessionScopeService {
         .filter(session -> session.getAccountId().equals(accountId))
         .filter(session -> session.getRevokedAt() == null)
         .orElseThrow(AuthenticationRequiredException::new);
+  }
+
+  private Optional<UUID> soleSelectableProfileId(UUID accountId, UUID householdId) {
+    var links = accountProfileRepository.findByAccountIdAndHouseholdId(accountId, householdId);
+    if (links.size() != 1) {
+      return Optional.empty();
+    }
+    return Optional.of(links.getFirst().getProfileId());
   }
 
   private void clearSelection(AuthSession session, boolean includingHousehold) {

--- a/src/main/java/com/streamarr/server/services/auth/SessionScopeService.java
+++ b/src/main/java/com/streamarr/server/services/auth/SessionScopeService.java
@@ -33,7 +33,8 @@ public class SessionScopeService {
 
   /**
    * ADR 0016 auto-selection: a sole household is selected automatically, then a sole selectable
-   * profile within it.
+   * profile within it. The profile is set unconditionally from the resolved value, so a session
+   * arriving with a stale selection has it cleared rather than carried into the minted token.
    */
   @Transactional
   public TokenContext autoSelectContext(UserAccount account, AuthSession session) {
@@ -44,7 +45,7 @@ public class SessionScopeService {
 
     var householdId = memberships.getFirst().getHouseholdId();
     session.setActiveHouseholdId(householdId);
-    soleSelectableProfileId(account.getId(), householdId).ifPresent(session::setActiveProfileId);
+    session.setActiveProfileId(soleSelectableProfileId(account.getId(), householdId).orElse(null));
 
     persistSelection(session);
 

--- a/src/test/java/com/streamarr/server/services/auth/SessionScopeServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/auth/SessionScopeServiceTest.java
@@ -88,6 +88,36 @@ class SessionScopeServiceTest {
     assertThat(context.profileId()).isNull();
   }
 
+  @Test
+  @DisplayName("Should clear stale profile when sole household has no selectable profile")
+  void shouldClearStaleProfileWhenSoleHouseholdHasNoSelectableProfile() {
+    var f = fixture();
+    f.session.setActiveProfileId(f.profile.getId());
+    sessionRepository.save(f.session);
+
+    var context = service.autoSelectContext(f.account, f.session);
+
+    assertThat(context.householdId()).isEqualTo(f.household.getId());
+    assertThat(context.profileId()).isNull();
+    assertThat(reloadSession(f).getActiveProfileId()).isNull();
+  }
+
+  @Test
+  @DisplayName("Should clear stale profile when sole household has multiple selectable profiles")
+  void shouldClearStaleProfileWhenSoleHouseholdHasMultipleSelectableProfiles() {
+    var f = fixture();
+    f.session.setActiveProfileId(UUID.randomUUID());
+    sessionRepository.save(f.session);
+    linkProfile(f);
+    linkProfile(newProfile(f.household.getId()), f);
+
+    var context = service.autoSelectContext(f.account, f.session);
+
+    assertThat(context.householdId()).isEqualTo(f.household.getId());
+    assertThat(context.profileId()).isNull();
+    assertThat(reloadSession(f).getActiveProfileId()).isNull();
+  }
+
   // --- revalidateStoredContext ---
 
   @Test


### PR DESCRIPTION
`autoSelectContext` set `activeProfileId` only when the sole household had exactly one selectable profile, leaving any prior value in place — and then read it into the minted token. ADR 0016 says a stale selection can never mint a mismatched household/profile pair; this method relied on callers passing fresh sessions rather than enforcing it.

Latent, not exploitable: both callers pass freshly created sessions.

Fixed by removing the conditional rather than adding an else — the lookup returns `Optional`, and the set is unconditional, so absent clears. `selectHousehold` already did exactly this, so both selection paths now share one shape; `autoSelectContext` was the outlier.

Two tests construct the case no current caller produces (zero and several selectable profiles); both failed pre-fix on `context.profileId()`.

**On rebase:** #261 reshaped this method and carries the same hole as `if (selection.hasProfile())`. Resolve toward the unconditional set — keeping the conditional reintroduces the defect. Noted in the commit message too.