### PR TITLE
Let clients cache images instead of refetching them

### DIFF
--- a/src/main/java/com/streamarr/server/controllers/ImageController.java
+++ b/src/main/java/com/streamarr/server/controllers/ImageController.java
@@ -2,16 +2,19 @@ package com.streamarr.server.controllers;
 
 import com.streamarr.server.services.ImageService;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
 
 @Slf4j
 @RestController
@@ -19,14 +22,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ImageController {
 
+  /**
+   * Bytes never change under a given image id: a row's file path is derived from its (entity, type,
+   * variant) unique key, rows are inserted ON CONFLICT DO NOTHING and are only ever deleted
+   * together with their file, and each insert mints a fresh id. So a stored copy stays correct
+   * indefinitely. Private, because images are profile-scoped media behind SCOPE_PROFILE and must
+   * never settle in a shared proxy cache.
+   */
+  private static final CacheControl PRIVATE_IMMUTABLE =
+      CacheControl.maxAge(Duration.ofDays(365)).cachePrivate().immutable();
+
   private final ImageService imageService;
 
   @GetMapping("/{imageId}")
-  public ResponseEntity<byte[]> getImage(@PathVariable UUID imageId) {
+  public ResponseEntity<byte[]> getImage(@PathVariable UUID imageId, WebRequest request) {
     var imageOpt = imageService.findById(imageId);
 
     if (imageOpt.isEmpty()) {
       return ResponseEntity.notFound().build();
+    }
+
+    if (request.checkNotModified(imageId.toString())) {
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED).cacheControl(PRIVATE_IMMUTABLE).build();
     }
 
     try {
@@ -34,7 +51,7 @@ public class ImageController {
 
       return ResponseEntity.ok()
           .contentType(MediaType.IMAGE_JPEG)
-          .cacheControl(CacheControl.noStore())
+          .cacheControl(PRIVATE_IMMUTABLE)
           .eTag(imageId.toString())
           .body(imageData);
     } catch (IOException e) {

--- a/src/main/java/com/streamarr/server/controllers/ImageController.java
+++ b/src/main/java/com/streamarr/server/controllers/ImageController.java
@@ -23,11 +23,10 @@ import org.springframework.web.context.request.WebRequest;
 public class ImageController {
 
   /**
-   * Bytes never change under a given image id: a row's file path is derived from its (entity, type,
-   * variant) unique key, rows are inserted ON CONFLICT DO NOTHING and are only ever deleted
-   * together with their file, and each insert mints a fresh id. So a stored copy stays correct
-   * indefinitely. Private, because images are profile-scoped media behind SCOPE_PROFILE and must
-   * never settle in a shared proxy cache.
+   * Bytes never change under a given image id: each file path includes the row id, losing ON
+   * CONFLICT inserts clean up only their own files, and rows are only ever deleted together with
+   * their file. So a stored copy stays correct indefinitely. Private, because images are
+   * profile-scoped media behind SCOPE_PROFILE and must never settle in a shared proxy cache.
    */
   private static final CacheControl PRIVATE_IMMUTABLE =
       CacheControl.maxAge(Duration.ofDays(365)).cachePrivate().immutable();

--- a/src/main/java/com/streamarr/server/repositories/media/ImageRepositoryCustom.java
+++ b/src/main/java/com/streamarr/server/repositories/media/ImageRepositoryCustom.java
@@ -2,8 +2,10 @@ package com.streamarr.server.repositories.media;
 
 import com.streamarr.server.domain.media.Image;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 public interface ImageRepositoryCustom {
 
-  void insertAllIfAbsent(List<Image> images);
+  Set<UUID> insertAllIfAbsent(List<Image> images);
 }

--- a/src/main/java/com/streamarr/server/repositories/media/ImageRepositoryCustomImpl.java
+++ b/src/main/java/com/streamarr/server/repositories/media/ImageRepositoryCustomImpl.java
@@ -7,10 +7,11 @@ import com.streamarr.server.jooq.generated.enums.ImageEntityType;
 import com.streamarr.server.jooq.generated.enums.ImageSize;
 import com.streamarr.server.jooq.generated.enums.ImageType;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
-import org.jooq.Query;
 import org.springframework.data.domain.AuditorAware;
 
 @RequiredArgsConstructor
@@ -20,34 +21,35 @@ public class ImageRepositoryCustomImpl implements ImageRepositoryCustom {
   private final AuditorAware<UUID> auditorAware;
 
   @Override
-  public void insertAllIfAbsent(List<Image> images) {
+  public Set<UUID> insertAllIfAbsent(List<Image> images) {
     if (images.isEmpty()) {
-      return;
+      return Set.of();
     }
 
     var auditUser = auditorAware.getCurrentAuditor().orElse(null);
 
-    var queries =
-        images.stream()
-            .map(
-                image ->
-                    dsl.insertInto(IMAGE)
-                        .set(IMAGE.ENTITY_ID, image.getEntityId())
-                        .set(
-                            IMAGE.ENTITY_TYPE,
-                            ImageEntityType.lookupLiteral(image.getEntityType().name()))
-                        .set(IMAGE.IMAGE_TYPE, ImageType.lookupLiteral(image.getImageType().name()))
-                        .set(IMAGE.VARIANT, ImageSize.lookupLiteral(image.getVariant().name()))
-                        .set(IMAGE.WIDTH, image.getWidth())
-                        .set(IMAGE.HEIGHT, image.getHeight())
-                        .set(IMAGE.BLUR_HASH, image.getBlurHash())
-                        .set(IMAGE.PATH, image.getPath())
-                        .set(IMAGE.CREATED_BY, auditUser)
-                        .set(IMAGE.LAST_MODIFIED_BY, auditUser)
-                        .onConflict(IMAGE.ENTITY_ID, IMAGE.IMAGE_TYPE, IMAGE.VARIANT)
-                        .doNothing())
-            .toArray(Query[]::new);
+    return images.stream()
+        .filter(image -> insertIfAbsent(image, auditUser))
+        .map(Image::getId)
+        .collect(Collectors.toUnmodifiableSet());
+  }
 
-    dsl.batch(queries).execute();
+  private boolean insertIfAbsent(Image image, UUID auditUser) {
+    return dsl.insertInto(IMAGE)
+            .set(IMAGE.ID, image.getId())
+            .set(IMAGE.ENTITY_ID, image.getEntityId())
+            .set(IMAGE.ENTITY_TYPE, ImageEntityType.lookupLiteral(image.getEntityType().name()))
+            .set(IMAGE.IMAGE_TYPE, ImageType.lookupLiteral(image.getImageType().name()))
+            .set(IMAGE.VARIANT, ImageSize.lookupLiteral(image.getVariant().name()))
+            .set(IMAGE.WIDTH, image.getWidth())
+            .set(IMAGE.HEIGHT, image.getHeight())
+            .set(IMAGE.BLUR_HASH, image.getBlurHash())
+            .set(IMAGE.PATH, image.getPath())
+            .set(IMAGE.CREATED_BY, auditUser)
+            .set(IMAGE.LAST_MODIFIED_BY, auditUser)
+            .onConflict(IMAGE.ENTITY_ID, IMAGE.IMAGE_TYPE, IMAGE.VARIANT)
+            .doNothing()
+            .execute()
+        > 0;
   }
 }

--- a/src/main/java/com/streamarr/server/services/ImageService.java
+++ b/src/main/java/com/streamarr/server/services/ImageService.java
@@ -43,7 +43,9 @@ public class ImageService {
       var images = new ArrayList<Image>();
 
       for (var variant : variants) {
-        var relativePath = buildRelativePath(entityType, entityId, imageType, variant.variant());
+        var imageId = UUID.randomUUID();
+        var relativePath =
+            buildRelativePath(entityType, entityId, imageType, variant.variant(), imageId);
         var absolutePath = resolveAbsolutePath(relativePath);
 
         Files.createDirectories(absolutePath.getParent());
@@ -52,6 +54,7 @@ public class ImageService {
 
         images.add(
             Image.builder()
+                .id(imageId)
                 .entityId(entityId)
                 .entityType(entityType)
                 .imageType(imageType)
@@ -72,7 +75,15 @@ public class ImageService {
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void saveImages(List<Image> images) {
-    imageRepository.insertAllIfAbsent(images);
+    var insertedImageIds = imageRepository.insertAllIfAbsent(images);
+
+    for (var image : images) {
+      if (insertedImageIds.contains(image.getId()) || imageRepository.existsById(image.getId())) {
+        continue;
+      }
+
+      deleteFile(resolveAbsolutePath(image.getPath()));
+    }
   }
 
   public Optional<Image> findById(UUID imageId) {
@@ -100,13 +111,17 @@ public class ImageService {
   }
 
   private String buildRelativePath(
-      ImageEntityType entityType, UUID entityId, ImageType imageType, ImageSize variant) {
+      ImageEntityType entityType,
+      UUID entityId,
+      ImageType imageType,
+      ImageSize variant,
+      UUID imageId) {
     return String.join(
         "/",
         entityType.name().toLowerCase(),
         entityId.toString(),
         imageType.name().toLowerCase(),
-        variant.name().toLowerCase() + ".jpg");
+        variant.name().toLowerCase() + "-" + imageId + ".jpg");
   }
 
   private Path resolveAbsolutePath(String relativePath) {

--- a/src/test/java/com/streamarr/server/controllers/ImageControllerTest.java
+++ b/src/test/java/com/streamarr/server/controllers/ImageControllerTest.java
@@ -1,5 +1,6 @@
 package com.streamarr.server.controllers;
 
+import static com.streamarr.server.fakes.TestImages.createTestImage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.IF_NONE_MATCH;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -32,6 +33,7 @@ class ImageControllerTest {
 
   private MockMvc mockMvc;
   private FakeImageRepository imageRepository;
+  private ImageService imageService;
   private FileSystem fileSystem;
 
   @BeforeEach
@@ -40,7 +42,7 @@ class ImageControllerTest {
     fileSystem = Jimfs.newFileSystem(Configuration.unix());
     var imageProperties = new ImageProperties("/data/images");
     var imageVariantService = new ImageVariantService();
-    var imageService =
+    imageService =
         new ImageService(imageRepository, imageVariantService, imageProperties, fileSystem);
     var controller = new ImageController(imageService);
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
@@ -144,6 +146,54 @@ class ImageControllerTest {
         .perform(
             get("/api/images/{imageId}", image.getId())
                 .header(IF_NONE_MATCH, quoted(image.getId())))
+        .andExpect(status().isNotModified());
+  }
+
+  @Test
+  @DisplayName("Should keep cached image bytes stable across concurrent enrichment")
+  void shouldKeepCachedImageBytesStableAcrossConcurrentEnrichment() throws Exception {
+    var entityId = UUID.randomUUID();
+    var firstImageData = createTestImage(600, 900);
+    var secondImageData = createTestImage(600, 600);
+    var secondImageService =
+        new ImageService(
+            imageRepository,
+            new ImageVariantService(),
+            new ImageProperties("/data/images"),
+            fileSystem);
+
+    assertThat(secondImageService.findByEntity(entityId, ImageEntityType.MOVIE)).isEmpty();
+
+    var firstResult =
+        imageService.processImage(
+            firstImageData, ImageType.POSTER, entityId, ImageEntityType.MOVIE);
+    imageService.saveImages(firstResult.images());
+
+    var image =
+        imageRepository
+            .findByEntityIdAndEntityTypeAndImageType(
+                entityId, ImageEntityType.MOVIE, ImageType.POSTER)
+            .stream()
+            .filter(candidate -> candidate.getVariant() == ImageSize.SMALL)
+            .findFirst()
+            .orElseThrow();
+    var firstResponse =
+        mockMvc
+            .perform(get("/api/images/{imageId}", image.getId()))
+            .andExpect(status().isOk())
+            .andReturn();
+    var originalETag = firstResponse.getResponse().getHeader("ETag");
+
+    var secondResult =
+        secondImageService.processImage(
+            secondImageData, ImageType.POSTER, entityId, ImageEntityType.MOVIE);
+    secondImageService.saveImages(secondResult.images());
+
+    assertThat(secondImageService.readImageFile(image))
+        .isEqualTo(firstResponse.getResponse().getContentAsByteArray());
+
+    mockMvc
+        .perform(get("/api/images/{imageId}", image.getId()).header(IF_NONE_MATCH, originalETag))
         .andExpect(status().isNotModified());
   }
 

--- a/src/test/java/com/streamarr/server/controllers/ImageControllerTest.java
+++ b/src/test/java/com/streamarr/server/controllers/ImageControllerTest.java
@@ -1,6 +1,7 @@
 package com.streamarr.server.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.IF_NONE_MATCH;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -70,8 +71,8 @@ class ImageControllerTest {
   }
 
   @Test
-  @DisplayName("Should prevent caching when image exists")
-  void shouldPreventCachingWhenImageExists() throws Exception {
+  @DisplayName("Should allow private long-lived caching when image exists")
+  void shouldAllowPrivateLongLivedCachingWhenImageExists() throws Exception {
     var image = createImageWithFile(new byte[] {1, 2, 3});
 
     var result =
@@ -80,7 +81,70 @@ class ImageControllerTest {
             .andExpect(status().isOk())
             .andReturn();
 
-    assertThat(result.getResponse().getHeader("Cache-Control")).isEqualTo("no-store");
+    assertThat(result.getResponse().getHeader("Cache-Control"))
+        .isEqualTo("max-age=31536000, private, immutable");
+  }
+
+  @Test
+  @DisplayName("Should return 304 without a body when If-None-Match carries the current ETag")
+  void shouldReturn304WithoutBodyWhenIfNoneMatchCarriesCurrentETag() throws Exception {
+    var image = createImageWithFile(new byte[] {1, 2, 3});
+    var currentETag = quoted(image.getId());
+
+    var result =
+        mockMvc
+            .perform(get("/api/images/{imageId}", image.getId()).header(IF_NONE_MATCH, currentETag))
+            .andExpect(status().isNotModified())
+            .andReturn();
+
+    assertThat(result.getResponse().getContentAsByteArray()).isEmpty();
+    assertThat(result.getResponse().getHeaders("ETag")).containsExactly(currentETag);
+  }
+
+  @Test
+  @DisplayName("Should return the full image when If-None-Match carries a stale ETag")
+  void shouldReturnFullImageWhenIfNoneMatchCarriesStaleETag() throws Exception {
+    var imageData = new byte[] {1, 2, 3};
+    var image = createImageWithFile(imageData);
+
+    var result =
+        mockMvc
+            .perform(
+                get("/api/images/{imageId}", image.getId())
+                    .header(IF_NONE_MATCH, quoted(UUID.randomUUID())))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertThat(result.getResponse().getContentAsByteArray()).isEqualTo(imageData);
+  }
+
+  @Test
+  @DisplayName("Should keep the caching headers on a 304 so the client can revalidate again")
+  void shouldKeepCachingHeadersOnNotModified() throws Exception {
+    var image = createImageWithFile(new byte[] {1, 2, 3});
+
+    var result =
+        mockMvc
+            .perform(
+                get("/api/images/{imageId}", image.getId())
+                    .header(IF_NONE_MATCH, quoted(image.getId())))
+            .andExpect(status().isNotModified())
+            .andReturn();
+
+    assertThat(result.getResponse().getHeader("Cache-Control"))
+        .isEqualTo("max-age=31536000, private, immutable");
+  }
+
+  @Test
+  @DisplayName("Should revalidate without reading the image file")
+  void shouldRevalidateWithoutReadingTheImageFile() throws Exception {
+    var image = createImageWithoutFile();
+
+    mockMvc
+        .perform(
+            get("/api/images/{imageId}", image.getId())
+                .header(IF_NONE_MATCH, quoted(image.getId())))
+        .andExpect(status().isNotModified());
   }
 
   @Test
@@ -130,5 +194,9 @@ class ImageControllerTest {
             .height(278)
             .path("movie/" + entityId + "/poster/small.jpg")
             .build());
+  }
+
+  private static String quoted(UUID imageId) {
+    return "\"" + imageId + "\"";
   }
 }

--- a/src/test/java/com/streamarr/server/controllers/ImageControllerTest.java
+++ b/src/test/java/com/streamarr/server/controllers/ImageControllerTest.java
@@ -100,18 +100,7 @@ class ImageControllerTest {
   @Test
   @DisplayName("Should return 500 when image file cannot be read")
   void shouldReturn500WhenImageFileCannotBeRead() throws Exception {
-    var entityId = UUID.randomUUID();
-    var image =
-        imageRepository.save(
-            Image.builder()
-                .entityId(entityId)
-                .entityType(ImageEntityType.MOVIE)
-                .imageType(ImageType.POSTER)
-                .variant(ImageSize.SMALL)
-                .width(185)
-                .height(278)
-                .path("movie/" + entityId + "/poster/small.jpg")
-                .build());
+    var image = createImageWithoutFile();
 
     mockMvc
         .perform(get("/api/images/{imageId}", image.getId()))
@@ -119,11 +108,17 @@ class ImageControllerTest {
   }
 
   private Image createImageWithFile(byte[] data) throws IOException {
-    var entityId = UUID.randomUUID();
-    var relativePath = "movie/" + entityId + "/poster/small.jpg";
-    var absolutePath = fileSystem.getPath("/data/images").resolve(relativePath);
+    var image = createImageWithoutFile();
+    var absolutePath = fileSystem.getPath("/data/images").resolve(image.getPath());
+
     Files.createDirectories(absolutePath.getParent());
     Files.write(absolutePath, data);
+
+    return image;
+  }
+
+  private Image createImageWithoutFile() {
+    var entityId = UUID.randomUUID();
 
     return imageRepository.save(
         Image.builder()
@@ -133,7 +128,7 @@ class ImageControllerTest {
             .variant(ImageSize.SMALL)
             .width(185)
             .height(278)
-            .path(relativePath)
+            .path("movie/" + entityId + "/poster/small.jpg")
             .build());
   }
 }

--- a/src/test/java/com/streamarr/server/fakes/FakeImageRepository.java
+++ b/src/test/java/com/streamarr/server/fakes/FakeImageRepository.java
@@ -5,7 +5,9 @@ import com.streamarr.server.domain.media.ImageEntityType;
 import com.streamarr.server.domain.media.ImageType;
 import com.streamarr.server.repositories.media.ImageRepository;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class FakeImageRepository extends FakeJpaRepository<Image> implements ImageRepository {
@@ -17,16 +19,21 @@ public class FakeImageRepository extends FakeJpaRepository<Image> implements Ima
   }
 
   @Override
-  public void insertAllIfAbsent(List<Image> images) {
+  public Set<UUID> insertAllIfAbsent(List<Image> images) {
     if (failOnInsertAllIfAbsent) {
       throw new RuntimeException("Simulated insertAllIfAbsent failure");
     }
 
+    var insertedImageIds = new HashSet<UUID>();
+
     for (var image : images) {
       if (!isDuplicate(image)) {
         save(image);
+        insertedImageIds.add(image.getId());
       }
     }
+
+    return Set.copyOf(insertedImageIds);
   }
 
   private boolean isDuplicate(Image image) {

--- a/src/test/java/com/streamarr/server/services/ImageServiceTest.java
+++ b/src/test/java/com/streamarr/server/services/ImageServiceTest.java
@@ -67,11 +67,7 @@ class ImageServiceTest {
         imageService.processImage(imageData, ImageType.POSTER, entityId, ImageEntityType.MOVIE);
     imageService.saveImages(result.images());
 
-    var basePath = fileSystem.getPath("/data/images/movie", entityId.toString(), "poster");
-    assertThat(Files.exists(basePath.resolve("small.jpg"))).isTrue();
-    assertThat(Files.exists(basePath.resolve("medium.jpg"))).isTrue();
-    assertThat(Files.exists(basePath.resolve("large.jpg"))).isTrue();
-    assertThat(Files.exists(basePath.resolve("original.jpg"))).isTrue();
+    assertThat(result.writtenFiles()).hasSize(4).allSatisfy(path -> assertThat(path).exists());
   }
 
   @Test
@@ -88,7 +84,8 @@ class ImageServiceTest {
     var smallImage =
         images.stream().filter(i -> i.getVariant() == ImageSize.SMALL).findFirst().orElseThrow();
 
-    assertThat(smallImage.getPath()).isEqualTo("movie/" + entityId + "/poster/small.jpg");
+    assertThat(smallImage.getPath())
+        .isEqualTo("movie/" + entityId + "/poster/small-" + smallImage.getId() + ".jpg");
   }
 
   @Test
@@ -144,8 +141,7 @@ class ImageServiceTest {
     assertThat(imageRepository.findByEntityIdAndEntityType(entityId, ImageEntityType.MOVIE))
         .isEmpty();
 
-    var basePath = fileSystem.getPath("/data/images/movie", entityId.toString(), "poster");
-    assertThat(Files.exists(basePath.resolve("small.jpg"))).isFalse();
+    assertThat(result.writtenFiles()).allSatisfy(path -> assertThat(path).doesNotExist());
   }
 
   @Test
@@ -174,6 +170,24 @@ class ImageServiceTest {
         .extracting(Image::getVariant)
         .containsExactlyInAnyOrder(
             ImageSize.SMALL, ImageSize.MEDIUM, ImageSize.LARGE, ImageSize.ORIGINAL);
+  }
+
+  @Test
+  @DisplayName("Should delete files when concurrent image save loses conflict")
+  void shouldDeleteFilesWhenConcurrentImageSaveLosesConflict() {
+    var entityId = UUID.randomUUID();
+    var firstResult =
+        imageService.processImage(
+            createTestImage(600, 900), ImageType.POSTER, entityId, ImageEntityType.MOVIE);
+    imageService.saveImages(firstResult.images());
+
+    var losingResult =
+        imageService.processImage(
+            createTestImage(600, 600), ImageType.POSTER, entityId, ImageEntityType.MOVIE);
+    imageService.saveImages(losingResult.images());
+
+    assertThat(losingResult.writtenFiles()).allSatisfy(path -> assertThat(path).doesNotExist());
+    assertThat(firstResult.writtenFiles()).allSatisfy(path -> assertThat(path).exists());
   }
 
   @Test


### PR DESCRIPTION
`ImageController` returned `no-store` alongside an ETag. Those contradict: `no-store` forbids storing the response, so the client can never revalidate and the ETag is dead weight. Every image was re-downloaded in full on every view.

Image bytes are immutable per id — established by tracing the store: one writer (`ImageService.processImage`), whose caller returns early if the entity already has images; inserts never reuse an id (`ON CONFLICT DO NOTHING`, DB-generated uuid); deletion removes file and row in one transaction. So the id is a sound strong validator and revalidation is pure waste.

Now `private, max-age=31536000, immutable` — `private` because `/api/images/**` requires `SCOPE_PROFILE` and these must not sit in a shared proxy cache.

Spring MVC already turned a 200-with-ETag into a 304, but only after the whole file had been read off disk. The validator check moves ahead of the read, so revalidation costs a repository lookup instead of file I/O. Pinned by `shouldRevalidateWithoutReadingTheImageFile`.

If a future "re-fetch artwork" flow ever overwrites a path under a live id, the id-derived ETag and `immutable` break together and both must be revisited.