### PR TITLE
Cancel superseded CI runs per pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- group CI workflow runs by workflow name and pull request number
- fall back to the Git ref for non-PR events such as pushes to `main`
- cancel an older in-progress run when a newer run supersedes it

## Root cause

PR #268 is stacked on another feature branch. Its head and base branches were force-pushed one second apart, which generated two `pull_request/synchronize` workflow runs for the same final merge state. Both reached SonarQube Cloud concurrently, and the duplicate server-side analyses left the authoritative status check cancelled even though both builds and the quality gate passed.

The PR number in the concurrency key keeps different stacked PRs independent: #264 and #268 still each run CI. Only duplicate runs for the same PR collapse to the newest one.

## Validation

- parsed `.github/workflows/ci.yml` as YAML
- `git diff --cached --check`
- GitHub Actions will perform the authoritative workflow-expression validation
